### PR TITLE
Add d_type value in the dirent struct

### DIFF
--- a/ee/libc/include/dirent.h
+++ b/ee/libc/include/dirent.h
@@ -20,6 +20,7 @@ struct dirent
 {
 	/** relative filename */
 	char d_name[256];
+	unsigned int d_type;
 };
 
 typedef struct DIR


### PR DESCRIPTION
I think that to add this new value in the struct is so useful. Usually this is the common architecture.

For instance, right now I'm working in Picodrive emulator which is shared code between a lot of platform.
I have need to create custom dirent struct because should feet with the rest of platform.

Thanks in advance, and sorry if this is a stupid idea.
Francisco Javier