### PR TITLE
EE SIFRPC: Fix bug in SifRegisterRpc

### DIFF
--- a/ee/kernel/src/sifrpc.c
+++ b/ee/kernel/src/sifrpc.c
@@ -375,7 +375,7 @@ static void _request_call(SifRpcCallPkt_t *request, void *data)
     (void)data;
 
     if (base->start)
-        base->end->link = server;
+        base->end->next = server;
     else
         base->start = server;
 

--- a/ee/kernel/src/sifrpc.c
+++ b/ee/kernel/src/sifrpc.c
@@ -492,11 +492,11 @@ SifRegisterRpc(SifRpcServerData_t *sd,
     if (!(server = qd->link)) {
         qd->link = sd;
     } else {
-        while (server->next != NULL) {
-            server = server->next;
+        while (server->link != NULL) {
+            server = server->link;
         }
 
-        server->next = sd;
+        server->link = sd;
     }
 
     EI();


### PR DESCRIPTION
This PR fixes a bug in SifRegisterRpc, where if the queue already had registered servers, the function would incorrectly iterate through the next field of the server linked list instead of the link field to find a free space for the server. With the old code, if an RPC request arrived for a queue with multiple registered servers, the SIFRPC protocol would execute not only the correct server, but all servers registered after it as well.

Practically speaking, this bug has little to no influence on current homebrew, as the vast majority of programs do not register any servers, let alone multiple ones to the same queue. However, the official SDK correctly handles this, so it is important that ps2sdk does as well.