### PR TITLE
iomanX: Added support for PSX's io_stat_t.

### DIFF
--- a/iop/kernel/include/iomanX.h
+++ b/iop/kernel/include/iomanX.h
@@ -31,7 +31,8 @@
 #define IOP_DT_FS	0x10
 #ifndef IOMAN_NO_EXTENDED
 /** Supports calls after chstat().  */
-#define IOP_DT_FSEXT	0x10000000	
+#define IOP_DT_FSEXT	0x10000000
+#define IOP_DT_PSX		0x20000000
 #endif
 
 /** File objects passed to driver operations.  */

--- a/iop/system/iomanx/src/iomanX.c
+++ b/iop/system/iomanx/src/iomanX.c
@@ -74,6 +74,9 @@ int AddDrv(iop_device_t *device)
 {
 	int i, res = -1;
     int oldIntr;
+	
+	if (!strcmp(device->name, "xfrom"))
+		device->type |= IOP_DT_PSX;
 
     CpuSuspendIntr(&oldIntr);
 
@@ -387,11 +390,11 @@ int mode2modex(int mode)
 {
 	int modex = 0;
 
-	if (FIO_SO_ISLNK(mode))
+	if (mode & FIO_SO_IFLNK)
 		modex |= FIO_S_IFLNK;
-	if (FIO_SO_ISREG(mode))
+	if (mode & FIO_SO_IFREG)
 		modex |= FIO_S_IFREG;
-	if (FIO_SO_ISDIR(mode))
+	if (mode & FIO_SO_IFDIR)
 		modex |= FIO_S_IFDIR;
 
 	/* Convert the file access modes.  */
@@ -409,11 +412,11 @@ int modex2mode(int modex)
 {
 	int mode = 0;
 
-	if (FIO_S_ISLNK(modex))
+	if (modex & FIO_S_IFLNK)
 		mode |= FIO_SO_IFLNK;
-	if (FIO_S_ISREG(modex))
+	if (modex & FIO_S_IFREG)
 		mode |= FIO_SO_IFREG;
-	if (FIO_S_ISDIR(modex))
+	if (modex & FIO_S_IFDIR)
 		mode |= FIO_SO_IFDIR;
 
 	/* Convert the file access modes.  */
@@ -434,11 +437,19 @@ int dread(int fd, iox_dirent_t *iox_dirent)
 
     if (f == NULL ||  !(f->mode & 8))
             return -EBADF;
-
-    /* If this is a legacy device (such as mc:) then we need to convert the mode
-       variable of the stat structure to iomanX's extended format.  */
-    if ((f->device->type & 0xf0000000) != IOP_DT_FSEXT)
+    if ((f->device->type & 0xf0000000) == IOP_DT_PSX)
+	{
+		res = f->device->ops->dread(f, iox_dirent);
+		iox_dirent->stat.mode = mode2modex(iox_dirent->stat.mode);
+	}
+    else if ((f->device->type & 0xf0000000) == IOP_DT_FSEXT)
+	{
+        res = f->device->ops->dread(f, iox_dirent);	
+	}
+	else
     {
+	    /* If this is a legacy device (such as mc:) then we need to convert the mode
+	       variable of the stat structure to iomanX's extended format.  */
         typedef int	io_dread_t(iop_file_t *, io_dirent_t *);
         io_dirent_t io_dirent;
         io_dread_t *io_dread = (io_dread_t*) f->device->ops->dread;
@@ -455,8 +466,6 @@ int dread(int fd, iox_dirent_t *iox_dirent)
 
         strncpy(iox_dirent->name, io_dirent.name, sizeof(iox_dirent->name));
     }
-    else
-        res = f->device->ops->dread(f, iox_dirent);
 
     return res;
 }


### PR DESCRIPTION
I just didn't see any possible side effects inside these changes. It seems that this modification only adds support for xfrom device from PSX DVR, so as for me this can be safely merged with the mainstream.