### PR TITLE
Updated Multitap Page.

### DIFF
--- a/ee/rpc/multitap/README
+++ b/ee/rpc/multitap/README
@@ -75,7 +75,7 @@ Meaning that Mtap Port 2 is Still Memory Card Port 0 (Console Port 1)
 
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //MTAP Controller Ports
-mtapPortOpen(0); >> MTAP PORT0 = Memory Card Port 2 (Console Port 1)
+mtapPortOpen(0); >> MTAP PORT0 = Memory Card Port 0 (Console Port 1)
 mtapPortOpen(1); >> MTAP PORT1 = Memory Card Port 1 (Console Port 2)
 //MTAP Memory Card Ports
 mtapPortOpen(2); >> MTAP PORT2 = Memory Card Port 0 (Console Port 1)

--- a/ee/rpc/multitap/README
+++ b/ee/rpc/multitap/README
@@ -158,7 +158,7 @@ void mtapDetect()
     else
     {
         printf("Controller Port 0: Multi-tap is Not Connected. \n");
-        mtapPortClose(1); //Closes The Multitap Port if The Multitap Is Not Connected
+        mtapPortClose(0); //Closes The Multitap Port if The Multitap Is Not Connected
     }
     
     mtapPortOpen(1); // Checks MTAP port 1 (Controller Port 1) For MTAP Connection

--- a/ee/rpc/multitap/README
+++ b/ee/rpc/multitap/README
@@ -52,9 +52,9 @@ However You Will Need to Load The freesio2,MCMAN,MCSERV Modules in addition to t
   |            |          |        | A   B |
   |            |          |        |-------|
   |            |          |          |   \_____ [ Port 1, Slot 1 ]
-  |ConsolePort1|]---------|          \__________[ Port 1, Slot 0 ]
+  |ConsolePort2|]---------|          \__________[ Port 1, Slot 0 ]
   |            |
-  |ConsolePort2|]---[ Port 0, Slot 0 ]
+  |ConsolePort1|]---[ Port 0, Slot 0 ]
   |            |
   |------------|
 ==== Controller/Memcard Port & Slot Listing ====

--- a/ee/rpc/multitap/README
+++ b/ee/rpc/multitap/README
@@ -3,24 +3,32 @@ libmtap - Playstation 2 multi-tap access library
 
 Copyright (c) 2004 Nicholas Van Veen <nickvv@xtra.co.nz>
 
+Multitap Introduction Page Updated by Based_Skid on 1/17/2019
+
 Introduction
 ------------
 
-libmtap is a simple library which allows you to poll controllers connected
+libmtap is a simple library which allows you to poll controllers and memorycards connected
 through a PS2 multi-tap. libmtap works alongside the standard pad library,
-libpad. Steps for polling a controller connected to a multi-tap are as
+libpad. Steps for polling a controller or memorycard connected to a multi-tap are as
 follows:
 
- 1. Load required IRX files
+ 1. Load required IRX files 
  2. Init the multi-tap library
  3. Init the pad library
  4. Open the multi-tap port
  5. Check if a multi-tap is connected to the opened port - if not, you may
     close the port (note that a port must be opened in order to determine
     if a multi-tap is connected).
- 6. "Open" each controller with padPortOpen(port, slot);
+ 6. "Open" each controller with padPortOpen(port, slot); (if using multiple controllers)
  7. Use standard libpad functions such as padGetState, padRead to get the state
     of each controller connected to the multi-tap.
+
+--------
+If You Are Working With The Memory Cards Connected to a Multitap make sure you include libmc in your project.
+You Will also need to call mcInit(MC_TYPE_XMC);
+--------
+You can Optionally Include The iomanX/fileXio IRX Modules If you need them
 
 Ports & Slots
 -------------
@@ -30,8 +38,13 @@ Port relates to either of the two ports on the PS2. Slot relates to one of the
 4 slots present on a multi-tap. The diagram below should give you a better idea
 of this system.
 
-				      _________[ Port 1, Slot 3 ]
-                                     /    _____[ Port 1, Slot 2 ]
+This Diagram is Also The Same For Memorycards. 
+However You Will Need to Load The freesio2,MCMAN,MCSERV Modules in addition to the multitap module.
+
+
+
+				      _________[ Port 1, Slot 2 ]
+                                     /    _____[ Port 1, Slot 3 ]
   |------------|                     |   /
   |            |                   |-------|
   |            |                   | C   D |
@@ -39,53 +52,151 @@ of this system.
   |            |          |        | A   B |
   |            |          |        |-------|
   |            |          |          |   \_____ [ Port 1, Slot 1 ]
-  |     Port 1 |]---------|          \__________[ Port 1, Slot 0 ]
+  |ConsolePort1|]---------|          \__________[ Port 1, Slot 0 ]
   |            |
-  |     Port 0 |]---[ Port 0, Slot 0 ]
+  |ConsolePort2|]---[ Port 0, Slot 0 ]
   |            |
   |------------|
+==== Controller/Memcard Port & Slot Listing ====
+ 1A: PORT = 0,SLOT = 0
+ 1B: PORT = 0,SLOT = 1
+ 1C: PORT = 0,SLOT = 2
+ 1D: PORT = 0,SLOT = 3
+ 
+ 2A: PORT = 1,SLOT = 0
+ 2B: PORT = 1,SLOT = 1
+ 2C: PORT = 1,SLOT = 2
+ 2D: PORT = 1,SLOT = 3
+================================================== 
+
+****MTAP Port Info****
+MTAP Ports Shouldnt Be Confused With Controller & MC ports
+Meaning that Mtap Port 2 is Still Memory Card Port 0 (Console Port 1)
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+//MTAP Controller Ports
+mtapPortOpen(0); >> MTAP PORT0 = Memory Card Port 2 (Console Port 1)
+mtapPortOpen(1); >> MTAP PORT1 = Memory Card Port 1 (Console Port 2)
+//MTAP Memory Card Ports
+mtapPortOpen(2); >> MTAP PORT2 = Memory Card Port 0 (Console Port 1)
+mtapPortOpen(3); >> MTAP PORT3 = Memory Card Port 1 (Console Port 2)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
 
 Example code
 ------------
+Some More Info Before you Proceed.
+---
+ACCORING TO THE Original MULTITAP SAMPLE it Declares that YOU MUST USE XMODULES IN ORDER TO USE THE MULTITAP,
+Please Be Advised That You Can Use The Software IRX modules with the Multitap and the Board Secific Xmodules are not Required.
+The Software Modules Are Meant to Be Drop in Replacments for The XModules!
+See The LoadModule Function in This File and Check the Makefile to See How Software Modules Can be Used in Your Project.
+---
+===
+A Quick Note about XMODULES: You Should NEVER Use XMODULES in your Applications
+X Modules are Board Specific and Compatibility Across all PS2 Models is Not Guarenteed. 
+This Application uses the Software module (freemtap.irx) for the mutltitap module.
+All of The Modules Loaded in this Application Are The Software Replacement Modules provided by the ps2sdk
+===
 
  1. Loading the required IRX files
 
-    // NOTE: X** modules must be used!
-    SifLoadModule("rom0:XSIO2MAN", 0, NULL);
-    SifLoadModule("rom0:XMTAPMAN", 0, NULL);
-    SifLoadModule("rom0:XPADMAN", 0, NULL);
+	SifExecModuleBuffer(&iomanX, size_iomanX, 0, NULL, NULL); // Optional iomanX
+	
+	SifExecModuleBuffer(&fileXio, size_fileXio, 0, NULL, NULL); // Optional fileXio
+	// Init fileXio After Loading it
+	fileXioInit();
 
+	SifExecModuleBuffer(&freesio2, size_freesio2, 0, NULL, NULL); //XSIO2MAN Software Module Replacement 
+	SifExecModuleBuffer(&mtapman, size_mtapman, 0, NULL, &ret); //XMTAPMAN Software Module Replacement
+	SifExecModuleBuffer(&freepad, size_freepad, 0, NULL, NULL); //FreePad Software Module
+	SifExecModuleBuffer(&mcman, size_mcman, 0, NULL, NULL); //XMCMAN Software Module Replacement
+	SifExecModuleBuffer(&mcserv, size_mcserv, 0, NULL, NULL); //XMCSERV Software Module Replacement.
+
+
+========================================================================================================
+    //This Xmodule Code Below is Shown For Historical Reference of this Page. 
+    //SifLoadModule("rom0:XSIO2MAN", 0, NULL);
+    //SifLoadModule("rom0:XMTAPMAN", 0, NULL);
+    //SifLoadModule("rom0:XPADMAN", 0, NULL);
+    //SifLoadModule("rom0:XMCMAN", 0, NULL);
+    //SifLoadModule("rom0:XMCSERV", 0, NULL);
+========================================================================================================
  2. Init, opening ports
-
+    
+   //Init LibMC
+    mcInit(MC_TYPE_XMC);
+    
     // Init libmtap
     mtapInit();
 
-    // Init libpad
+    // Init libpad (or FreePad)
     padInit(0);
 
     // Open ports
-    mtapPortOpen(0);
-    mtapPortOpen(1);
+    //MTAP Controller Ports
+    mtapPortOpen(0); // >> MTAP PORT0 = Controller Port 0 (Console Port 1)
+    mtapPortOpen(1); // >> MTAP PORT1 = Controller Port 1 (Console Port 2)
+    //MTAP Memory Card Ports
+    mtapPortOpen(2); // >> MTAP PORT2 = Memory Card Port 0 (Console Port 1)
+    mtapPortOpen(3); // >> MTAP PORT3 = Memory Card Port 1 (Console Port 2)
 
  3. Check connections
 
-    rv = mtapGetConnection(0);
-    if(rv == 1)
-        printf("- Multitap exists on slot 0\n");
+void mtapDetect()
+// Detects If Multi-tap is Connected. Closes Multi-tap Port(s) if Multi-tap(s) are not Connected
+{
+    int mt;
+    printf("Multi-tap Status:\n");
+    
+    mtapPortOpen(0); // Checks MTAP port 0 (Controller Port 0) For MTAP Connection
+    mt = mtapGetConnection(0);
+    if(mt == 1)
+    {
+        printf("Controller Port 0: Multi-tap Detected! \n");
+    }
     else
     {
-        printf("- No multitap exists on slot 0\n");
-        mtapPortClose(0);
+        printf("Controller Port 0: Multi-tap is Not Connected. \n");
+        mtapPortClose(1); //Closes The Multitap Port if The Multitap Is Not Connected
     }
-
-    rv = mtapGetConnection(1);
-    if(rv == 1)
-        printf("- Multitap exists on slot 1\n");
+    
+    mtapPortOpen(1); // Checks MTAP port 1 (Controller Port 1) For MTAP Connection
+    mt = mtapGetConnection(1);
+    if(mt == 1)
+    {
+        printf("Controller Port 1: Multi-tap Detected! \n");
+    }
     else
     {
-        printf("- No multitap exists on slot 1\n");
-        mtapPortClose(1);
+        printf("Controller Port 1: Multi-tap is Not Connected. \n");
+        mtapPortClose(1); //Closes The Multitap Port if The Multitap Is Not Connected
     }
+    
+    mtapPortOpen(2); // Checks MTAP port 2 (Memory Card Port 1) For MTAP Connection
+    mt = mtapGetConnection(2);
+    if(mt == 1)
+    {
+        printf("Memory Card Port 0: Multi-tap Detected! \n");
+    }
+    else
+    {
+        printf("Memory Card Port 0: Multi-tap is Not Connected. \n");
+        mtapPortClose(2); //Closes The Multitap Port if The Multitap Is Not Connected
+    }
+    
+    mtapPortOpen(3);
+    mt = mtapGetConnection(3); // Checks MTAP port 3 (Memory Card Port 2) For MTAP Connection
+    if(mt == 1)
+    {
+        printf("Memory Card Port 1: Multi-tap Detected! \n");
+    }
+    else
+    {
+        printf("Memory Card Port 1: Multi-tap is Not Connected. \n");
+        mtapPortClose(3); //Closes The Multitap Port if The Multitap Is Not Connected
+    }
+}
 
  4. Open the controllers
 
@@ -93,4 +204,28 @@ Example code
     padPortOpen(0, 1, padBuf1B);
     padPortOpen(0, 2, padBuf1C);
     padPortOpen(0, 3, padBuf1D);
+
+Some More Information
+----------------------
+
+You DONT have to Open Mulitap Ports 1 & 2 if you are just looking to access the Memory Cards. 
+--
+Libmc Works with Cards that are connected to the multitap!
+ 
+There are Examples Below to Demonstrate "Port,Slot" Use
+See The MC sample for more information about working with memory cards: 
+https://github.com/ps2dev/ps2sdk/blob/master/ee/rpc/memorycard/samples/mc_example.c#L78 
+
+The Calls Below are modified slightly from the example and are to show how the port and slot are passed to calls that expect them.
+--
+==
+mcGetInfo(0, 0, &mc_Type, &mc_Free, &mc_Format); << This would Target the 1A Port on the Multitap (port 0, slot 0)
+mcGetInfo(0, 1, &mc_Type, &mc_Free, &mc_Format); << 1B Port
+mcGetInfo(0, 2, &mc_Type, &mc_Free, &mc_Format); << 1B Port
+mcGetInfo(0, 3, &mc_Type, &mc_Free, &mc_Format); << 1B Port
+mcGetInfo(1, 0, &mc_Type, &mc_Free, &mc_Format); << 2A Port
+mcGetInfo(1, 1, &mc_Type, &mc_Free, &mc_Format); << 2B Port
+mcGetInfo(1, 2, &mc_Type, &mc_Free, &mc_Format); << 2C Port
+mcGetInfo(1, 3, &mc_Type, &mc_Free, &mc_Format); << 2D Port
+==
 

--- a/ee/rpc/multitap/README
+++ b/ee/rpc/multitap/README
@@ -221,8 +221,8 @@ The Calls Below are modified slightly from the example and are to show how the p
 ==
 mcGetInfo(0, 0, &mc_Type, &mc_Free, &mc_Format); << This would Target the 1A Port on the Multitap (port 0, slot 0)
 mcGetInfo(0, 1, &mc_Type, &mc_Free, &mc_Format); << 1B Port
-mcGetInfo(0, 2, &mc_Type, &mc_Free, &mc_Format); << 1B Port
-mcGetInfo(0, 3, &mc_Type, &mc_Free, &mc_Format); << 1B Port
+mcGetInfo(0, 2, &mc_Type, &mc_Free, &mc_Format); << 1C Port
+mcGetInfo(0, 3, &mc_Type, &mc_Free, &mc_Format); << 1D Port
 mcGetInfo(1, 0, &mc_Type, &mc_Free, &mc_Format); << 2A Port
 mcGetInfo(1, 1, &mc_Type, &mc_Free, &mc_Format); << 2B Port
 mcGetInfo(1, 2, &mc_Type, &mc_Free, &mc_Format); << 2C Port


### PR DESCRIPTION
This Page Did Not Have Any Mention about The use of Memory Cards With The MultiTap.

Updated The information Regarding the XModule Requirement and Provided Some information on Software Replacement Modules.

Fixed the Incorrect Slot Number Listing For The D Port in the Diagram of the console ports.
Supplemented This Information With The Full Listing of MultiTap Ports, 
Provided the Full port and slot listing By its Letter

Replaced The Multitap detection Example Code With Code From The Mass Format Utility Project
https://github.com/Based-Skid/PS2-Memory-Card-Formatter/blob/master/main.c#L743