### PR TITLE
libcdvd: replace busyloop checking with semaphore checking

### DIFF
--- a/ee/rpc/cdvd/src/ncmd.c
+++ b/ee/rpc/cdvd/src/ncmd.c
@@ -766,12 +766,12 @@ int sceCdSync(int mode)
 			printf("N cmd wait\n");
 
 		// wait till callback semaphore and client are ready
-		while (cbSema || SifCheckStatRpc(&clientNCmd))
+		while (cbSema || !WaitSema(nCmdSemaId))
 			;
 		return 0;
 	}
 	// check status and return
-	if (cbSema || SifCheckStatRpc(&clientNCmd))
+	if (cbSema || (PollSema(nCmdSemaId) < 0))
 		return 1;
 
 	return 0;

--- a/ee/rpc/cdvd/src/scmd.c
+++ b/ee/rpc/cdvd/src/scmd.c
@@ -916,11 +916,10 @@ int _CdSyncS(int mode)
 	if (mode == 0) {
 		if (CdDebug > 0)
 			printf("S cmd wait\n");
-		while (SifCheckStatRpc(&clientSCmd))
-			;
+		WaitSema(sCmdSemaId);
 		return 0;
 	}
 
-	return SifCheckStatRpc(&clientSCmd);
+	return PollSema(sCmdSemaId) < 0;
 }
 #endif


### PR DESCRIPTION
Busyloop checking is replaced with semaphore checking, so other threads can be run while waiting for RPC.  

This code is untested