### PR TITLE
Use -nostdlib when building ps2sdk

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -74,12 +74,12 @@ $(EE_OBJS_DIR):
 $(EE_OBJS): | $(EE_OBJS_DIR)
 
 $(EE_BIN): $(EE_OBJS) $(PS2SDKSRC)/ee/startup/obj/crt0.o | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
+	$(EE_CC) -nostdlib $(EE_NO_CRT) -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
 		-o $(EE_BIN) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_LIB): $(EE_OBJS) $(EE_LIB:%.a=%.erl) | $(EE_LIB_DIR)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)
 
 $(EE_LIB:%.a=%.erl): $(EE_OBJS) | $(EE_LIB_DIR)
-	$(EE_CC) $(EE_NO_CRT) -Wl,-r -Wl,-d -o $(EE_LIB:%.a=%.erl) $(EE_OBJS)
+	$(EE_CC) -nostdlib $(EE_NO_CRT) -Wl,-r -Wl,-d -o $(EE_LIB:%.a=%.erl) $(EE_OBJS)
 	$(EE_STRIP) --strip-unneeded -R .mdebug.eabi64 -R .reginfo -R .comment $(EE_LIB:%.a=%.erl)

--- a/ee/erl-loader/Makefile
+++ b/ee/erl-loader/Makefile
@@ -38,9 +38,9 @@ include $(PS2SDKSRC)/ee/Rules.release
 $(EE_OBJS_DIR)erl-loader.o: | $(EE_OBJS_DIR)
 
 $(LOADER_BIN): $(EE_OBJS) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_LIBS) | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
-	-o $(EE_BIN_DIR)tmp.elf $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_OBJS) $(EE_LIBS) $(EE_SRC_DIR)dummy-exports.c
+	$(EE_CC) $(EE_NO_CRT) -nostdlib -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
+	-o $(EE_BIN_DIR)tmp.elf $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_OBJS) $(EE_LIBS) -lgcc $(EE_SRC_DIR)dummy-exports.c
 	$(EE_SRC_DIR)build-exports.sh
 	rm $(EE_BIN_DIR)tmp.elf
-	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
-	-o $(LOADER_BIN) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_OBJS) $(EE_LIBS) $(EE_SRC_DIR)exports.c
+	$(EE_CC) $(EE_NO_CRT) -nostdlib -T$(PS2SDKSRC)/ee/startup/src/linkfile $(EE_CFLAGS) \
+	-o $(LOADER_BIN) $(PS2SDKSRC)/ee/startup/obj/crt0.o $(EE_OBJS) $(EE_LIBS) -lgcc $(EE_SRC_DIR)exports.c

--- a/ee/kernel/src/eenull/Makefile
+++ b/ee/kernel/src/eenull/Makefile
@@ -26,4 +26,4 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.make
 
 $(EE_EENULL_ELF): $(EE_OBJS) | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostartfiles -Tlinkfile -s $(EE_LIBS)
+	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostdlib -nostartfiles -Tlinkfile -s $(EE_LIBS)

--- a/ee/kernel/src/osdsrc/Makefile
+++ b/ee/kernel/src/osdsrc/Makefile
@@ -27,4 +27,4 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.make
 
 $(EE_OSDSRC_ELF): $(EE_OBJS) | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostartfiles -Tlinkfile -s $(EE_LIBS)
+	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostdlib -nostartfiles -Tlinkfile -s $(EE_LIBS)

--- a/ee/kernel/src/srcfile/Makefile
+++ b/ee/kernel/src/srcfile/Makefile
@@ -26,4 +26,4 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.make
 
 $(EE_SRCFILE_ELF): $(EE_OBJS) | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostartfiles -Tlinkfile -s $(EE_LIBS)
+	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostdlib -nostartfiles -Tlinkfile -s $(EE_LIBS)

--- a/ee/kernel/src/tlbsrc/Makefile
+++ b/ee/kernel/src/tlbsrc/Makefile
@@ -27,4 +27,4 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.make
 
 $(EE_TLBSRC_ELF): $(EE_OBJS) | $(EE_BIN_DIR)
-	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostartfiles -Tlinkfile -s $(EE_LIBS)
+	$(EE_CC) $(EE_CFLAGS) -o $@ $^ -nostdlib -nostartfiles -Tlinkfile -s $(EE_LIBS)


### PR DESCRIPTION
The recent change to the toolchain adds standard libraries to gcc. Some of these libraries (libc, libkernel) are built by ps2sdk. So ps2sdk needs to use the flag '-nostdlib' when linking or it will fail when compiling for the first time.

I didn't notice this before becouse I normally don't delete the entire $PS2DEV folder before building the toolchain. I still have to do some testing, so don't merge this pr just yet. Sorry for the inconvenience.