### PR TITLE
(NETMAN) Changed NETMAN to support zero-copy receiving for the EE-side protocol stack.

### DIFF
--- a/common/include/netman.h
+++ b/common/include/netman.h
@@ -8,6 +8,7 @@
 
 //Common structures
 #define NETMAN_NETIF_NAME_MAX_LEN	4
+#define NETMAN_NETIF_FRAME_SIZE		1514
 
 struct NetManNetProtStack{
 	void (*LinkStateUp)(void);
@@ -17,7 +18,8 @@ struct NetManNetProtStack{
 	void (*EnQRxPacket)(void *packet);
 	int (*NextTxPacket)(void **payload);
 	void (*DeQTxPacket)(void);
-	int (*AfterTxPacket)(void **payload);	//For EE only, peek at the packet after the current packet.
+	int (*AfterTxPacket)(void **payload);				//For EE only, peek at the packet after the current packet.
+	void (*ReallocRxPacket)(void *packet, unsigned int size);	//For EE only, update the size of the Rx packet (size will be always smaller than NETMAN_NETIF_FRAME_SIZE).
 };
 
 /** Flow-control */
@@ -105,7 +107,8 @@ void NetManNetProtStackEnQRxPacket(void *packet);
 int NetManTxPacketNext(void **payload);
 void NetManTxPacketDeQ(void);
 
-int NetManTxPacketAfter(void **payload);	//For EE only, for NETMAN's internal use
+int NetManTxPacketAfter(void **payload);					//For EE only, for NETMAN's internal use.
+void NetManNetProtStackReallocRxPacket(void *packet, unsigned int length);	//For EE only, for NETMAN's internal use.
 
 /* NETIF flags. */
 /** Set internally by NETMAN. Do not set externally. */

--- a/common/include/netman_rpc.h
+++ b/common/include/netman_rpc.h
@@ -32,7 +32,6 @@ enum NETMAN_IOP_RPC_FUNC_NUMS{
 
 struct NetManEEInitResult{
 	s32 result;
-	void *FrameBuffer;
 };
 
 struct NetManRegNetworkStack{
@@ -50,7 +49,7 @@ struct NetManQueryMainNetIFResult{
 };
 
 #define NETMAN_MAX_FRAME_SIZE	1536	//Maximum 1518 bytes, rounded up to nearest multiple of 16-byte units + 16 (for alignment)
-#define NETMAN_RPC_BLOCK_SIZE	64
+#define NETMAN_RPC_BLOCK_SIZE	32
 
 struct NetManIoctl{
 	u32 command;
@@ -69,6 +68,13 @@ struct NetManPktCmd {
 	u8 id;
 	u8 offset;	//For alignment correction on the EE (unused for IOP->EE).
 	u16 length;
+};
+
+struct NetManBD {
+	u32 length;	//When set to 0, buffer is available for use by MAC driver.
+	void *packet;
+	void *payload;	//Pointer to the data section of the packet.
+	u32 unused;
 };
 
 #endif /* __NETMAN_RPC_H__ */

--- a/ee/network/netman/src/include/rpc_server.h
+++ b/ee/network/netman/src/include/rpc_server.h
@@ -1,2 +1,3 @@
 int NetManInitRPCServer(void);
 void NetManDeinitRPCServer(void);
+int NetManRPCAllocRxBuffers(void);

--- a/ee/network/netman/src/netman.c
+++ b/ee/network/netman/src/netman.c
@@ -79,7 +79,8 @@ int NetManRegisterNetworkStack(const struct NetManNetProtStack *stack)
 			{
 				memcpy(&MainNetProtStack, stack, sizeof(MainNetProtStack));
 				IsNetStackInitialized=1;
-				NetManUpdateStackNIFLinkState();
+				if((result=NetManRPCAllocRxBuffers()) == 0)
+					NetManUpdateStackNIFLinkState();
 			}
 		}
 		else result=0;
@@ -140,4 +141,9 @@ void NetManTxPacketDeQ(void)
 int NetManTxPacketAfter(void **payload)
 {
 	return IsInitialized?MainNetProtStack.AfterTxPacket(payload):-1;
+}
+
+void NetManNetProtStackReallocRxPacket(void *packet, unsigned int length)
+{
+	if(IsNetStackInitialized) MainNetProtStack.ReallocRxPacket(packet, length);
 }

--- a/ee/network/tcpip/src/include/lwipopts.h
+++ b/ee/network/tcpip/src/include/lwipopts.h
@@ -107,7 +107,7 @@
  * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
  */
 //SP193: should be at least ((TCP_WND/PBUF_POOL_BUFSIZE)+1). But that is too small to accommodate data not accepted by the application layer and multiple connections.
-#define PBUF_POOL_SIZE			60
+#define PBUF_POOL_SIZE			64
 
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used

--- a/ee/network/tcpip/src/ps2ip.c
+++ b/ee/network/tcpip/src/ps2ip.c
@@ -178,6 +178,11 @@ static void *AllocRxPacket(unsigned int size, void **payload)
 	return pbuf;
 }
 
+static void ReallocRxPacket(void *packet, unsigned int size)
+{
+	pbuf_realloc((struct pbuf *)packet, size);
+}
+
 static void FreeRxPacket(void *packet)
 {
 	pbuf_free(packet);
@@ -307,7 +312,8 @@ int ps2ipInit(struct ip4_addr *ip_address, struct ip4_addr *subnet_mask, struct 
 		&EnQRxPacket,
 		&NextTxPacket,
 		&DeQTxPacket,
-		&AfterTxPacket
+		&AfterTxPacket,
+		&ReallocRxPacket
 	};
 
 	NetManInit();

--- a/iop/tcpip/tcpip-netman/src/ps2ip.c
+++ b/iop/tcpip/tcpip-netman/src/ps2ip.c
@@ -418,6 +418,7 @@ static inline int InitLWIPStack(IPAddr *IP, IPAddr *NM, IPAddr *GW){
 		&EnQRxPacket,
 		&NextTxPacket,
 		&DeQTxPacket,
+		NULL,
 		NULL
 	};
 


### PR DESCRIPTION
This allows receiving from the EE to no require an additional memcpy() statement.
Seems to be working fine now, but I did not notice any improvement in performance (tested with TCP), scoring roughly 69Mbps.

This system was designed based on the idea from [this article](https://community.nxp.com/docs/DOC-330815).

Compared to the current design, this:
- NETMAN's ring buffers have been reduced to 32, down from 64.
- Will always result in at least 32 PBUFs being actively allocated, due to NETMAN's ring buffer size.
- Had LWIP (EE) adjusted to come with 64 PBUFs (up from 60).
- Has a lower EE-side Rx thread priority, so that the while loop around the allocation function (which calls pbuf_alloc) will not prevent the LWIP TCPIP thread (if enabled) from running.

With 32 buffers always allocated, this will give 32 buffers for storage before processing by the application layer. If the application layer is too slow, then the Rx thread will busy-loop around the pbuf_alloc function until a pbuf can be allocated.

Performance was observed to be roughly the same, but this design results in the queuing of incoming frames because the time taken by LWIP to process a frame will not be part of the time taken to free up a position within the ring buffer. Unlike the current design, the TCP receive window can be seen decreasing. It might be more efficient.