### PR TITLE
added imports and exports into common iop makefiles

### DIFF
--- a/ee/draw/samples/cube/Makefile.sample
+++ b/ee/draw/samples/cube/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = cube.o
 EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/draw/samples/teapot/Makefile.sample
+++ b/ee/draw/samples/teapot/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = teapot.o
 EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/draw/samples/texture/Makefile.sample
+++ b/ee/draw/samples/texture/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = texture.o
 EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
 
 all: flower.c $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 flower.c:
 	bin2c texture.raw flower.c flower

--- a/ee/font/samples/Makefile.sample
+++ b/ee/font/samples/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = font.o impress.o
 EE_LIBS = -lfont -lpacket -ldma -lgraph -ldraw -lc -lmf
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/graph/samples/Makefile.sample
+++ b/ee/graph/samples/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = graph.o
 EE_LIBS = -lpacket -ldma -lgraph -ldraw -lc -lmf
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/kernel/src/osdsrc/Makefile
+++ b/ee/kernel/src/osdsrc/Makefile
@@ -18,7 +18,7 @@ EE_LDFLAGS = -nostartfiles -mno-crt0 -Tlinkfile -s
 $(EE_ELF) : $(EE_OBJS)
 	$(EE_CC) $(EE_LDFLAGS) \
 		-o $(EE_ELF) $(EE_OBJS) $(EE_LIBS)
-	ee-objcopy -Obinary $(EE_ELF) $(EE_BIN)
+	$(EE_OBJCOPY) -Obinary $(EE_ELF) $(EE_BIN)
 
 %.o : %.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@

--- a/ee/kernel/src/tlbsrc/Makefile
+++ b/ee/kernel/src/tlbsrc/Makefile
@@ -18,7 +18,7 @@ EE_LDFLAGS = -nostartfiles -mno-crt0 -Tlinkfile -s
 $(EE_ELF) : $(EE_OBJS)
 	$(EE_CC) $(EE_LDFLAGS) \
 		-o $(EE_ELF) $(EE_OBJS) $(EE_LIBS)
-	ee-objcopy -Obinary $(EE_ELF) $(EE_BIN)
+	$(EE_OBJCOPY) -Obinary $(EE_ELF) $(EE_BIN)
 
 %.o : %.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@

--- a/ee/libgs/samples/libgs_doublebuffer/Makefile.sample
+++ b/ee/libgs/samples/libgs_doublebuffer/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = main.o
 EE_LIBS = -lgs
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/libgs/samples/libgs_draw/Makefile.sample
+++ b/ee/libgs/samples/libgs_draw/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = main.o
 EE_LIBS = -lgs
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/ee/mpeg/samples/Makefile.sample
+++ b/ee/mpeg/samples/Makefile.sample
@@ -12,7 +12,7 @@ EE_OBJS = mpeg.o
 EE_LIBS = -ldraw -lgraph -ldma -lmpeg -lmf -lc -lpacket
 
 all: $(EE_BIN)
-	ee-strip --strip-all $(EE_BIN)
+	$(EE_STRIP) --strip-all $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS)

--- a/iop/iLink/IEEE1394_disk/Makefile
+++ b/iop/iLink/IEEE1394_disk/Makefile
@@ -16,7 +16,7 @@ IOP_BIN  = $(IOP_BIN_DIR)IEEE1394_disk.irx
 IOP_OBJS = sbp2_driver.o imports.o main.o scsi.o fat_write.o fs_driver.o scache.o fat_driver.o part_driver.o
 IOP_OBJS := $(IOP_OBJS:%=$(IOP_OBJS_DIR)%)
 
-IOP_INCS += -I$(PS2SDKSRC)/iop/kernel/include -I$(PS2SDKSRC)/common/include -I$(IOP_SRC_DIR)/include
+IOP_INCS += -I$(IOP_SRC_DIR)/include
 IOP_CFLAGS += -mno-check-zero-division #-DSIF_CALLBACKS_12_13
 
 all: $(IOP_OBJS_DIR) $(IOP_BIN_DIR) $(IOP_BIN)

--- a/iop/iLink/IEEE1394_disk/src/fat_driver.c
+++ b/iop/iLink/IEEE1394_disk/src/fat_driver.c
@@ -966,7 +966,7 @@ int fat_mount(struct SBP2Device* dev, unsigned int start, unsigned int count)
 void fat_forceUnmount(struct SBP2Device* dev)
 {
 	unsigned int i;
-	XPRINTF("USBHDFSD: usb fat: forceUnmount devId %i \n", dev->devId);
+	XPRINTF("USBHDFSD: usb fat: forceUnmount devId %i \n", dev->nodeId);
 
 	for (i = 0; i < NUM_DRIVES; ++i)
 	{

--- a/iop/iLink/IEEE1394_disk/src/fat_write.c
+++ b/iop/iLink/IEEE1394_disk/src/fat_write.c
@@ -1125,7 +1125,7 @@ static int fat_fillDirentryInfo(fat_driver* fatd, const unsigned char* lname, un
 	int seq;
 	int mask_ix, mask_sh;
 #ifdef DEBUG
-	mass_dev* mass_device = fatd->dev;
+	struct SBP2Device* mass_device = fatd->dev;
 #endif
 
 	memset(fatd->dir_used_mask, 0, DIR_MASK_SIZE/8);

--- a/iop/network/netman/Makefile
+++ b/iop/network/netman/Makefile
@@ -16,7 +16,7 @@ IOP_BIN  = $(IOP_BIN_DIR)netman.irx
 IOP_OBJS = netman.o rpc_server.o rpc_client.o imports.o exports.o
 IOP_OBJS := $(IOP_OBJS:%=$(IOP_OBJS_DIR)%)
 
-IOP_INCS += -I$(PS2SDKSRC)/iop/kernel/include -I$(PS2SDKSRC)/common/include -I$(IOP_SRC_DIR)/include
+IOP_INCS += -I$(IOP_SRC_DIR)/include
 IOP_CFLAGS += -mno-check-zero-division
 
 all: $(IOP_OBJS_DIR) $(IOP_BIN_DIR) $(IOP_BIN)

--- a/iop/network/smap/Makefile
+++ b/iop/network/smap/Makefile
@@ -19,7 +19,7 @@ IOP_BIN  = $(IOP_BIN_DIR)smap.irx
 IOP_OBJS = main.o smap.o xfer.o imports.o exports.o
 IOP_OBJS := $(IOP_OBJS:%=$(IOP_OBJS_DIR)%)
 
-IOP_INCS += -I$(PS2SDKSRC)/iop/kernel/include -I$(PS2SDKSRC)/common/include -I$(PS2SDKSRC)/iop/dev9/dev9/include -I$(IOP_SRC_DIR)/include
+IOP_INCS += -I$(PS2SDKSRC)/iop/dev9/dev9/include -I$(IOP_SRC_DIR)/include
 IOP_CFLAGS += -mgpopt -G19 -mno-check-zero-division
 
 ifdef LWIP_DHCP

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -52,7 +52,7 @@ endif
 
 IOP_BIN = $(IOP_BIN_DIR)ps2ip.irx
 IOP_OBJS = $(ps2ip_OBJECTS) $(ps2api_OBJECTS) $(ps2api_IPV4)
-IOP_INCS += -I$(LWIP)/src/include -I$(LWIP)/src/include/ipv4 -Isrc/include
+IOP_INCS += -I$(LWIP)/src/include -I$(LWIP)/src/include/ipv4 -I$(IOP_SRC_DIR)include
 IOP_CFLAGS += -DLWIP_NOASSERT -DLWIP_COMPAT_MUTEX $(DEBUG_FLAGS)
 
 all: $(IOP_OBJS_DIR) $(IOP_BIN_DIR) $(IOP_BIN)
@@ -64,96 +64,96 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.make
 include $(PS2SDKSRC)/iop/Rules.release
 
-obj/def.o: $(LWIP)/src/core/def.c
+$(IOP_OBJS_DIR)def.o: $(LWIP)/src/core/def.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/init.o: $(LWIP)/src/core/init.c
+$(IOP_OBJS_DIR)init.o: $(LWIP)/src/core/init.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/api_lib.o: $(LWIP)/src/api/api_lib.c
+$(IOP_OBJS_DIR)api_lib.o: $(LWIP)/src/api/api_lib.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/api_msg.o: $(LWIP)/src/api/api_msg.c
+$(IOP_OBJS_DIR)api_msg.o: $(LWIP)/src/api/api_msg.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/icmp.o: $(LWIP)/src/core/ipv4/icmp.c
+$(IOP_OBJS_DIR)icmp.o: $(LWIP)/src/core/ipv4/icmp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/ip.o: $(LWIP)/src/core/ipv4/ip.c
+$(IOP_OBJS_DIR)ip.o: $(LWIP)/src/core/ipv4/ip.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/ip_addr.o: $(LWIP)/src/core/ipv4/ip_addr.c
+$(IOP_OBJS_DIR)ip_addr.o: $(LWIP)/src/core/ipv4/ip_addr.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/ip_frag.o: $(LWIP)/src/core/ipv4/ip_frag.c
+$(IOP_OBJS_DIR)ip_frag.o: $(LWIP)/src/core/ipv4/ip_frag.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/err.o: $(LWIP)/src/api/err.c
+$(IOP_OBJS_DIR)err.o: $(LWIP)/src/api/err.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/sockets.o: $(LWIP)/src/api/sockets.c
+$(IOP_OBJS_DIR)sockets.o: $(LWIP)/src/api/sockets.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/tcpip.o: $(LWIP)/src/api/tcpip.c
+$(IOP_OBJS_DIR)tcpip.o: $(LWIP)/src/api/tcpip.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/inet.o: $(LWIP)/src/core/ipv4/inet.c
+$(IOP_OBJS_DIR)inet.o: $(LWIP)/src/core/ipv4/inet.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/inet_chksum.o: $(LWIP)/src/core/ipv4/inet_chksum.c
+$(IOP_OBJS_DIR)inet_chksum.o: $(LWIP)/src/core/ipv4/inet_chksum.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/mem.o: $(LWIP)/src/core/mem.c
+$(IOP_OBJS_DIR)mem.o: $(LWIP)/src/core/mem.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/memp.o: $(LWIP)/src/core/memp.c
+$(IOP_OBJS_DIR)memp.o: $(LWIP)/src/core/memp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/netbuf.o: $(LWIP)/src/api/netbuf.c
+$(IOP_OBJS_DIR)netbuf.o: $(LWIP)/src/api/netbuf.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/netif.o: $(LWIP)/src/core/netif.c
+$(IOP_OBJS_DIR)netif.o: $(LWIP)/src/core/netif.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/pbuf.o: $(LWIP)/src/core/pbuf.c
+$(IOP_OBJS_DIR)pbuf.o: $(LWIP)/src/core/pbuf.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/stats.o: $(LWIP)/src/core/stats.c
+$(IOP_OBJS_DIR)stats.o: $(LWIP)/src/core/stats.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/tcp.o: $(LWIP)/src/core/tcp.c
+$(IOP_OBJS_DIR)tcp.o: $(LWIP)/src/core/tcp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/tcp_in.o: $(LWIP)/src/core/tcp_in.c
+$(IOP_OBJS_DIR)tcp_in.o: $(LWIP)/src/core/tcp_in.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/tcp_out.o: $(LWIP)/src/core/tcp_out.c
+$(IOP_OBJS_DIR)tcp_out.o: $(LWIP)/src/core/tcp_out.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/sys.o: $(LWIP)/src/core/sys.c
+$(IOP_OBJS_DIR)sys.o: $(LWIP)/src/core/sys.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/raw.o: $(LWIP)/src/core/raw.c
+$(IOP_OBJS_DIR)raw.o: $(LWIP)/src/core/raw.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/timers.o: $(LWIP)/src/core/timers.c
+$(IOP_OBJS_DIR)timers.o: $(LWIP)/src/core/timers.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/etharp.o: $(LWIP)/src/netif/etharp.c
+$(IOP_OBJS_DIR)etharp.o: $(LWIP)/src/netif/etharp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
 ifdef PS2IP_DHCP
-obj/dhcp.o: $(LWIP)/src/core/dhcp.c
+$(IOP_OBJS_DIR)dhcp.o: $(LWIP)/src/core/dhcp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 endif
 
 ifdef PS2IP_DNS
-obj/dns.o: $(LWIP)/src/core/dns.c
+$(IOP_OBJS_DIR)dns.o: $(LWIP)/src/core/dns.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 
-obj/netdb.o: $(LWIP)/src/api/netdb.c
+$(IOP_OBJS_DIR)netdb.o: $(LWIP)/src/api/netdb.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
 endif
 
-obj/udp.o: $(LWIP)/src/core/udp.c
+$(IOP_OBJS_DIR)udp.o: $(LWIP)/src/core/udp.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@

--- a/iop/usb/mouse/Makefile
+++ b/iop/usb/mouse/Makefile
@@ -12,8 +12,9 @@ IOP_BIN_DIR = irx/
 IOP_SRC_DIR = src/
 IOP_INC_DIR = include/
 
-IOP_BIN  = irx/ps2mouse.irx
-IOP_OBJS = obj/ps2mouse.o obj/imports.o
+IOP_BIN  = $(IOP_BIN_DIR)ps2mouse.irx
+IOP_OBJS = ps2mouse.o imports.o
+IOP_OBJS := $(IOP_OBJS:%=$(IOP_OBJS_DIR)%)
 
 IOP_CFLAGS=-Wall
 IOP_INCS += -I$(PS2SDKSRC)/iop/usb/usbd/include

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -34,8 +34,22 @@ IOP_CFLAGS := $(CFLAGS_TARGET) -O2 -G0 $(IOP_INCS) $(IOP_CFLAGS)
 # linker flags
 IOP_LDFLAGS := $(LDFLAGS_TARGET) -nostdlib -L$(PS2SDK)/iop/lib $(IOP_LDFLAGS)
 
-# asssembler flags
+# assembler flags
 IOP_ASFLAGS := $(ASFLAGS_TARGET) -EL -G0 $(IOP_ASFLAGS)
+
+# A rule to build imports.lst.
+%.o : %.lst
+	$(ECHO) "#include \"irx_imports.h\"" > build-imports.c
+	cat $< >> build-imports.c
+	$(IOP_CC) $(IOP_CFLAGS) -I. -c build-imports.c -o $@
+	-rm -f build-imports.c
+
+# A rule to build exports.tab.
+%.o : %.tab
+	$(ECHO) "#include \"irx.h\"" > build-exports.c
+	cat $< >> build-exports.c
+	$(IOP_CC) $(IOP_CFLAGS) -I. -c build-exports.c -o $@
+	-rm -f build-exports.c
 
 # link with following libraries (libs need to be defined multiple times in order for linking to work!!)
 IOP_LIBS += -lkernel -lgcc
@@ -52,7 +66,7 @@ IOP_LIBS += -lkernel -lgcc
 	$(IOP_AS) $(IOP_ASFLAGS) $< -o $@
 
 $(IOP_BIN) : $(IOP_OBJS)
-	$(IOP_CC) -o $(IOP_BIN) $(IOP_OBJS) $(IOP_LDFLAGS) $(IOP_LIBS)
+	$(IOP_CC) $(IOP_CFLAGS) -o $(IOP_BIN) $(IOP_OBJS) $(IOP_LDFLAGS) $(IOP_LIBS)
 
 $(IOP_LIB) : $(IOP_OBJS)
 	$(IOP_AR) cru $(IOP_LIB) $(IOP_OBJS)


### PR DESCRIPTION
fixed debug build of i.Link driver
fixed sample makefiles
added imports and exports into common iop makefiles
 for better use in external projects

Now it is possible to get rid of iop PS2SDK-style
Rules.make and use instead Makefile.iopglobal

-include Rules.make
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.iopglobal