### PR TITLE
Add lseek64 function

### DIFF
--- a/ee/libc/include/ps2sdkapi.h
+++ b/ee/libc/include/ps2sdkapi.h
@@ -20,6 +20,7 @@ extern int (*_ps2sdk_close)(int);
 extern int (*_ps2sdk_open)(const char*, int, ...);
 extern int (*_ps2sdk_read)(int, void*, int);
 extern int (*_ps2sdk_lseek)(int, int, int);
+extern long (*_ps2sdk_lseek64)(int, long, int);
 extern int (*_ps2sdk_write)(int, const void*, int);
 extern int (*_ps2sdk_ioctl)(int, int, void*);
 extern int (*_ps2sdk_remove)(const char*);
@@ -41,5 +42,10 @@ typedef uint64_t ps2_clock_t;
 ps2_clock_t ps2_clock(void);
 
 extern void _ps2sdk_timezone_update();
+
+// The newlib port does not support 64bit
+// this should have been defined in unistd.h
+typedef int64_t off64_t;
+off64_t lseek64(int fd, off64_t offset, int whence);
 
 #endif /* __PS2SDKAPI_H__ */

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -173,6 +173,7 @@ int (*_ps2sdk_close)(int) = fioClose;
 int (*_ps2sdk_open)(const char*, int, ...) = (void *)fioOpen;
 int (*_ps2sdk_read)(int, void*, int) = fioRead;
 int (*_ps2sdk_lseek)(int, int, int) = fioLseek;
+long (*_ps2sdk_lseek64)(int, long, int) = NULL;
 int (*_ps2sdk_write)(int, const void*, int) = fioWrite;
 int (*_ps2sdk_ioctl)(int, int, void*) = fioIoctl;
 int (*_ps2sdk_remove)(const char*) = fioRemove;
@@ -447,6 +448,14 @@ int isatty(int fd) {
 off_t _lseek(int fd, off_t offset, int whence)
 {
 	return _ps2sdk_lseek(fd, offset, whence);
+}
+
+off64_t lseek64(int fd, off64_t offset, int whence)
+{
+    if (_ps2sdk_lseek64 == NULL)
+        return EOVERFLOW;
+
+    return _ps2sdk_lseek64(fd, offset, whence);
 }
 
 int chdir(const char *path) {

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -219,6 +219,7 @@ int fileXioInit(void)
 	_ps2sdk_open = fileXioOpen;
 	_ps2sdk_read = fileXioRead;
 	_ps2sdk_lseek = fileXioLseek;
+	_ps2sdk_lseek64 = fileXioLseek64;
 	_ps2sdk_write = fileXioWrite;
 	_ps2sdk_ioctl = fileXioIoctl;
 	_ps2sdk_remove= fileXioRemove;


### PR DESCRIPTION
This PR adds lseek64 support to ps2sdk.

Since I'm having issues with my OPL SMB support I have not been able to test but the changes are fairly simple.