### PR TITLE
Update for BDM drivers

### DIFF
--- a/iop/iLink/IEEE1394_bd/src/imports.lst
+++ b/iop/iLink/IEEE1394_bd/src/imports.lst
@@ -27,9 +27,11 @@ I_CpuSuspendIntr
 I_CpuResumeIntr
 intrman_IMPORTS_end
 
+#ifndef MINI_DRIVER
 stdio_IMPORTS_start
 I_printf
 stdio_IMPORTS_end
+#endif
 
 sysclib_IMPORTS_start
 I_memset

--- a/iop/iLink/IEEE1394_bd/src/include/module_debug.h
+++ b/iop/iLink/IEEE1394_bd/src/include/module_debug.h
@@ -2,7 +2,7 @@
 #define _MODULE_DEBUG_H
 
 #ifndef MINI_DRIVER
-#define M_PRINTF(format, args...) printf("IEEE: " format, ##args)
+#define M_PRINTF(format, args...) printf("SBP2: " format, ##args)
 #else
 #define M_PRINTF(format, args...)
 #endif

--- a/iop/iLink/IEEE1394_bd/src/include/module_debug.h
+++ b/iop/iLink/IEEE1394_bd/src/include/module_debug.h
@@ -1,8 +1,6 @@
 #ifndef _MODULE_DEBUG_H
 #define _MODULE_DEBUG_H
 
-//#define MINI_DRIVER
-
 #ifndef MINI_DRIVER
 #define M_PRINTF(format, args...) printf("IEEE: " format, ##args)
 #else

--- a/iop/iLink/IEEE1394_bd/src/sbp2_driver.c
+++ b/iop/iLink/IEEE1394_bd/src/sbp2_driver.c
@@ -146,41 +146,6 @@ static int initConfigureSBP2Device(struct SBP2Device* dev)
 
     M_DEBUG("Completed device initialization.\n");
 
-    /****** !!!FOR TESTING ONLY!!! ******/
-#if 0
-	iop_sys_clock_t lTime;
-	u32 lSecStart, lUSecStart;
-	u32 lSecEnd,   lUSecEnd, nbytes, i, rounds;
-	void *buffer;
-	int result;
-
-	nbytes=1048576;
-	rounds=64;
-	if((buffer=malloc(nbytes))==NULL) M_PRINTF("Unable to allocate memory. :(\n");
-	M_PRINTF("Read test: %p.\n", buffer);
-	M_PRINTF("Start reading data...\n" );
-
-	GetSystemTime ( &lTime );
-	SysClock2USec ( &lTime, &lSecStart, &lUSecStart );
-
-	for(i=0; i<rounds; i++){
-		if((result=scsiReadSector(dev, 16, buffer, nbytes/512))!=0){
-		    M_PRINTF("Sector read error %d.\n", result);
-		    break;
-		}
-	}
-	free(buffer);
-
-	GetSystemTime ( &lTime );
-	SysClock2USec ( &lTime, &lSecEnd, &lUSecEnd );
-
-	M_PRINTF("Completed.\n");
-
-	M_PRINTF( "Done: %lu %lu/%lu %lu\n", lSecStart, lUSecStart, lSecEnd, lUSecEnd );
-	M_PRINTF("KB: %lu, time: %lu, Approximate KB/s: %lu", (nbytes*rounds/1024), (lSecEnd -lSecStart), (nbytes*rounds/1024)/(lSecEnd -lSecStart));
-	/****** !!!FOR TESTING ONLY!!! ******/
-#endif
-
     return 0;
 }
 

--- a/iop/iLink/IEEE1394_bd_mini/Makefile
+++ b/iop/iLink/IEEE1394_bd_mini/Makefile
@@ -6,7 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = usbd keyboard camera mouse usbhdfsd usbmass_bd usbmass_bd_mini
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/iLink/IEEE1394_bd/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_CFLAGS += -DMINI_DRIVER
+
+include $(PS2SDKSRC)/iop/iLink/IEEE1394_bd/Makefile

--- a/iop/iLink/Makefile
+++ b/iop/iLink/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = iLinkman IEEE1394_disk IEEE1394_bd
+SUBDIRS = iLinkman IEEE1394_disk IEEE1394_bd IEEE1394_bd_mini
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/Rules.make

--- a/iop/usb/usbmass_bd/src/imports.lst
+++ b/iop/usb/usbmass_bd/src/imports.lst
@@ -3,9 +3,11 @@ I_bdm_connect_bd
 I_bdm_disconnect_bd
 bdm_IMPORTS_end
 
+#ifndef MINI_DRIVER
 stdio_IMPORTS_start
 I_printf
 stdio_IMPORTS_end
+#endif
 
 sysclib_IMPORTS_start
 I_memset

--- a/iop/usb/usbmass_bd/src/include/module_debug.h
+++ b/iop/usb/usbmass_bd/src/include/module_debug.h
@@ -1,8 +1,6 @@
 #ifndef _MODULE_DEBUG_H
 #define _MODULE_DEBUG_H
 
-//#define MINI_DRIVER
-
 #ifndef MINI_DRIVER
 #define M_PRINTF(format, args...) printf("USBMASS: " format, ##args)
 #else

--- a/iop/usb/usbmass_bd_mini/Makefile
+++ b/iop/usb/usbmass_bd_mini/Makefile
@@ -6,7 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = usbd keyboard camera mouse usbhdfsd usbmass_bd usbmass_bd_mini
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/usb/usbmass_bd/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_CFLAGS += -DMINI_DRIVER
+
+include $(PS2SDKSRC)/iop/usb/usbmass_bd/Makefile


### PR DESCRIPTION
I've had these improvements laying around for some time now:
- Add MINI_DRIVER: add's a 2nd build option for the block devices. This removes all debugging and makes them small enough to be used as OPL in-game drivers.
- IEEE1394: small improvements to compatibility, but compatibility is still poor.