### PR TITLE
Libkernel compatability patch for loader-like/resident projects

### DIFF
--- a/ee/kernel-nopatch/Makefile
+++ b/ee/kernel-nopatch/Makefile
@@ -6,11 +6,9 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = kernel kernel-nopatch libc rpc startup debug \
-	eedebug sbv dma graph math3d math \
-	packet draw erl erl-loader mpeg libgs \
-	libvux font input inputx network iopreboot
+#Define to 1, to build a special version of libkernel that does not contain any runtime patches (useful for loaders/resident programs).
+KERNEL_NO_PATCHES = 1
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
-include $(PS2SDKSRC)/ee/Rules.release
+EE_SRC_DIR = $(PS2SDKSRC)/ee/kernel/src/
+
+include $(PS2SDKSRC)/ee/kernel/Makefile

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -6,19 +6,51 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+#Define to 1, to build a special version of libkernel that does not contain any runtime patches (useful for loaders/resident programs).
+KERNEL_NO_PATCHES ?= 0
+
+ifeq ($(KERNEL_NO_PATCHES),1)
+	EE_CFLAGS += -DKERNEL_NO_PATCHES=1
+	EXEC_SYSCALLS = Exit.o LoadExecPS2.o ExecPS2.o
+	EXECOSD_SYSCALL = ExecOSD.o
+	ALARM_SYSCALLS = _SetAlarm.o _ReleaseAlarm.o
+	ALARM_INTR_SYSCALLS = _iSetAlarm.o _iReleaseAlarm.o
+	ROTATE_THREAD_READY_QUEUE_SYSCALL = iRotateThreadReadyQueue.o
+	IWAKEUP_THREAD_SYSCALL = iWakeupThread.o
+	ISUSPEND_THREAD_SYSCALL = iSuspendThread.o
+	TLB_SYSCALLS =
+else
+	EXEC_SYSCALLS = _Exit.o _LoadExecPS2.o _ExecPS2.o
+	EXECOSD_SYSCALL = _ExecOSD.o
+	ALARM_SYSCALLS = _SetAlarm.o SetAlarm.o _ReleaseAlarm.o ReleaseAlarm.o
+	ALARM_INTR_SYSCALLS = _iSetAlarm.o iSetAlarm.o _iReleaseAlarm.o iReleaseAlarm.o
+	ROTATE_THREAD_READY_QUEUE_SYSCALL = _iRotateThreadReadyQueue.o
+	IWAKEUP_THREAD_SYSCALL = _iWakeupThread.o
+	ISUSPEND_THREAD_SYSCALL = _iSuspendThread.o
+	TLB_SYSCALLS = PutTLBEntry.o iPutTLBEntry.o _SetTLBEntry.o iSetTLBEntry.o GetTLBEntry.o iGetTLBEntry.o ProbeTLBEntry.o iProbeTLBEntry.o ExpandScratchPad.o
+endif
+
+### SIFCMD objects objects
+
 SIFCMD_OBJS = sif_cmd_send.o _sif_cmd_int_handler.o sif_cmd_main.o \
 	sif_cmd_client.o sif_cmd_remove_cmdhandler.o sif_sreg_get.o
+
+### SIFRPC objects
 
 SIFRPC_OBJS = SifBindRpc.o SifCallRpc.o SifRpcGetOtherData.o \
 	SifRegisterRpc.o SifRemoveRpc.o SifSetRpcQueue.o SifRemoveRpcQueue.o SifGetNextRequest.o \
 	SifExecRequest.o SifRpcLoop.o SifRpcMain.o _rpc_get_packet.o \
 	_rpc_get_fpacket.o SifCheckStatRpc.o
 
+### FILEIO client objects
+
 FILEIO_OBJS = __fio_internals.o fio_init.o _fio_intr.o fio_sync.o fio_setblockmode.o \
 	fio_exit.o fio_open.o fio_close.o fio_read.o \
 	fio_write.o fio_lseek.o fio_mkdir.o _fio_read_intr.o fio_getc.o fio_putc.o \
 	fio_ioctl.o fio_dopen.o fio_dclose.o fio_dread.o fio_getstat.o fio_chstat.o \
 	fio_remove.o fio_format.o fio_rmdir.o fio_gets.o
+
+### LOADFILE client objects
 
 LOADFILE_OBJS = SifLoadFileInit.o SifLoadFileExit.o _SifLoadModule.o SifLoadModule.o \
 	SifLoadStartModule.o SifLoadModuleEncrypted.o SifStopModule.o SifUnloadModule.o \
@@ -27,19 +59,33 @@ LOADFILE_OBJS = SifLoadFileInit.o SifLoadFileExit.o _SifLoadModule.o SifLoadModu
 	_SifLoadModuleBuffer.o SifLoadModuleBuffer.o SifLoadStartModuleBuffer.o \
 	SifExecModuleBuffer.o SifExecModuleFile.o
 
+### IOPHEAP client objects
+
 IOPHEAP_OBJS = SifInitIopHeap.o SifExitIopHeap.o SifAllocIopHeap.o \
 	SifFreeIopHeap.o SifLoadIopHeap.o
 
+### IOP-management objects
+
 IOPCONTROL_OBJS = SifIopReboot.o SifIopReset.o SifIopIsAlive.o SifIopSync.o __iop_control_internals.o
 
-GLUE_OBJS = DIntr.o EIntr.o EnableIntc.o DisableIntc.o EnableDmac.o DisableDmac.o \
-	iEnableIntc.o iDisableIntc.o iEnableDmac.o iDisableDmac.o SyncDCache.o \
-	iSyncDCache.o InvalidDCache.o iInvalidDCache.o
+### Glue objects
 
-THREAD_OBJS = _thread_internals.o iWakeupThread.o iRotateThreadReadyQueue.o iSuspendThread.o
+GLUE_OBJS = DIntr.o EIntr.o EnableIntc.o DisableIntc.o EnableDmac.o DisableDmac.o
+ifeq ($(KERNEL_NO_PATCHES),1)
+	GLUE_OBJS += SetAlarm.o ReleaseAlarm.o
+endif
+GLUE_OBJS += iEnableIntc.o iDisableIntc.o iEnableDmac.o iDisableDmac.o
+ifeq ($(KERNEL_NO_PATCHES),1)
+	GLUE_OBJS += iSetAlarm.o iReleaseAlarm.o
+endif
+GLUE_OBJS += SyncDCache.o iSyncDCache.o InvalidDCache.o iInvalidDCache.o
+
+### SIO objects
 
 SIO_OBJS = sio_init.o sio_putc.o sio_getc.o sio_write.o sio_read.o sio_puts.o \
 	sio_gets.o sio_getc_block.o sio_flush.o sio_putsn.o
+
+### Config objects
 
 CONFIG_OBJS = _config_internals.o GetRomName.o IsT10K.o IsEarlyJap.o configGetLanguage.o \
 	configSetLanguage.o configGetTvScreenType.o configSetTvScreenType.o \
@@ -48,43 +94,57 @@ CONFIG_OBJS = _config_internals.o GetRomName.o IsT10K.o IsEarlyJap.o configGetLa
 	configIsSpdifEnabled.o configSetSpdifEnabled.o configGetTime.o \
 	configIsDaylightSavingEnabled.o configSetDaylightSavingEnabled.o
 
-LIBOSD_OBJS = libosd.o libosd_full.o libosd_common.o osdsrc_bin.o
+### Patch objects
 
-TLBFUNC_OBJS = tlbfunc.o tlbsrc_bin.o
+ifneq ($(KERNEL_NO_PATCHES),1)
+	LIBOSD_OBJS = libosd.o libosd_full.o libosd_common.o osdsrc_bin.o
 
-ALARM_OBJS = alarm.o srcfile_bin.o eenull_bin.o
+	TLBFUNC_OBJS = tlbfunc.o tlbsrc_bin.o
+
+	ALARM_OBJS = alarm.o srcfile_bin.o eenull_bin.o
+
+	THREAD_OBJS = _thread_internals.o iWakeupThread.o iRotateThreadReadyQueue.o iSuspendThread.o
+
+	SETUP_OBJS = kCopy.o kCopyBytes.o
+endif
+
+### Timer objects
 
 TIMER_OBJS = cpu_ticks.o
 
+### Getter objects
+
 GETKERNEL_OBJS = GetSyscallHandler.o GetSyscall.o GetExceptionHandler.o GetInterruptHandler.o
 
-SETUP_OBJS = kCopy.o kCopyBytes.o
+### System initialization objects
 
-INITSYS_OBJS = _InitSys.o SetArg.o TerminateLibrary.o _initsys_internals.o Exit.o ExecPS2.o LoadExecPS2.o ExecOSD.o
+INITSYS_OBJS = _InitSys.o SetArg.o TerminateLibrary.o
+ifneq ($(KERNEL_NO_PATCHES),1)
+	INITSYS_OBJS += _initsys_internals.o Exit.o ExecPS2.o LoadExecPS2.o ExecOSD.o
+endif
 
 ### SYSCALL OBJECTS
 
-KERNEL_OBJS = ResetEE.o SetGsCrt.o _Exit.o _LoadExecPS2.o _ExecPS2.o \
+KERNEL_OBJS = ResetEE.o SetGsCrt.o $(EXEC_SYSCALLS) \
 	RFU009.o AddSbusIntcHandler.o RemoveSbusIntcHandler.o Interrupt2Iop.o \
 	SetVTLBRefillHandler.o SetVCommonHandler.o SetVInterruptHandler.o \
 	AddIntcHandler.o AddIntcHandler2.o RemoveIntcHandler.o AddDmacHandler.o AddDmacHandler2.o \
 	RemoveDmacHandler.o _EnableIntc.o _DisableIntc.o _EnableDmac.o _DisableDmac.o \
-	_SetAlarm.o SetAlarm.o _ReleaseAlarm.o ReleaseAlarm.o _iEnableIntc.o _iDisableIntc.o _iEnableDmac.o \
-	_iDisableDmac.o _iSetAlarm.o iSetAlarm.o _iReleaseAlarm.o iReleaseAlarm.o CreateThread.o DeleteThread.o \
+	$(ALARM_SYSCALLS) _iEnableIntc.o _iDisableIntc.o _iEnableDmac.o \
+	_iDisableDmac.o $(ALARM_INTR_SYSCALLS) CreateThread.o DeleteThread.o \
 	StartThread.o ExitThread.o ExitDeleteThread.o TerminateThread.o \
 	iTerminateThread.o DisableDispatchThread.o EnableDispatchThread.o \
 	ChangeThreadPriority.o iChangeThreadPriority.o RotateThreadReadyQueue.o \
-	_iRotateThreadReadyQueue.o ReleaseWaitThread.o iReleaseWaitThread.o \
+	$(ROTATE_THREAD_READY_QUEUE_SYSCALL) ReleaseWaitThread.o iReleaseWaitThread.o \
 	GetThreadId.o _iGetThreadId.o ReferThreadStatus.o iReferThreadStatus.o SleepThread.o \
-	WakeupThread.o _iWakeupThread.o CancelWakeupThread.o iCancelWakeupThread.o \
-	SuspendThread.o _iSuspendThread.o ResumeThread.o iResumeThread.o \
+	WakeupThread.o $(IWAKEUP_THREAD_SYSCALL) CancelWakeupThread.o iCancelWakeupThread.o \
+	SuspendThread.o $(ISUSPEND_THREAD_SYSCALL) ResumeThread.o iResumeThread.o \
 	RFU059.o RFU060.o SetupThread.o RFU061.o SetupHeap.o EndOfHeap.o CreateSema.o DeleteSema.o \
 	iSignalSema.o SignalSema.o WaitSema.o PollSema.o iPollSema.o \
 	ReferSemaStatus.o iReferSemaStatus.o iDeleteSema.o SetOsdConfigParam.o \
 	GetOsdConfigParam.o GetGsHParam.o GetGsVParam.o SetGsHParam.o \
 	SetGsVParam.o CreateEventFlag.o DeleteEventFlag.o SetEventFlag.o \
-	iSetEventFlag.o PutTLBEntry.o iPutTLBEntry.o _SetTLBEntry.o iSetTLBEntry.o \
-	GetTLBEntry.o iGetTLBEntry.o ProbeTLBEntry.o iProbeTLBEntry.o ExpandScratchPad.o \
+	iSetEventFlag.o $(TLB_SYSCALLS) \
 	EnableIntcHandler.o iEnableIntcHandler.o DisableIntcHandler.o iDisableIntcHandler.o \
 	EnableDmacHandler.o iEnableDmacHandler.o DisableDmacHandler.o iDisableDmacHandler.o \
 	KSeg0.o EnableCache.o DisableCache.o GetCop0.o FlushCache.o CpuConfig.o \
@@ -93,14 +153,18 @@ KERNEL_OBJS = ResetEE.o SetGsCrt.o _Exit.o _LoadExecPS2.o _ExecPS2.o \
 	GetOsdConfigParam2.o GsGetIMR.o iGsGetIMR.o GsPutIMR.o iGsPutIMR.o \
 	SetPgifHandler.o SetVSyncFlag.o SetSyscall.o SifDmaStat.o iSifDmaStat.o \
 	SifSetDma.o iSifSetDma.o SifSetDChain.o iSifSetDChain.o SifSetReg.o \
-	SifGetReg.o _ExecOSD.o Deci2Call.o PSMode.o MachineType.o GetMemorySize.o _GetGsDxDyOffset.o _InitTLB.o \
+	SifGetReg.o $(EXECOSD_SYSCALL) Deci2Call.o PSMode.o MachineType.o GetMemorySize.o _GetGsDxDyOffset.o _InitTLB.o \
 	SifWriteBackDCache.o _SyncDCache.o _InvalidDCache.o __errno.o errno.o \
 	strncpy.o strlen.o memcpy.o memset.o __syscall.o
 
 EE_OBJS = $(KERNEL_OBJS) $(SIFCMD_OBJS) $(SIFRPC_OBJS) $(FILEIO_OBJS) \
 	$(LOADFILE_OBJS) $(IOPHEAP_OBJS) $(IOPCONTROL_OBJS) $(CONFIG_OBJS) \
-	$(GLUE_OBJS) $(THREAD_OBJS) $(SIO_OBJS) $(TIMER_OBJS) $(GETKERNEL_OBJS) $(LIBOSD_OBJS)	\
-	$(TLBFUNC_OBJS) $(ALARM_OBJS) $(SETUP_OBJS) setup_syscalls.o $(INITSYS_OBJS) erl-support.o
+	$(GLUE_OBJS) $(SIO_OBJS) $(TIMER_OBJS) $(GETKERNEL_OBJS) \
+	$(INITSYS_OBJS) erl-support.o
+
+ifneq ($(KERNEL_NO_PATCHES),1)
+	EE_OBJS += $(THREAD_OBJS) $(LIBOSD_OBJS) $(TLBFUNC_OBJS) $(ALARM_OBJS) $(SETUP_OBJS) setup_syscalls.o
+endif
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make

--- a/ee/kernel/include/kernel.h
+++ b/ee/kernel/include/kernel.h
@@ -320,14 +320,18 @@ s32  _DisableDmac(s32 channel);
 
 //Alarm value is in H-SYNC ticks.
 s32  SetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common);
+s32  _SetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common);
 s32  ReleaseAlarm(s32 alarm_id);
+s32  _ReleaseAlarm(s32 alarm_id);
 
 s32  _iEnableIntc(s32 cause);
 s32  _iDisableIntc(s32 cause);
 s32  _iEnableDmac(s32 channel);
 s32  _iDisableDmac(s32 channel);
 s32  iSetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common);
+s32  _iSetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common);
 s32  iReleaseAlarm(s32 alarm_id);
+s32  _iReleaseAlarm(s32 alarm_id);
 s32	 CreateThread(ee_thread_t *thread);
 s32	 DeleteThread(s32 thread_id);
 s32	 StartThread(s32 thread_id, void *args);

--- a/ee/kernel/src/glue.c
+++ b/ee/kernel/src/glue.c
@@ -136,6 +136,48 @@ int DisableDmac(int dmac)
 }
 #endif
 
+#ifdef F_SetAlarm
+int SetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common)
+{
+	int eie, res;
+
+	asm volatile ("mfc0\t%0, $12" : "=r" (eie));
+	eie &= 0x10000;
+
+	if (eie)
+		DI();
+
+	res = _SetAlarm(time, callback, common);
+	EE_SYNC();
+
+	if (eie)
+		EI();
+
+	return res;
+}
+#endif
+
+#ifdef F_ReleaseAlarm
+int ReleaseAlarm(int alarm_id)
+{
+	int eie, res;
+
+	asm volatile ("mfc0\t%0, $12" : "=r" (eie));
+	eie &= 0x10000;
+
+	if (eie)
+		DI();
+
+	res = _ReleaseAlarm(alarm_id);
+	EE_SYNC();
+
+	if (eie)
+		EI();
+
+	return res;
+}
+#endif
+
 #ifdef F_iEnableIntc
 int iEnableIntc(int intc)
 {
@@ -170,6 +212,26 @@ int iEnableDmac(int dmac)
 int iDisableDmac(int dmac)
 {
 	int res = _iDisableDmac(dmac);
+	EE_SYNC();
+
+	return res;
+}
+#endif
+
+#ifdef F_iSetAlarm
+int iSetAlarm(u16 time, void (*callback)(s32 alarm_id, u16 time, void *common), void *common)
+{
+	int res = _iSetAlarm(time, callback, common);
+	EE_SYNC();
+
+	return res;
+}
+#endif
+
+#ifdef F_iReleaseAlarm
+int iReleaseAlarm(int alarm_id)
+{
+	int res = _iReleaseAlarm(alarm_id);
 	EE_SYNC();
 
 	return res;

--- a/ee/kernel/src/initsys.c
+++ b/ee/kernel/src/initsys.c
@@ -21,17 +21,21 @@ void *SetArg(const char *filename, int argc, char *argv[]);
 #ifdef F__InitSys
 void _InitSys(void)
 {
+#ifndef KERNEL_NO_PATCHES
 	InitAlarm();
 	InitThread();
 	InitExecPS2();
 	InitTLBFunctions();
+#endif
 }
 #endif
 
 #ifdef F_TerminateLibrary
 void TerminateLibrary(void)
 {
+#ifndef KERNEL_NO_PATCHES
 	InitTLB();
+#endif
 }
 #endif
 

--- a/ee/kernel/src/kernel.S
+++ b/ee/kernel/src/kernel.S
@@ -19,36 +19,39 @@
 	.text
 	.p2align 3
 
+#define SYSCALL(name)	\
+		SYSCALL_SPECIAL(name, name)
+
 #ifdef USE_KMODE
-#define SYSCALL(name) 		\
+#define SYSCALL_SPECIAL(symbol, name) 		\
 	.set	push;		\
 	.set	noreorder;	\
 	.text;			\
 	.align 4;		\
-	.globl	name;		\
-	.type	name,@function;	\
-	.ent	name,0;		\
-name:	j	__syscall;	\
+	.globl	symbol;		\
+	.type	symbol,@function;	\
+	.ent	symbol,0;		\
+symbol:	j	__syscall;	\
 	li	$3, __NR_##name;\
 	nop;			\
-	.end	name;		\
-	.size	name,.-name;	\
+	.end	symbol;		\
+	.size	symbol,.-symbol;	\
 	.set	pop;
 #else
-#define SYSCALL(name) 		\
+#define SYSCALL_SPECIAL(symbol, name) 		\
 	.set	push;		\
 	.set	noreorder;	\
 	.text;			\
 	.align 4;		\
-	.globl	name;		\
-	.type	name,@function;	\
-	.ent	name,0;		\
-name:	li	$3, __NR_##name;\
+	.globl	symbol;		\
+	.type	symbol,@function;	\
+	.ent	symbol,0;		\
+symbol:	li	$3, __NR_##name;\
 	syscall;		\
 	jr	$31;		\
 	nop;			\
-	.end	name;		\
-	.size	name,.-name;	\
+	.end	symbol;		\
+	.size	symbol,.-symbol;	\
 	.set	pop;
 #endif
 
@@ -94,6 +97,22 @@ SYSCALL(ResetEE)
 SYSCALL(SetGsCrt)
 #endif
 
+#ifdef KERNEL_NO_PATCHES
+
+#ifdef F_Exit
+SYSCALL_SPECIAL(Exit, _Exit)
+#endif
+
+#ifdef F_LoadExecPS2
+SYSCALL_SPECIAL(LoadExecPS2, _LoadExecPS2)
+#endif
+
+#ifdef F_ExecPS2
+SYSCALL_SPECIAL(ExecPS2, _ExecPS2)
+#endif
+
+#else	/* KERNEL_NO_PATCHES */
+
 #ifdef F__Exit
 SYSCALL(_Exit)
 #endif
@@ -105,6 +124,8 @@ SYSCALL(_LoadExecPS2)
 #ifdef F__ExecPS2
 SYSCALL(_ExecPS2)
 #endif
+
+#endif	/* KERNEL_NO_PATCHES */
 
 #ifdef F_RFU009
 SYSCALL(RFU009)
@@ -179,15 +200,19 @@ SYSCALL(_SetAlarm)
 #endif
 
 #ifdef F_SetAlarm
+#ifndef KERNEL_NO_PATCHES
 SYSCALL(SetAlarm)
+#endif
 #endif
 
 #ifdef F__ReleaseAlarm
 SYSCALL(_ReleaseAlarm)
 #endif
 
+#ifndef KERNEL_NO_PATCHES
 #ifdef F_ReleaseAlarm
 SYSCALL(ReleaseAlarm)
+#endif
 #endif
 
 #ifdef F__iEnableIntc
@@ -210,16 +235,20 @@ SYSCALL(_iDisableDmac)
 SYSCALL(_iSetAlarm)
 #endif
 
+#ifndef KERNEL_NO_PATCHES
 #ifdef F_iSetAlarm
 SYSCALL(iSetAlarm)
+#endif
 #endif
 
 #ifdef F__iReleaseAlarm
 SYSCALL(_iReleaseAlarm)
 #endif
 
+#ifndef KERNEL_NO_PATCHES
 #ifdef F_iReleaseAlarm
 SYSCALL(iReleaseAlarm)
+#endif
 #endif
 
 #ifdef F_CreateThread
@@ -270,9 +299,19 @@ SYSCALL(iChangeThreadPriority)
 SYSCALL(RotateThreadReadyQueue)
 #endif
 
+#ifdef KERNEL_NO_PATCHES
+
+#ifdef F_iRotateThreadReadyQueue
+SYSCALL_SPECIAL(iRotateThreadReadyQueue, _iRotateThreadReadyQueue)
+#endif
+
+#else	/* KERNEL_NO_PATCHES */
+
 #ifdef F__iRotateThreadReadyQueue
 SYSCALL(_iRotateThreadReadyQueue)
 #endif
+
+#endif	/* KERNEL_NO_PATCHES */
 
 #ifdef F_ReleaseWaitThread
 SYSCALL(ReleaseWaitThread)
@@ -306,9 +345,19 @@ SYSCALL(SleepThread)
 SYSCALL(WakeupThread)
 #endif
 
+#ifdef KERNEL_NO_PATCHES
+
+#ifdef F_iWakeupThread
+SYSCALL_SPECIAL(iWakeupThread, _iWakeupThread)
+#endif
+
+#else	/* KERNEL_NO_PATCHES */
+
 #ifdef F__iWakeupThread
 SYSCALL(_iWakeupThread)
 #endif
+
+#endif	/* KERNEL_NO_PATCHES */
 
 #ifdef F_CancelWakeupThread
 SYSCALL(CancelWakeupThread)
@@ -322,9 +371,19 @@ SYSCALL(iCancelWakeupThread)
 SYSCALL(SuspendThread)
 #endif
 
+#ifdef KERNEL_NO_PATCHES
+
+#ifdef F_iSuspendThread
+SYSCALL_SPECIAL(iSuspendThread, _iSuspendThread)
+#endif
+
+#else	/* KERNEL_NO_PATCHES */
+
 #ifdef F__iSuspendThread
 SYSCALL(_iSuspendThread)
 #endif
+
+#endif	/* KERNEL_NO_PATCHES */
 
 #ifdef F_ResumeThread
 SYSCALL(ResumeThread)
@@ -438,6 +497,8 @@ SYSCALL(SetEventFlag)
 SYSCALL(iSetEventFlag)
 #endif
 
+#ifndef KERNEL_NO_PATCHES
+
 #ifdef F_PutTLBEntry
 SYSCALL(PutTLBEntry)
 #endif
@@ -473,6 +534,8 @@ SYSCALL(iProbeTLBEntry)
 #ifdef F_ExpandScratchPad
 SYSCALL(ExpandScratchPad)
 #endif
+
+#endif /* KERNEL_NO_PATCHES */
 
 #ifdef F_EnableIntcHandler
 SYSCALL(EnableIntcHandler)
@@ -630,9 +693,19 @@ SYSCALL(SifSetReg)
 SYSCALL(SifGetReg)
 #endif
 
+#ifdef KERNEL_NO_PATCHES
+
+#ifdef F_ExecOSD
+SYSCALL_SPECIAL(ExecOSD, _ExecOSD)
+#endif
+
+#else	/* KERNEL_NO_PATCHES */
+
 #ifdef F__ExecOSD
 SYSCALL(_ExecOSD)
 #endif
+
+#endif	/* KERNEL_NO_PATCHES */
 
 #ifdef F_Deci2Call
 SYSCALL(Deci2Call)

--- a/ee/kernel/src/srcfile/src/alarm.c
+++ b/ee/kernel/src/srcfile/src/alarm.c
@@ -41,7 +41,7 @@ u128 AlarmDispatch_sp;
 //Function prototypes
 static u32 CalculateTimeDiff(u32 t1, u32 t2);
 static int InsertAlarm(u32 now, u32 target);
-static s32 _SetAlarm(u16 time, void (*callback)(s32 dispatch_id, u16 time, void *common), void *common);
+static s32 SetAlarmInternal(u16 time, void (*callback)(s32 dispatch_id, u16 time, void *common), void *common);
 static void SetupTIM3(u16 ticks);
 
 static u32 CalculateTimeDiff(u32 t1, u32 t2)
@@ -68,7 +68,7 @@ static int InsertAlarm(u32 now, u32 target)
 	return pos;
 }
 
-static s32 _SetAlarm(u16 time, void (*callback)(s32 dispatch_id, u16 time, void *common), void *common)
+static s32 SetAlarmInternal(u16 time, void (*callback)(s32 dispatch_id, u16 time, void *common), void *common)
 {
 	void *gp;
 	u32 target, now;
@@ -153,7 +153,7 @@ s32 SetAlarm(u16 time, void (*callback)(s32 dispatch_id, u16 time, void *common)
 {
 	s32 result;
 
-	result = _SetAlarm(time, callback, common);
+	result = SetAlarmInternal(time, callback, common);
 	EE_SYNC();
 
 	return result;

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -42,12 +42,12 @@ STDIO_OBJS = clearerr.o fclose.o fcloseall.o feof.o ferror.o fflush.o fflushall.
 	fgetpos.o fgets.o fopen.o fputc.o fputs.o fread.o fseek.o fsetpos.o ftell.o fwrite.o fileno.o \
 	getc.o getchar.o getfdtype.o gets.o perror.o putc.o puts.o remove.o fdopen.o \
 	rewind.o skipatoi.o stdio.o tmpfile.o tmpnam.o ungetc.o updatestdoutxy.o strerror.o \
-	__stdio_internals.o chdir.o
+	__stdio_internals.o __stdio_helper_internals.o chdir.o
 
 STDLIB_OBJS = abs.o atexit.o atof.o bsearch.o div.o getenv.o _itoa.o labs.o \
 	ldiv.o llabs.o lldiv.o _lltoa.o _ltoa.o rand.o setenv.o srand.o \
 	strtod.o strtol.o strtoul.o __assert_fail.o \
-	__stdlib_internals.o \
+	__stdlib_internals.o __stdlib_environmentals.o \
 	mblen.o mbslen.o mbstowcs.o mbtowc.o wcstombs.o wctomb.o
 
 WSTDLIB_OBJS = wcstod.o wcstol.o wcstoul.o

--- a/ee/libc/src/stdio.c
+++ b/ee/libc/src/stdio.c
@@ -759,9 +759,6 @@ int getchar(void)
 
 
 #ifdef F_getfdtype
-/* the present working directory variable. */
-char __direct_pwd[256] = "";
-
 static struct {
   char * prefix;
   int len;
@@ -976,6 +973,9 @@ int __stdio_skip_atoi(const char **s)
 /* stdio data variables. */
 int __stdio_initialised = 0;
 
+/* the present working directory variable. */
+char __direct_pwd[256] = "";
+
 FILE __iob[_NFILE] = {
   { -1,                 0, 0, 0 },     // stdin
 #ifdef USE_GS
@@ -1062,7 +1062,7 @@ void __stdio_update_stdout_xy(int x, int y)
 #endif
 
 
-#ifdef F___stdio_internals
+#ifdef F___stdio_helper_internals
 int (*_ps2sdk_close)(int) = fioClose;
 int (*_ps2sdk_open)(const char*, int) = fioOpen;
 int (*_ps2sdk_read)(int, void*, int) = fioRead;
@@ -1076,8 +1076,9 @@ int fioRename(const char *old, const char *new)
 }
 
 int (*_ps2sdk_rename)(const char*, const char*) = fioRename;
+#endif
 
-
+#ifdef F___stdio_internals
 void _ps2sdk_stdio_init()
 {
     int i;

--- a/ee/libc/src/stdlib.c
+++ b/ee/libc/src/stdlib.c
@@ -551,9 +551,13 @@ void srand(unsigned int seed)
 #endif
 
 
+#ifdef F___stdlib_environmentals
+/* stdlib environmental data variables. */
+environvariable_t    __stdlib_env[32];
+#endif
+
 #ifdef F___stdlib_internals
 /* stdlib data variables. */
-environvariable_t    __stdlib_env[32];
 void                 (* __stdlib_exit_func[32])(void);
 int                  __stdlib_exit_index = 0;
 int                  __stdlib_mb_shift = 0;


### PR DESCRIPTION
Modified libkernel to allow building with no support for patches (for ease of maintaining/building loader-like/resident projects). Such projects can be built without the patches by linking to libkernel-nopatch instead of libkernel.

Also added a (missing) workaround for the old SetAlarm and ReleaseAlarm, when the alarm patch is not built.

I also moved around internal data of libc, to reduce the bloat that is linked to by crt0 itself. However, these changes do not totally eliminate the bloat of libc (the use of a custom crt0 is required).

On a side note, if a host program is compiled with the alarm patch and it loads an ELF loader, the ELF loader should reside at 0x00084000 instead of 0x00082000. Otherwise, it may overwrite the alarm patch, which may cause an exception. This is done by the official HDD Browser.