### PR TITLE
Artifacts and fixes to action

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,13 +26,12 @@ jobs:
     - name: Compile samples
       if: ${{ success() }}
       run: |
-        cd $PS2SDK/samples
-        make
-        tar -zcvf samples.tar.gz ./
+        cp -rv $PS2SDK/samples ~/
+        make -C ~/samples
 
     - name: Upload artifacts
       if: ${{ success() }}
       uses: actions/upload-artifact@v2
       with:
-        name: ps2sdk-samples-${{github.sha}}.zip
-        path: samples.tar.gz
+        name: ps2sdk-samples-${{ github.sha }}
+        path: ~/samples

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -34,5 +34,5 @@ jobs:
       if: ${{ success() }}
       uses: actions/upload-artifact@v2
       with:
-        name: gsKit-samples-${{github.sha}}.tar.gz
-        path: examples.tar.gz
+        name: ps2sdk-samples-${{github.sha}}.zip
+        path: samples.tar.gz

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ${{ github.repository_owner }}/ps2toolchain:latest
+    container: ps2dev/ps2toolchain:latest
     steps:
     - uses: actions/checkout@v2
 
@@ -22,3 +22,17 @@ jobs:
         make clean all install
         ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/ee/lib/libps2sdkc.a"
         ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/ee/lib/libkernel.a"
+        
+    - name: Compile samples
+      if: ${{ success() }}
+      run: |
+        cd $PS2SDK/samples
+        make
+        tar -zcvf samples.tar.gz ./
+
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: gsKit-samples-${{github.sha}}.tar.gz
+        path: examples.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PS2SDK - PS2DEV Open Source Project.
 
-![CI](https://github.com/ps2dev/ps2sdk/workflows/CI/badge.svg)
-![CI-Docker](https://github.com/ps2dev/ps2sdk/workflows/CI-Docker/badge.svg)
+[![CI](https://github.com/ps2dev/ps2sdk/workflows/CI/badge.svg)](https://github.com/ps2dev/ps2sdk/actions?query=workflow%3ACI)
+[![CI-Docker](https://github.com/ps2dev/ps2sdk/workflows/CI-Docker/badge.svg)](https://github.com/ps2dev/ps2sdk/actions?query=workflow%3ACI-Docker)
 
 [PS2SDK Documentation](https://ps2dev.github.io/ps2sdk/)
 

--- a/ee/draw/samples/cube/Makefile.sample
+++ b/ee/draw/samples/cube/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = cube.elf
 EE_OBJS = cube.o
-EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
+EE_LIBS = -ldraw -lgraph -lmath3d -lpacket -ldma
 
 all: $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)

--- a/ee/draw/samples/teapot/Makefile.sample
+++ b/ee/draw/samples/teapot/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = teapot.elf
 EE_OBJS = teapot.o
-EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
+EE_LIBS = -ldraw -lgraph -lmath3d -lpacket -ldma
 
 all: $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)

--- a/ee/draw/samples/texture/Makefile.sample
+++ b/ee/draw/samples/texture/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = texture.elf
 EE_OBJS = texture.o
-EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
+EE_LIBS = -ldraw -lgraph -lmath3d -lpacket -ldma
 
 all: flower.c $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)

--- a/ee/font/samples/Makefile.sample
+++ b/ee/font/samples/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = font.elf
 EE_OBJS = font.o impress.o
-EE_LIBS = -lfont -lpacket -ldma -lgraph -ldraw -lc -lmf
+EE_LIBS = -lfont -lpacket -ldma -lgraph -ldraw -lc
 
 all: $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)

--- a/ee/graph/samples/Makefile.sample
+++ b/ee/graph/samples/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = graph.elf
 EE_OBJS = graph.o
-EE_LIBS = -lpacket -ldma -lgraph -ldraw -lc -lmf
+EE_LIBS = -lpacket -ldma -lgraph -ldraw -lc
 
 all: $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)

--- a/ee/mpeg/samples/Makefile.sample
+++ b/ee/mpeg/samples/Makefile.sample
@@ -8,7 +8,7 @@
 
 EE_BIN = mpeg.elf
 EE_OBJS = mpeg.o
-EE_LIBS = -ldraw -lgraph -ldma -lmpeg -lmf -lc -lpacket
+EE_LIBS = -ldraw -lgraph -ldma -lmpeg -lc -lpacket
 
 all: $(EE_BIN)
 	$(EE_STRIP) --strip-all $(EE_BIN)


### PR DESCRIPTION
Removed -lmf
Added ps2sdk sample compilation stage
ps2sdk samples now available as artifacts

`github.repository_owner` replaced to `ps2dev` cause this environment doesn't work in forked projects, but this Testing Workflow can be useful for forks as well