### PR TITLE
Doxygen: enable static members

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -453,7 +453,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,


### PR DESCRIPTION
Hi.

I'm preparing to add packet2 documentation to Doxygen.
I think that it will be required to enable static members in doxygen config file.
Packet2 have a lot of static inline functions which will be not included in doxygen, without changing this option.

Thanks!