### PR TITLE
Include the access function in the ps2sdkapi

### DIFF
--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -285,6 +285,20 @@ int _stat(const char *path, struct stat *buf) {
         return _ps2sdk_stat(path, buf);
 }
 
+int access(const char *fn, int flags) {
+	struct stat s;
+	if (stat(fn, &s))
+		return -1;
+	if (s.st_mode & S_IFDIR)
+		return 0;
+	if (flags & W_OK) {
+		if (s.st_mode & S_IWRITE)
+			return 0;
+		return -1;
+	}
+	return 0;
+}
+
 DIR *opendir(const char *path)
 {
     return _ps2sdk_opendir(path);


### PR DESCRIPTION
## Description

This PR is just for including the missing `access` function in the `ps2sdkapi.c`

Additional info:
https://linux.die.net/man/2/access

Thanks