### PR TITLE
Patch 4

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-EE_CC_VERSION := $(shell $(EE_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+EE_CC_VERSION := $(shell $(EE_CC) -dumpversion)
 
 EE_OBJS_DIR ?= obj/
 EE_SRC_DIR ?= src/

--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-IOP_CC_VERSION := $(shell $(IOP_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+IOP_CC_VERSION := $(shell $(IOP_CC) -dumpversion)
 
 IOP_OBJS_DIR ?= obj/
 IOP_SRC_DIR ?= src/

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-EE_CC_VERSION := $(shell $(EE_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+EE_CC_VERSION := $(shell $(EE_CC) -dumpversion)
 
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-EE_CC_VERSION := $(shell $(EE_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+EE_CC_VERSION := $(shell $(EE_CC) -dumpversion)
 
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-IOP_CC_VERSION := $(shell $(IOP_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
+IOP_CC_VERSION := $(shell $(IOP_CC) -dumpversion)
 
 ifeq ($(IOP_CC_VERSION),3.2.2)
 ASFLAGS_TARGET = -march=r3000

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -8,8 +8,6 @@
 
 IOP_CC_VERSION := $(shell $(IOP_CC) --version 2>&1 | sed -n 's/^.*(GCC) //p')
 
-ASFLAGS_TARGET = -mcpu=r3000
-
 ifeq ($(IOP_CC_VERSION),3.2.2)
 ASFLAGS_TARGET = -march=r3000
 endif
@@ -25,9 +23,9 @@ IOP_INCS := -I$(PS2SDK)/iop/include -I$(PS2SDK)/common/include \
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,
 #   for finer-grained control over what goes into each IRX.
-IOP_CFLAGS := $(CFLAGS_TARGET) -D_IOP -fno-builtin -Os -G0 $(IOP_INCS) $(IOP_CFLAGS)
+IOP_CFLAGS := -D_IOP -fno-builtin -Os -G0 -Wall $(IOP_INCS) $(IOP_CFLAGS)
 # linker flags
-IOP_LDFLAGS := $(LDFLAGS_TARGET) -nostdlib -L$(PS2SDK)/iop/lib $(IOP_LDFLAGS)
+IOP_LDFLAGS := -nostdlib -s $(IOP_LDFLAGS)
 
 # Additional C compiler flags for GCC >=v5.3.0
 # -msoft-float is to "remind" GCC/Binutils that the soft-float ABI is to be used. This is due to a bug, which
@@ -48,11 +46,14 @@ IOP_ASFLAGS := $(ASFLAGS_TARGET) -EL -G0 $(IOP_ASFLAGS)
 
 # Externally defined variables: IOP_BIN, IOP_OBJS, IOP_LIB
 
+# These macros can be used to simplify certain build rules.
+IOP_C_COMPILE = $(IOP_CC) $(IOP_CFLAGS)
+
 %.o: %.c
-	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
+	$(IOP_C_COMPILE) -c $< -o $@
 
 %.o: %.S
-	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@
+	$(IOP_C_COMPILE) -c $< -o $@
 
 %.o: %.s
 	$(IOP_AS) $(IOP_ASFLAGS) $< -o $@
@@ -65,7 +66,7 @@ build-imports.c: imports.lst
 	cat $< >> $@
 
 imports.o: build-imports.c
-	$(IOP_CC) $(IOP_CFLAGS) $(IOP_IETABLE_CFLAGS) -I. -c $< -o $@
+	$(IOP_C_COMPILE) $(IOP_IETABLE_CFLAGS) -I. -c $< -o $@
 
 # Rules to build exports.tab.
 build-exports.c: exports.tab
@@ -73,13 +74,13 @@ build-exports.c: exports.tab
 	cat $< >> $@
 
 exports.o: build-exports.c
-	$(IOP_CC) $(IOP_CFLAGS) $(IOP_IETABLE_CFLAGS) -I. -c $< -o $@
+	$(IOP_C_COMPILE) $(IOP_IETABLE_CFLAGS) -I. -c $< -o $@
 
 # link with following libraries (libs need to be defined multiple times in order for linking to work!!)
 IOP_LIBS += -lkernel -lgcc
 
 $(IOP_BIN): $(IOP_OBJS)
-	$(IOP_CC) $(IOP_CFLAGS) -o $(IOP_BIN) $(IOP_OBJS) $(IOP_LDFLAGS) $(IOP_LIBS)
+	$(IOP_C_COMPILE) -o $(IOP_BIN) $(IOP_OBJS) $(IOP_LDFLAGS) $(IOP_LIBS)
 
 $(IOP_LIB): $(IOP_OBJS)
 	$(IOP_AR) cru $(IOP_LIB) $(IOP_OBJS)


### PR DESCRIPTION
Update Makefile.iopglobal_sample

Simplified gcc version detection  …
GCC can be detected in much easier way without sed using
-dumpversion can be used with all gcc to just print compiler version
More info here https://gcc.gnu.org/onlinedocs/gcc/Developer-Options.html
