### PR TITLE
Fix GitHub workflow: Docker-CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Send Compile action
       run: |
         export DISPATCH_ACTION="$(echo run_build)"
-        echo "{NEW_DISPATCH_ACTION}={$DISPATCH_ACTION}" >> $GITHUB_ENV
+        echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
 
     - name: Repository Dispatch to gsKit
       uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - hotfix/docker-ci
   repository_dispatch:
     types: [run_build]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - hotfix/docker-ci
   repository_dispatch:
     types: [run_build]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Send Compile action
       run: |
         export DISPATCH_ACTION="$(echo run_build)"
-        echo "::set-env name=NEW_DISPATCH_ACTION::$DISPATCH_ACTION"
+        echo "{NEW_DISPATCH_ACTION}={$DISPATCH_ACTION}" >> $GITHUB_ENV
 
     - name: Repository Dispatch to gsKit
       uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
Hi.

I see that Docker-CI job is failing.

This PR is about:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Proof: 
<img src="https://user-images.githubusercontent.com/32263891/100139465-d2657e80-2e8f-11eb-9ce0-96763ec0795b.png" width="300px" height="auto" />

Thanks!