### PR TITLE
Fixed job server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ subdir_release = $(patsubst %,release-%,$(SUBDIRS))
 subdirs: dummy $(subdir_list)
 
 $(subdir_list): dummy
-	$(MAKEREC) $(patsubst all-%,%,$@)
+	+$(MAKEREC) $(patsubst all-%,%,$@)
 $(subdir_clean): dummy
-	$(MAKEREC) $(patsubst clean-%,%,$@) clean
+	+$(MAKEREC) $(patsubst clean-%,%,$@) clean
 $(subdir_release): dummy
 	$(MAKEREC) $(patsubst release-%,%,$@) release
 
@@ -40,12 +40,12 @@ build: env_build_check $(subdir_list)
 clean: env_build_check $(subdir_clean)
 
 release-clean:
-	$(MAKE) -C common release-clean
-	$(MAKE) -C iop release-iop-clean
-	$(MAKE) -C ee release-ee-clean
-	$(MAKE) -C samples release-clean
-	$(MAKE) -C tools release-clean
-	
+	+$(MAKE) -C common release-clean
+	+$(MAKE) -C iop release-iop-clean
+	+$(MAKE) -C ee release-ee-clean
+	+$(MAKE) -C samples release-clean
+	+$(MAKE) -C tools release-clean
+
 rebuild: env_build_check $(subdir_clean) $(subdir_list)
 
 $(PS2SDK)/common/include:
@@ -58,7 +58,12 @@ $(PS2SDK)/ports:
 
 install: release
 
-release: build release_base release-clean $(PS2SDK)/common/include $(PS2SDK)/ports $(subdir_release)
+release: | build
+	$(MAKE) release_base
+	$(MAKE) release-clean
+	$(MAKE) $(PS2SDK)/common/include
+	$(MAKE) $(PS2SDK)/ports
+	$(MAKE) $(subdir_release)
 
 release_base: env_release_check
 	@if test ! -d $(PS2SDK) ; then \

--- a/ee/Makefile
+++ b/ee/Makefile
@@ -6,9 +6,9 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = kernel kernel-nopatch libc rpc debug \
+SUBDIRS = erl kernel kernel-nopatch libc rpc debug \
 	eedebug sbv dma graph math3d \
-	packet draw erl erl-loader mpeg libgs \
+	packet draw erl-loader mpeg libgs \
 	libvux font input inputx network iopreboot
 
 include $(PS2SDKSRC)/Defs.make

--- a/samples/Makefile_sample
+++ b/samples/Makefile_sample
@@ -20,7 +20,7 @@ SUBDIRS += graph
 SUBDIRS += libgs/doublebuffer
 SUBDIRS += libgs/draw
 #SUBDIRS += mpeg                #TODO: not modified for updated newlib
-SUBDIRS += network/tcpip-basic 
+SUBDIRS += network/tcpip-basic
 SUBDIRS += network/tcpip-dhcp
 SUBDIRS += remote
 SUBDIRS += rpc/audsrv/playadpcm
@@ -41,9 +41,9 @@ endif
 all: $(patsubst %, _dir_%, $(SUBDIRS))
 
 $(patsubst %, _dir_%, $(SUBDIRS)):
-	@$(MAKE) -r -C $(patsubst _dir_%, %, $@)
+	@+$(MAKE) -r -C $(patsubst _dir_%, %, $@)
 
 clean: $(patsubst %, _cleandir_%, $(SUBDIRS))
 
 $(patsubst %, _cleandir_%, $(SUBDIRS)):
-	$(MAKE) -C $(patsubst _cleandir_%, %, $@) clean
+	+$(MAKE) -C $(patsubst _cleandir_%, %, $@) clean


### PR DESCRIPTION
I also had to run dos2unix on build-exports.sh but no matter what I did git always ignored the line endings.

Note that `make install` must still be run without jobs. Some of the prerequisite rules clean up without running `make clean` and I couldn't figure out the correct order to run them to make it work with a job server.