### PR TITLE
Fix C++ support, libkernel depends on libpatches

### DIFF
--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -31,7 +31,7 @@ EE_ASFLAGS := -G0 $(EE_ASFLAGS)
 EE_LIBS += -lstdc++ \
 	-Wl,--whole-archive $(PS2SDK)/ee/lib/libc.a -Wl,--no-whole-archive \
 	$(PS2DEV)/ee/ee/lib/libc.a \
-	-Wl,--whole-archive -lkernel -Wl,--no-whole-archive
+	-Wl,--whole-archive -lkernel -Wl,--no-whole-archive -lpatches
 
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
 


### PR DESCRIPTION
This fixes a missing dependency to sbv_patch_enable_lmb when using C++.

Is the dependency from libkernel to sbv/libpatches intended?
Is this the correct fix and are there any other Makefiles that need to be updated?