### PR TITLE
Workarounds in DEV9 & ATAD for bad GameStar adaptors

### DIFF
--- a/iop/dev9/atad/Makefile
+++ b/iop/dev9/atad/Makefile
@@ -15,6 +15,9 @@ ATA_MWDMA_MODES ?= 0
 #Enable to enable support for PIO modes 0-4 (as in early ATAD modules), instead of just PIO mode 0.
 ATA_ALL_PIO_MODES ?= 0
 
+#Disable to disable the workaround for bad GameStar compatible adaptors.
+ATA_GAMESTAR_WORKAROUND ?= 1
+
 IOP_BIN ?= ps2atad.irx
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/dev9/dev9/include
@@ -30,6 +33,10 @@ endif
 
 ifeq ($(ATA_ALL_PIO_MODES),1)
 IOP_CFLAGS += -DATA_ALL_PIO_MODES=1
+endif
+
+ifeq ($(ATA_GAMESTAR_WORKAROUND),1)
+IOP_CFLAGS += -DATA_GAMESTAR_WORKAROUND=1
 endif
 
 include $(PS2SDKSRC)/Defs.make

--- a/iop/dev9/dev9/Makefile
+++ b/iop/dev9/dev9/Makefile
@@ -12,6 +12,9 @@ DEV9_SKIP_SMAP_INIT ?= 0
 #Enable to enable support for the PSX's devices
 DEV9_PSX_SUPPORT ?= 1
 
+#Disable to disable the workaround (skip SMAP initialization) for bad GameStar compatible adaptors.
+DEV9_GAMESTAR_WORKAROUND ?= 1
+
 IOP_BIN ?= ps2dev9.irx
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/dev9/poweroff/include
@@ -23,6 +26,10 @@ endif
 
 ifeq ($(DEV9_PSX_SUPPORT),1)
 IOP_CFLAGS += -DDEV9_PSX_SUPPORT=1
+endif
+
+ifeq ($(DEV9_GAMESTAR_WORKAROUND),1)
+IOP_CFLAGS += -DDEV9_GAMESTAR_WORKAROUND=1
 endif
 
 include $(PS2SDKSRC)/Defs.make

--- a/iop/dev9/dev9/src/ps2dev9.c
+++ b/iop/dev9/dev9/src/ps2dev9.c
@@ -661,9 +661,8 @@ static int dev9_smap_init(void)
 	//Do not perform SMAP initialization if the SPEED device does not have such an interface
 	if (!(SPD_REG16(SPD_R_REV_3)&SPD_CAPS_SMAP)
 #ifdef DEV9_GAMESTAR_WORKAROUND
-	/*	If this adaptor is a GameStar compatible adaptor, do not initialize SMAP.
-		A GameStar masquerades as a SCPH-10281, but does not have SMAP implemented correctly.
-		Official adaptors appear to have a 0x0001 set for this register, but not the GameStar.
+	/*	If this adaptor is a compatible adaptor, do not initialize SMAP.
+		Official adaptors appear to have a 0x0001 set for this register, but not compatibles.
 		While official I/O to this register are 8-bit, some compatibles have a 0x01 for the lower 8-bits,
 		but the upper 8-bits contain some random value. Hence perform a 16-bit read instead. */
 	|| (SPD_REG16(0x20) != 1)

--- a/iop/dev9/dev9/src/ps2dev9.c
+++ b/iop/dev9/dev9/src/ps2dev9.c
@@ -659,7 +659,16 @@ static int dev9_smap_init(void)
 	int i;
 
 	//Do not perform SMAP initialization if the SPEED device does not have such an interface
-	if (!(SPD_REG16(SPD_R_REV_3)&SPD_CAPS_SMAP)) return 0;
+	if (!(SPD_REG16(SPD_R_REV_3)&SPD_CAPS_SMAP)
+#ifdef DEV9_GAMESTAR_WORKAROUND
+	/*	If this adaptor is a GameStar compatible adaptor, do not initialize SMAP.
+		A GameStar masquerades as a SCPH-10281, but does not have SMAP implemented correctly.
+		Official adaptors appear to have a 0x0001 set for this register, but not the GameStar.
+		While official I/O to this register are 8-bit, some compatibles have a 0x01 for the lower 8-bits,
+		but the upper 8-bits contain some random value. Hence perform a 16-bit read instead. */
+	|| (SPD_REG16(0x20) != 1)
+#endif
+        ) return 0;
 
 	SMAP_REG8(SMAP_R_TXFIFO_CTRL) = SMAP_TXFIFO_RESET;
 	for(i = 9; SMAP_REG8(SMAP_R_TXFIFO_CTRL)&SMAP_TXFIFO_RESET; i--)


### PR DESCRIPTION
This pull request contains workarounds in DEV9 & ATAD for bad GameStar adaptors.

As it appears that the current method of detecting a GameStar is not so effective, please **do not** merge this pull request yet.