### PR TITLE
Fix problem with clock() function

### DIFF
--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -425,8 +425,8 @@ clock_t _times(struct tms *buffer) {
 	if (buffer != NULL) {
 		buffer->tms_utime  = clk;
 		buffer->tms_stime  = 0;
-		buffer->tms_cutime = 0;
-		buffer->tms_cutime = 0;
+		buffer->tms_cutime = clk;
+		buffer->tms_cstime = 0;
 	}
 
 	return clk;


### PR DESCRIPTION
According to the https://linux.die.net/man/2/times:
The tms_cstime field contains the sum of the tms_stime and tms_cstime
values for all waited-for terminated children.