### PR TITLE
Continuously test PS2SDK using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker run -it --rm -v "$PWD:/src" mlafeldt/ps2dev make install
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This will test every push to master as well as all pull requests and report whether PS2SDK compiles and installs cleanly or not.

Utilizes https://github.com/mlafeldt/docker-ps2dev for cross-compiling.