### PR TITLE
PFS - Fixed faulty logic behind bitmap-management, readlink and attribute IOCTL2 calls

### DIFF
--- a/iop/hdd/libpfs/include/libpfs.h
+++ b/iop/hdd/libpfs/include/libpfs.h
@@ -89,6 +89,7 @@ typedef struct {
 	} log[127];
 } pfs_journal_t;
 
+// Attribute Entry
 typedef struct{
 	u8 kLen;			// key len/used for offset in to str for value
 	u8 vLen;			// value len
@@ -96,6 +97,7 @@ typedef struct{
 	char str[3];		// size = 3 so sizeof pfs_aentry_t=7 :P
 } pfs_aentry_t;
 
+// Directory Entry
 typedef struct {
 	u32	inode;
 	u8	sub;

--- a/iop/hdd/pfs/src/pfs.h
+++ b/iop/hdd/pfs/src/pfs.h
@@ -26,10 +26,13 @@ typedef struct
 	u8 buffer[512];	// used for reading mis-aligned/remainder data
 } pfs_unaligned_io_t;
 
+#define PFS_AENTRY_KEY_MAX	256
+#define PFS_AENTRY_VALUE_MAX	256
+
 typedef struct
 {
-	char key[256];
-	char value[256];
+	char key[PFS_AENTRY_KEY_MAX];
+	char value[PFS_AENTRY_VALUE_MAX];
 } pfs_ioctl2attr_t;
 
 typedef struct {

--- a/iop/hdd/pfs/src/pfs_fio.c
+++ b/iop/hdd/pfs/src/pfs_fio.c
@@ -1275,7 +1275,7 @@ int pfsFioSymlink(iop_file_t *f, const char *old, const char *new)
 {
 	int rv;
 	pfs_mount_t *pfsMount;
-	int mode=0x141FF;
+	int mode = 0x10000 | FIO_S_IFLNK | 0x1FF;
 
 	if(old==NULL || new==NULL)
 		return -ENOENT;
@@ -1301,7 +1301,7 @@ int pfsFioReadlink(iop_file_t *f, const char *path, char *buf, unsigned int bufl
 
 	if((clink=pfsInodeGetFile(pfsMount, NULL, path, &rv))!=NULL)
 	{
-		if((clink->u.inode->mode & FIO_S_IFMT) == FIO_S_IFLNK)
+		if(!FIO_S_ISLNK(clink->u.inode->mode))
 			rv=-EINVAL;
 		else
 		{

--- a/iop/hdd/pfs/src/pfs_fioctl.c
+++ b/iop/hdd/pfs/src/pfs_fioctl.c
@@ -35,6 +35,12 @@ extern pfs_file_slot_t *pfsFileSlots;
 extern u32 pfsBlockSize;
 #endif
 
+enum PFS_AENTRY_MODE {
+	PFS_AENTRY_MODE_LOOKUP = 0,
+	PFS_AENTRY_MODE_ADD,
+	PFS_AENTRY_MODE_DELETE
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 //	Function declarations
 
@@ -47,7 +53,7 @@ static int ioctl2Attr(pfs_cache_t *clink, int cmd, void *arg, void *outbuf, u32 
 static pfs_aentry_t *getAentry(pfs_cache_t *clink, char *key, char *value, int mode);
 static int ioctl2AttrAdd(pfs_cache_t *clink, pfs_ioctl2attr_t *attr);
 static int ioctl2AttrDelete(pfs_cache_t *clink, void *arg);
-static int ioctl2AttrLoopUp(pfs_cache_t *clink, char *key, char *value);
+static int ioctl2AttrLookUp(pfs_cache_t *clink, char *key, char *value);
 static int ioctl2AttrRead(pfs_cache_t *clink, pfs_ioctl2attr_t *attr, u32 *unkbuf);
 
 int pfsFioIoctl(iop_file_t *f, int cmd, void *param)
@@ -189,7 +195,7 @@ static int ioctl2Attr(pfs_cache_t *clink, int cmd, void *arg, void *outbuf, u32 
 		break;
 
 	case PIOCATTRLOOKUP:
-		rv=ioctl2AttrLoopUp(flink, arg, outbuf);
+		rv=ioctl2AttrLookUp(flink, arg, outbuf);
 		break;
 
 	case PIOCATTRREAD:
@@ -233,7 +239,7 @@ static int devctlFsckStat(pfs_mount_t *pfsMount, int mode)
 }
 
 static pfs_aentry_t *getAentry(pfs_cache_t *clink, char *key, char *value, int mode)
-{	// mode 0=lookup, 1=add, 2=delete
+{
 	int kLen, fullsize;
 	pfs_aentry_t *aentry=clink->u.aentry;
 	pfs_aentry_t *aentryLast=NULL;
@@ -241,27 +247,27 @@ static pfs_aentry_t *getAentry(pfs_cache_t *clink, char *key, char *value, int m
 
 	kLen=strlen(key);
 	fullsize=(kLen+strlen(value)+7) & ~3;
-	for(end=(pfs_aentry_t *)((u8*)aentry+1024);end < aentry; aentry=(pfs_aentry_t *)((u8*)aentry+aentry->aLen))
-	{
+	for(end=(pfs_aentry_t *)((u8*)aentry+1024);aentry < end; aentry=(pfs_aentry_t *)((u8*)aentry+aentry->aLen))
+	{	//Other than critical errors, do nothing about the filesystem errors.
 		if(aentry->aLen & 3)
-			PFS_PRINTF(PFS_DRV_NAME" Error: attrib-entry allocated length/4 != 0\n");
+			PFS_PRINTF(PFS_DRV_NAME" Error: aentry allocated length/4 != 0\n");
 		if(aentry->aLen < ((aentry->kLen+aentry->vLen+7) & ~3))
 		{
-			PFS_PRINTF(PFS_DRV_NAME" Panic: attrib-entry is too small\n");
+			PFS_PRINTF(PFS_DRV_NAME" Panic: aentry is too small\n");
 			return NULL;
 		}
 		if(end < (pfs_aentry_t*)((u8*)aentry+aentry->aLen))
-			PFS_PRINTF(PFS_DRV_NAME" Error: attrib-entry too big\n");
+			PFS_PRINTF(PFS_DRV_NAME" Error: aentry too big\n");
 
 		switch(mode)
 		{
-		case 0:// lookup
+		case PFS_AENTRY_MODE_LOOKUP:
 			if(kLen==aentry->kLen)
 				if(memcmp(key, aentry->str, kLen)==0)
 					return aentry;
 			break;
 
-		case 1:// add
+		case PFS_AENTRY_MODE_ADD:
 			if(aentry->kLen==0)
 			{
 				if(aentry->aLen>=fullsize)
@@ -271,7 +277,8 @@ static pfs_aentry_t *getAentry(pfs_cache_t *clink, char *key, char *value, int m
 				continue;
 			return aentry;
 
-		default:// delete
+		case PFS_AENTRY_MODE_DELETE:
+		default:
 			if(kLen==aentry->kLen)
 			{
 				if(memcmp(key, aentry->str, kLen)==0)
@@ -304,21 +311,21 @@ static int ioctl2AttrAdd(pfs_cache_t *clink, pfs_ioctl2attr_t *attr)
 	// input check
 	kLen=strlen(attr->key);
 	vLen=strlen(attr->value);
-	if(kLen>=256 || vLen>=256)	// max size safe e check
+	if(kLen>=PFS_AENTRY_KEY_MAX || vLen>=PFS_AENTRY_VALUE_MAX)	// max size bounds check
 		return -EINVAL;
 
 	if(kLen==0 || vLen==0)		// no input check
 		return -EINVAL;
 
-	if(getAentry(clink, attr->key, NULL, 0))
+	if(getAentry(clink, attr->key, NULL, PFS_AENTRY_MODE_LOOKUP))
 		return -EEXIST;
-	if(!(aentry=getAentry(clink, attr->key, attr->value, 1)))
+	if((aentry=getAentry(clink, attr->key, attr->value, PFS_AENTRY_MODE_ADD)) == NULL)
 		return -ENOSPC;
 
 	if(aentry->kLen==0)
 		tmp=aentry->aLen;
 	else
-		tmp=aentry->aLen-((aentry->kLen+(aentry->vLen + 7)) & ~3);
+		tmp=aentry->aLen-((aentry->kLen+(aentry->vLen + 7)) & 0x3FC);	//The only case that uses 0x3FC within the whole PFS driver.
 
 	aentry->aLen-=tmp;
 	aentry = (pfs_aentry_t*)((u8 *)aentry + aentry->aLen);
@@ -336,17 +343,18 @@ static int ioctl2AttrDelete(pfs_cache_t *clink, void *arg)
 {
 	pfs_aentry_t *aentry;
 
-	if((aentry=getAentry(clink, arg, 0, 2))==NULL)
+	if((aentry=getAentry(clink, arg, NULL, PFS_AENTRY_MODE_DELETE)) == NULL)
 		return -ENOENT;
 	clink->flags|=PFS_CACHE_FLAG_DIRTY;
 	return 0;
 }
 
-static int ioctl2AttrLoopUp(pfs_cache_t *clink, char *key, char *value)
+static int ioctl2AttrLookUp(pfs_cache_t *clink, char *key, char *value)
 {
 	pfs_aentry_t *aentry;
 
-	if((aentry=getAentry(clink, key, 0, 0))){
+	if((aentry=getAentry(clink, key, NULL, PFS_AENTRY_MODE_LOOKUP)) != NULL)
+	{
 		memcpy(value, &aentry->str[aentry->kLen], aentry->vLen);
 		value[aentry->vLen]=0;
 		return aentry->vLen;


### PR DESCRIPTION
The logic behind the Bitmap-management functions was always slightly different in ours, compared to the original.
Recent logs from HDDChecker have shown that PFS may be unable to correctly update the volume bitmap. Perhaps it is due to the homebrew module dividing the index by 32 (instead of 8), before it is left-shifted by 2. As a result, 2 bits of the index will be lost.

Readlink had a faulty check around whether the inode is a symbolic link or not. However, this function still cannot be correctly used from the EE, since fileXio's RPC server does not correctly support readlink().

The IOCTL2 commands for attributes had faulty logic around the main loop corrected.