### PR TITLE
C++ support fix

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -39,15 +39,15 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS)
 
 # Extra macro for disabling the automatic inclusion of the built-in CRT object(s)
 ifeq ($(EE_CC_VERSION),3.2.2)
-EE_NO_CRT = -mno-crt0
-endif
-ifeq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -mno-crt0
-endif
-ifneq ($(EE_CC_VERSION),3.2.2)
-ifneq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -nostartfiles
-endif
+	EE_NO_CRT = -mno-crt0
+else ifeq ($(EE_CC_VERSION),3.2.3)
+	EE_NO_CRT = -mno-crt0
+else
+	EE_NO_CRT = -nostartfiles
+	CRTBEGIN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtbegin.o)
+	CRTEND_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtend.o)
+	CRTI_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crti.o)
+	CRTN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtn.o)
 endif
 
 $(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c
@@ -75,7 +75,7 @@ $(EE_OBJS): | $(EE_OBJS_DIR)
 
 $(EE_BIN): $(EE_OBJS) $(PS2SDKSRC)/ee/startup/obj/crt0.o | $(EE_BIN_DIR)
 	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
-		-o $(EE_BIN) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+		-o $(EE_BIN) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_LIB): $(EE_OBJS) $(EE_LIB:%.a=%.erl) | $(EE_LIB_DIR)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+EE_CC_VERSION := $(shell $(EE_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)
 
@@ -50,21 +52,28 @@ EE_NO_CRT = -nostartfiles
 endif
 endif
 
-%.o : %.c
+%.o: %.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o : %.cpp
+%.o: %.cc
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o : %.S
+%.o: %.cpp
+	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.S
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o : %.s
+%.o: %.s
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
-$(EE_BIN) : $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
+$(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
 	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CXXFLAGS) \
-	-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 
-$(EE_LIB) : $(EE_OBJS)
+$(EE_ERL): $(EE_OBJS)
+	$(EE_CC) $(EE_NO_CRT) -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d
+	$(EE_STRIP) --strip-unneeded -R .mdebug.eabi64 -R .reginfo -R .comment $(EE_ERL)
+
+$(EE_LIB): $(EE_OBJS)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -41,15 +41,15 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 
 # Extra macro for disabling the automatic inclusion of the built-in CRT object(s)
 ifeq ($(EE_CC_VERSION),3.2.2)
-EE_NO_CRT = -mno-crt0
-endif
-ifeq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -mno-crt0
-endif
-ifneq ($(EE_CC_VERSION),3.2.2)
-ifneq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -nostartfiles
-endif
+	EE_NO_CRT = -mno-crt0
+else ifeq ($(EE_CC_VERSION),3.2.3)
+	EE_NO_CRT = -mno-crt0
+else
+	EE_NO_CRT = -nostartfiles
+	CRTBEGIN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtbegin.o)
+	CRTEND_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtend.o)
+	CRTI_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crti.o)
+	CRTN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtn.o)
 endif
 
 %.o: %.c
@@ -69,7 +69,7 @@ endif
 
 $(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
 	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CXXFLAGS) \
-		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_ERL): $(EE_OBJS)
 	$(EE_CC) $(EE_NO_CRT) -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -36,15 +36,15 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 
 # Extra macro for disabling the automatic inclusion of the built-in CRT object(s)
 ifeq ($(EE_CC_VERSION),3.2.2)
-EE_NO_CRT = -mno-crt0
-endif
-ifeq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -mno-crt0
-endif
-ifneq ($(EE_CC_VERSION),3.2.2)
-ifneq ($(EE_CC_VERSION),3.2.3)
-EE_NO_CRT = -nostartfiles
-endif
+	EE_NO_CRT = -mno-crt0
+else ifeq ($(EE_CC_VERSION),3.2.3)
+	EE_NO_CRT = -mno-crt0
+else
+	EE_NO_CRT = -nostartfiles
+	CRTBEGIN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtbegin.o)
+	CRTEND_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtend.o)
+	CRTI_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crti.o)
+	CRTN_OBJ := $(shell $(EE_CC) $(CFLAGS) -print-file-name=crtn.o)
 endif
 
 %.o: %.c
@@ -64,7 +64,7 @@ endif
 
 $(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
 	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CFLAGS) \
-		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_ERL): $(EE_OBJS)
 	$(EE_CC) $(EE_NO_CRT) -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+EE_CC_VERSION := $(shell $(EE_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)
 


### PR DESCRIPTION
To keep things going here is a pull request to fix C++ support when using the samples makefiles, and when using newer compilers.

I have tested C++ support when using gcc 3.2.3 and Makefile.eeglobal_cpp. The rest is not tested but looks good to me.