### PR TITLE
(USBHDFSD) Avoid corrupting adjacent clusters, due to a scache design issue.

### DIFF
--- a/iop/usb/usbhdfsd/src/fat_write.c
+++ b/iop/usb/usbhdfsd/src/fat_write.c
@@ -39,7 +39,7 @@
 #define DATE_MODIFY 2
 
 #define READ_SECTOR(d, a, b)	scache_readSector((d)->cache, (a), (void **)&b)
-#define ALLOC_SECTOR(d, a, b)	scache_allocSector((d)->cache, (a), (void **)&b)
+#define ALLOC_SECTOR(d, a, b)	scache_readSector((d)->cache, (a), (void **)&b)	//Cannot allocate a block as the cluster might not necessarily be aligned with the cache block; may result in corruption of the adjacent cluster.
 #define WRITE_SECTOR(d, a)		scache_writeSector((d)->cache, (a))
 #define WRITE_SECTORS_RAW(d, a, c, b)	mass_stor_writeSector((d), a, b, c);
 #define FLUSH_SECTORS(d)		scache_flushSectors((d)->cache)

--- a/iop/usb/usbhdfsd/src/include/scache.h
+++ b/iop/usb/usbhdfsd/src/include/scache.h
@@ -4,7 +4,7 @@
 cache_set* scache_init(mass_dev* dev, int sectorSize);
 void scache_close(cache_set* cache);
 void scache_kill(cache_set* cache); //dlanor: added for disconnection events (flush impossible)
-int  scache_allocSector(cache_set* cache, unsigned int sector, void** buf);
+//int  scache_allocSector(cache_set* cache, unsigned int sector, void** buf);
 int  scache_readSector(cache_set* cache, unsigned int sector, void** buf);
 int  scache_writeSector(cache_set* cache, unsigned int sector);
 int  scache_flushSectors(cache_set* cache);

--- a/iop/usb/usbhdfsd/src/scache.c
+++ b/iop/usb/usbhdfsd/src/scache.c
@@ -217,6 +217,12 @@ int scache_readSector(cache_set* cache, unsigned int sector, void** buf) {
 
 
 //---------------------------------------------------------------------------
+/* SP193: this function is dangerous if not used correctly.
+   As scache's blocks are aligned to the start of the disk, the clusters of the partition
+   must also be aligned to a multiple of the scache block size.
+   Otherwise, it is possible to cause the adjacent cluster to lose data, if the block spans across more than one cluster.
+*/
+#if 0
 int scache_allocSector(cache_set* cache, unsigned int sector, void** buf) {
 	int index; //index is given in single sectors not octal sectors
 	//int ret;
@@ -240,6 +246,7 @@ int scache_allocSector(cache_set* cache, unsigned int sector, void** buf) {
 	XPRINTF("cache: done allocating sector\n");
 	return cache->sectorSize;
 }
+#endif
 
 //---------------------------------------------------------------------------
 int scache_writeSector(cache_set* cache, unsigned int sector) {


### PR DESCRIPTION
Changed fat_write.c to use scache_readSector instead of scache_allocSector(), and disabled scache_allocSector. Avoid corrupting the adjacent cluster if:

* Directory entries are added (renaming will destroy and add a new entry).
* The cache block size does not match the cluster size.
* The cache blocks are not aligned to the start of the clusters.