### PR TITLE
Fix printf specifier for _tzname

### DIFF
--- a/ee/libc/src/timezone.c
+++ b/ee/libc/src/timezone.c
@@ -34,7 +34,7 @@ void _ps2sdk_timezone_update()
 	// Add one hour if configIsDaylightSavingEnabled is 1
 	_timezone = (configGetTimezone() + (configIsDaylightSavingEnabled() * 60)) * 60;
 	tz->__tzrule[0].offset = _timezone;
-	snprintf(_ps2sdk_tzname, sizeof(_ps2sdk_tzname), "GMT+%ld", _timezone);
+	snprintf(_ps2sdk_tzname, sizeof(_ps2sdk_tzname), "GMT%+ld", _timezone);
 	_tzname[0] = _ps2sdk_tzname;
 	_tzname[1] = _ps2sdk_tzname;
 


### PR DESCRIPTION
Before this change, the string in _ps2sdk_tzname could be named "GMT+-x" for negative timezone offsets