### PR TITLE
Create a library to make easier the Loading of ELF files

### DIFF
--- a/ee/Makefile
+++ b/ee/Makefile
@@ -9,7 +9,8 @@
 SUBDIRS = erl kernel kernel-nopatch libc rpc debug \
 	eedebug sbv dma graph math3d \
 	packet draw erl-loader mpeg libgs \
-	libvux font input inputx network iopreboot
+	libvux font input inputx network iopreboot \
+	elf-loader
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/Rules.make

--- a/ee/elf-loader/Makefile
+++ b/ee/elf-loader/Makefile
@@ -1,0 +1,23 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2005, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+# EE_INCS += -I$(PS2SDKSRC)/ee/math/include -I$(PS2SDKSRC)/ee/graph/include
+EE_BIN2C = bin2c
+
+EE_OBJS = elf.o loader.o
+
+# all:: prepareLoader
+
+prepareLoader:
+	$(MAKE) -C src/loader
+	$(EE_BIN2C) src/loader/loader.elf src/loader.c loader_elf
+
+include $(PS2SDKSRC)/Defs.make
+include $(PS2SDKSRC)/ee/Rules.lib.make
+include $(PS2SDKSRC)/ee/Rules.make
+include $(PS2SDKSRC)/ee/Rules.release

--- a/ee/elf-loader/Makefile
+++ b/ee/elf-loader/Makefile
@@ -2,7 +2,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# Copyright 2001-2005, ps2dev - http://www.ps2dev.org
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 

--- a/ee/elf-loader/Makefile
+++ b/ee/elf-loader/Makefile
@@ -6,16 +6,13 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-# EE_INCS += -I$(PS2SDKSRC)/ee/math/include -I$(PS2SDKSRC)/ee/graph/include
-EE_BIN2C = bin2c
-
 EE_OBJS = elf.o loader.o
 
-# all:: prepareLoader
+all:: prepareLoader $(EE_LIB)
 
 prepareLoader:
 	$(MAKE) -C src/loader
-	$(EE_BIN2C) src/loader/loader.elf src/loader.c loader_elf
+	$(PS2SDKSRC)/tools/bin2c/bin/bin2c src/loader/loader.elf src/loader.c loader_elf
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make

--- a/ee/elf-loader/Makefile
+++ b/ee/elf-loader/Makefile
@@ -10,9 +10,14 @@ EE_OBJS = elf.o loader.o
 
 all:: prepareLoader $(EE_LIB)
 
+clean:: cleanLoader
+
 prepareLoader:
 	$(MAKE) -C src/loader
 	$(PS2SDKSRC)/tools/bin2c/bin/bin2c src/loader/loader.elf src/loader.c loader_elf
+
+cleanLoader:
+	$(MAKE) -C src/loader clean
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make

--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-int LoadELFFromFile(const char *filename);
+int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 
 #ifdef __cplusplus
 }

--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -22,6 +22,7 @@
 extern "C" {
 #endif
 
+// Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 
 #ifdef __cplusplus

--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -1,0 +1,31 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * ELF Loader functions.
+ */
+
+#ifndef __ELFLOADER_H__
+#define __ELFLOADER_H__
+
+#include <tamtypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int LoadELFFromFile(const char *filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ELFLOADER_H__ */

--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -3,7 +3,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 */
@@ -15,8 +15,6 @@
 
 #ifndef __ELFLOADER_H__
 #define __ELFLOADER_H__
-
-#include <tamtypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/ee/elf-loader/src/.gitignore
+++ b/ee/elf-loader/src/.gitignore
@@ -1,0 +1,2 @@
+# c representation of generated loader.elf
+loader.c

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -14,8 +14,7 @@
 
 #include "elf.h"
 
-#define MAX_PATH 1025
-
+// Loader ELF variables
 extern u8 loader_elf[];
 extern int size_loader_elf;
 
@@ -23,16 +22,7 @@ extern int size_loader_elf;
 #define ELF_MAGIC 0x464c457f
 #define ELF_PT_LOAD 1
 
-
-//------------------------------
-//End of func:  int checkELFheader(const char *path)
-//--------------------------------------------------------------
-// RunLoaderElf loads LOADER.ELF from program memory and passes
-// args of selected ELF and partition to it
-// Modified version of loader from Independence
-//	(C) 2003 Marcus R. Brown <mrbrown@0xd6.org>
-//------------------------------
-void RunLoaderElf(char *filename, char *party)
+void LoadELFFromFile(char *filename)
 {
 	u8 *boot_elf;
 	elf_header_t *eh;

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -40,12 +40,14 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 	void *pdata;
 	int i;
 	int new_argc = argc + 1;
-	char **new_argv = malloc(new_argc);
+	char **new_argv;
 	
 	// We need to check that the ELF file before continue
 	if (!file_exists(filename)) {
 		return -1; // ELF file doesn't exists
 	}
+	// ELF Exists
+	new_argv = malloc(new_argc);
 
 	new_argv[0] = (char *)filename;
     for (i = 0; i < argc; i++) {

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -26,8 +26,8 @@ extern int size_loader_elf;
 #define ELF_PT_LOAD 1
 
 static bool file_exists(const char *filename) {
-  struct stat   buffer;   
-  return (stat (filename, &buffer) == 0);
+	struct stat   buffer;   
+	return (stat (filename, &buffer) == 0);
 }
 
 int LoadELFFromFile(const char *filename, int argc, char *argv[])
@@ -47,7 +47,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 	char *new_argv[new_argc];
 
 	new_argv[0] = (char *)filename;
-    for (i = 0; i < argc; i++) {
+	for (i = 0; i < argc; i++) {
 		new_argv[i + 1] = argv[i];
 	}
 	
@@ -59,8 +59,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 
 	eph = (elf_pheader_t *)(boot_elf + eh->phoff);
 
-	/* Scan through the ELF's program headers and copy them into RAM, then
-									zero out any non-loaded regions.  */
+	/* Scan through the ELF's program headers and copy them into RAM, then zero out any non-loaded regions.  */
 	for (i = 0; i < eh->phnum; i++) {
 		if (eph[i].type != ELF_PT_LOAD)
 			continue;
@@ -69,8 +68,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 		memcpy(eph[i].vaddr, pdata, eph[i].filesz);
 
 		if (eph[i].memsz > eph[i].filesz)
-			memset(eph[i].vaddr + eph[i].filesz, 0,
-			       eph[i].memsz - eph[i].filesz);
+			memset(eph[i].vaddr + eph[i].filesz, 0, eph[i].memsz - eph[i].filesz);
 	}
 
 	/* Let's go.  */

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -1,0 +1,75 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#include <string.h>
+#include <sifrpc.h>
+#include <kernel.h>
+
+#include "elf.h"
+
+#define MAX_PATH 1025
+
+extern u8 loader_elf[];
+extern int size_loader_elf;
+
+// ELF-loading stuff
+#define ELF_MAGIC 0x464c457f
+#define ELF_PT_LOAD 1
+
+
+//------------------------------
+//End of func:  int checkELFheader(const char *path)
+//--------------------------------------------------------------
+// RunLoaderElf loads LOADER.ELF from program memory and passes
+// args of selected ELF and partition to it
+// Modified version of loader from Independence
+//	(C) 2003 Marcus R. Brown <mrbrown@0xd6.org>
+//------------------------------
+void RunLoaderElf(char *filename, char *party)
+{
+	u8 *boot_elf;
+	elf_header_t *eh;
+	elf_pheader_t *eph;
+	void *pdata;
+	int i;
+	char *argv[2];
+
+    argv[0] = filename;
+    argv[1] = filename;
+
+	/* NB: LOADER.ELF is embedded  */
+	boot_elf = (u8 *)loader_elf;
+	eh = (elf_header_t *)boot_elf;
+	if (_lw((u32)&eh->ident) != ELF_MAGIC)
+		asm volatile("break\n");
+
+	eph = (elf_pheader_t *)(boot_elf + eh->phoff);
+
+	/* Scan through the ELF's program headers and copy them into RAM, then
+									zero out any non-loaded regions.  */
+	for (i = 0; i < eh->phnum; i++) {
+		if (eph[i].type != ELF_PT_LOAD)
+			continue;
+
+		pdata = (void *)(boot_elf + eph[i].offset);
+		memcpy(eph[i].vaddr, pdata, eph[i].filesz);
+
+		if (eph[i].memsz > eph[i].filesz)
+			memset(eph[i].vaddr + eph[i].filesz, 0,
+			       eph[i].memsz - eph[i].filesz);
+	}
+
+	/* Let's go.  */
+	SifExitRpc();
+	FlushCache(0);
+	FlushCache(2);
+
+	ExecPS2((void *)eh->entry, NULL, 2, argv);
+}

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -3,7 +3,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 */
@@ -25,8 +25,6 @@ extern int size_loader_elf;
 #define ELF_MAGIC 0x464c457f
 #define ELF_PT_LOAD 1
 
-int printf(const char *format, ...);
-
 static bool file_exists(const char *filename) {
   struct stat   buffer;   
   return (stat (filename, &buffer) == 0);
@@ -40,14 +38,13 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 	void *pdata;
 	int i;
 	int new_argc = argc + 1;
-	char **new_argv;
 	
 	// We need to check that the ELF file before continue
 	if (!file_exists(filename)) {
 		return -1; // ELF file doesn't exists
 	}
 	// ELF Exists
-	new_argv = malloc(new_argc);
+	char *new_argv[new_argc];
 
 	new_argv[0] = (char *)filename;
     for (i = 0; i < argc; i++) {

--- a/ee/elf-loader/src/elf.h
+++ b/ee/elf-loader/src/elf.h
@@ -3,7 +3,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 */

--- a/ee/elf-loader/src/elf.h
+++ b/ee/elf-loader/src/elf.h
@@ -1,0 +1,54 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#ifndef __ELF_H__
+#define __ELF_H__
+
+#include <tamtypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+	u8 ident[16];  // struct definition for ELF object header
+	u16 type;
+	u16 machine;
+	u32 version;
+	u32 entry;
+	u32 phoff;
+	u32 shoff;
+	u32 flags;
+	u16 ehsize;
+	u16 phentsize;
+	u16 phnum;
+	u16 shentsize;
+	u16 shnum;
+	u16 shstrndx;
+} elf_header_t;
+
+typedef struct
+{
+	u32 type;  // struct definition for ELF program section header
+	u32 offset;
+	void *vaddr;
+	u32 paddr;
+	u32 filesz;
+	u32 memsz;
+	u32 flags;
+	u32 align;
+} elf_pheader_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ELF_H__ */

--- a/ee/elf-loader/src/loader/Makefile
+++ b/ee/elf-loader/src/loader/Makefile
@@ -1,0 +1,33 @@
+###dlanor: adjust these three, for PS2Link compatibility tests
+###dlanor: old LaunchELF used LA=0x90000, SA=0xB0000, SS=0x08000
+###dlanor: The values below were implemented in LaunchELF v3.50
+LOADADDR  = 0x90000
+STACKADDR = 0xA8000
+STACKSIZE = 0x04000
+
+ifeq ($(DEBUG),1)
+LOADADDR  = 0x1700000
+STACKADDR = 0x1720000
+STACKSIZE = 0x08000
+endif
+
+LDPARAMS := -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
+
+EE_LDFLAGS += -Wl,-Ttext -Wl,$(LOADADDR) -s $(LDPARAMS)
+
+EE_BIN = loader.elf
+
+EE_OBJS = loader.o
+
+EE_LIBS =
+ifeq ($(DEBUG),1)
+EE_LIBS += -ldebug
+endif
+
+all: $(EE_BIN)
+
+clean:
+	rm -f -r $(EE_OBJS) $(EE_BIN)
+
+include $(PS2SDKSRC)/Defs.make
+include Rules.make

--- a/ee/elf-loader/src/loader/Makefile
+++ b/ee/elf-loader/src/loader/Makefile
@@ -1,6 +1,13 @@
-###dlanor: adjust these three, for PS2Link compatibility tests
-###dlanor: old LaunchELF used LA=0x90000, SA=0xB0000, SS=0x08000
-###dlanor: The values below were implemented in LaunchELF v3.50
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+### Adjust these three, for PS2Link compatibility tests
+### Old LaunchELF used LA=0x90000, SA=0xB0000, SS=0x08000
 LOADADDR  = 0x90000
 STACKADDR = 0xA8000
 STACKSIZE = 0x04000

--- a/ee/elf-loader/src/loader/Rules.make
+++ b/ee/elf-loader/src/loader/Rules.make
@@ -1,0 +1,58 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+EE_CC_VERSION := $(shell $(EE_CC) -dumpversion)
+
+EE_SRC_DIR ?= src/
+EE_INC_DIR ?= include/
+
+# Include directories
+EE_INCS := $(EE_INCS) -I$(EE_SRC_DIR) -I$(EE_SRC_DIR)include -I$(EE_INC_DIR) -I$(PS2SDKSRC)/ee/kernel/include -I$(PS2SDKSRC)/common/include -I$(PS2SDKSRC)/ee/libc/include -I$(PS2SDKSRC)/ee/erl/include
+
+# C compiler flags
+EE_CFLAGS := -D_EE -O2 -G0 -Wall -Werror $(EE_CFLAGS)
+
+# C++ compiler flags
+EE_CXXFLAGS := -D_EE -O2 -G0 -Wall -Werror $(EE_CXXFLAGS)
+
+# Linker flags
+EE_LDFLAGS := -L$(PS2SDKSRC)/ee/kernel/lib -L$(PS2SDKSRC)/ee/libc/lib
+
+# Assembler flags
+EE_ASFLAGS := -G0 $(EE_ASFLAGS)
+
+# Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
+
+# These macros can be used to simplify certain build rules.
+EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
+EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
+
+%.o: %.c
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.cc
+	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.cpp
+	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.S
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.s
+	$(EE_AS) $(EE_ASFLAGS) $< -o $@
+
+$(EE_BIN): $(EE_OBJS)
+	$(EE_CC) $(EE_CFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+
+$(EE_ERL): $(EE_OBJS)
+	$(EE_CC) -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d
+	$(EE_STRIP) --strip-unneeded -R .mdebug.eabi64 -R .reginfo -R .comment $(EE_ERL)
+
+$(EE_LIB): $(EE_OBJS)
+	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)

--- a/ee/elf-loader/src/loader/Rules.make
+++ b/ee/elf-loader/src/loader/Rules.make
@@ -21,7 +21,7 @@ EE_CFLAGS := -D_EE -O2 -G0 -Wall -Werror $(EE_CFLAGS)
 EE_CXXFLAGS := -D_EE -O2 -G0 -Wall -Werror $(EE_CXXFLAGS)
 
 # Linker flags
-EE_LDFLAGS := -L$(PS2SDKSRC)/ee/kernel/lib -L$(PS2SDKSRC)/ee/libc/lib
+EE_LDFLAGS := -L$(PS2SDKSRC)/ee/kernel/lib -L$(PS2SDKSRC)/ee/libc/lib $(EE_LDFLAGS)
 
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)

--- a/ee/elf-loader/src/loader/Rules.make
+++ b/ee/elf-loader/src/loader/Rules.make
@@ -28,6 +28,14 @@ EE_ASFLAGS := -G0 $(EE_ASFLAGS)
 
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
 
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
 # These macros can be used to simplify certain build rules.
 EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
 EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -3,7 +3,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 */

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -1,0 +1,80 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 20020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#include <kernel.h>
+#include <loadfile.h>
+#include <sifrpc.h>
+#include <errno.h>
+
+//--------------------------------------------------------------
+//Start of function code:
+//--------------------------------------------------------------
+// Clear user memory
+// PS2Link (C) 2003 Tord Lindstrom (pukko@home.se)
+//         (C) 2003 adresd (adresd_ps2dev@yahoo.com)
+//--------------------------------------------------------------
+static void wipeUserMem(void)
+{
+	int i;
+	for (i = 0x100000; i < GetMemorySize(); i += 64) {
+		asm volatile(
+		    "\tsq $0, 0(%0) \n"
+		    "\tsq $0, 16(%0) \n"
+		    "\tsq $0, 32(%0) \n"
+		    "\tsq $0, 48(%0) \n" ::"r"(i));
+	}
+}
+
+//--------------------------------------------------------------
+//End of func:  void wipeUserMem(void)
+//--------------------------------------------------------------
+// *** MAIN ***
+//--------------------------------------------------------------
+int main(int argc, char *argv[])
+{
+	static t_ExecData elfdata;
+	char *target, *path;
+	char *args[1];
+	int ret;
+
+	// Initialize
+	SifInitRpc(0);
+	wipeUserMem();
+
+	if (argc != 2) {  // arg1=path to ELF, arg2=partition to mount
+		SifExitRpc();
+		return -EINVAL;
+	}
+
+	target = argv[0];
+	path = argv[1];
+
+	//Writeback data cache before loading ELF.
+	FlushCache(0);
+	ret = SifLoadElf(target, &elfdata);
+	if (ret == 0) {
+		SifExitRpc();
+
+		FlushCache(0);
+		FlushCache(2);
+
+		ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, 1, args);
+		return 0;
+	} else {
+		SifExitRpc();
+		return -ENOENT;
+	}
+}
+
+//--------------------------------------------------------------
+//End of func:  int main(int argc, char *argv[])
+//--------------------------------------------------------------
+//End of file:  loader.c
+//--------------------------------------------------------------

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -25,10 +25,10 @@ static void wipeUserMem(void)
 	int i;
 	for (i = 0x100000; i < GetMemorySize(); i += 64) {
 		asm volatile(
-		    "\tsq $0, 0(%0) \n"
-		    "\tsq $0, 16(%0) \n"
-		    "\tsq $0, 32(%0) \n"
-		    "\tsq $0, 48(%0) \n" ::"r"(i));
+			"\tsq $0, 0(%0) \n"
+			"\tsq $0, 16(%0) \n"
+			"\tsq $0, 32(%0) \n"
+			"\tsq $0, 48(%0) \n" ::"r"(i));
 	}
 }
 


### PR DESCRIPTION
## Description

This PR is for making it easier to load ELFs from other `ELFs`. 
The main concept is inspired by the logic that `uLE` is following for launching `ELFs`, but obviously is improved.

Now, whatever ELF app could load another ELF.
The only steps that need to do is:
Add in the make file the `-lelf-loader` to the linked libraries.
Call `sbv_patch_disable_prefix_check()`
Call `LoadELFFromFile(newELFPath, argc, argv)`

I did test through a dummy test app and in `RetroArch` as well.

Thanks.
