### PR TITLE
ps2_clock() needs an u64 datatype

### DIFF
--- a/ee/libc/include/ps2sdkapi.h
+++ b/ee/libc/include/ps2sdkapi.h
@@ -12,6 +12,7 @@
 #define __PS2SDKAPI_H__
 
 #include <dirent.h>
+#include <inttypes.h>
 #include <sys/stat.h>
 
 /** Inter-library helpers */
@@ -36,6 +37,7 @@ extern int (*_ps2sdk_closedir)(DIR *dir);
 #define PS2_CLOCKS_PER_SEC (147456000 / 256) // 576.000
 #define PS2_CLOCKS_PER_MSEC (PS2_CLOCKS_PER_SEC / 1000) // 576
 
-clock_t ps2_clock(void);
+typedef uint64_t ps2_clock_t;
+ps2_clock_t ps2_clock(void);
 
 #endif /* __PS2SDKAPI_H__ */

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -38,7 +38,6 @@
 
 
 extern void *ps2_sbrk(size_t increment);
-extern clock_t ps2_clock(void);
 
 
 /* the present working directory variable. */

--- a/ee/libc/src/sleep.c
+++ b/ee/libc/src/sleep.c
@@ -39,11 +39,11 @@ static inline u64 timespec_to_us(const struct timespec *pts) {
     return (pts->tv_sec * 1000000ULL) + (pts->tv_nsec / 1000ULL);
 }
 
-static inline clock_t us_to_ps2_clock(u64 us) {
+static inline ps2_clock_t us_to_ps2_clock(u64 us) {
     return (us * PS2_CLOCKS_PER_MSEC) / 1000;
 }
 
-static inline clock_t timespec_to_ps2_clock(const struct timespec *pts) {
+static inline ps2_clock_t timespec_to_ps2_clock(const struct timespec *pts) {
     return us_to_ps2_clock(timespec_to_us(pts));
 }
 
@@ -51,7 +51,7 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
 {
     ee_sema_t sema;
     s32 sema_id;
-    clock_t clock_delay, clock_end, clock_real_end;
+    ps2_clock_t clock_delay, clock_end, clock_real_end;
     u16 hsync_delay;
 
     clock_delay = timespec_to_ps2_clock(req);

--- a/ee/libc/src/time.c
+++ b/ee/libc/src/time.c
@@ -16,9 +16,10 @@
 #include <time.h>
 #include <kernel.h>
 #include <timer.h>
+#include "ps2sdkapi.h"
 
-extern int      __time_intr_overflow_id;
-extern clock_t  __time_intr_overflow_count;
+extern int  __time_intr_overflow_id;
+extern ps2_clock_t  __time_intr_overflow_count;
 
 #ifdef TIME_USE_T0
 #define INTC_TIM       INTC_TIM0
@@ -33,8 +34,8 @@ extern clock_t  __time_intr_overflow_count;
 #endif
 
 #ifdef F___time_internals
-int      __time_intr_overflow_id = -1;
-clock_t  __time_intr_overflow_count = 0;
+int  __time_intr_overflow_id = -1;
+ps2_clock_t  __time_intr_overflow_count = 0;
 
 static int intrOverflow(int ca)
 {
@@ -84,9 +85,9 @@ void _ps2sdk_time_deinit(void)
 #endif
 
 #ifdef F_ps2_clock
-clock_t ps2_clock(void)
+ps2_clock_t ps2_clock(void)
 {
-   u64         t;
+   ps2_clock_t t;
 
    // Tn_COUNT is 16 bit precision. Therefore, each __time_intr_overflow_count is 65536 ticks
    t = *T_COUNT + (__time_intr_overflow_count << 16);


### PR DESCRIPTION
Since the newlib port the ps2_clock function uses the clock_t datatype as defined in newlib. Currently newlib has it defined as 64bit, but in different versions this can also be defined as 32bit, causing ps2_clock to then fail.

This PR creates a new ps2_clock_t type that is always 64bit.