### PR TITLE
Doxygen: Add markups for libpacket2

### DIFF
--- a/ee/packet2/include/packet2.h
+++ b/ee/packet2/include/packet2.h
@@ -8,7 +8,19 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
-/** @file Successor of standard packet library. */
+/** 
+ * @file Successor of standard packet library. 
+ * @defgroup packet2 Packet2 library
+ * Successor of packet_t. Main goal of this library is to
+ * create simple API for packet management. 
+ * Library is splitted into several parts:
+ * - This - core functionality of libpacket2  
+ * - "_types" - Enums and structures used in libpacket2  
+ * - "_chain" - DMA tags 
+ * - "_vif" - VU related
+ * - "_utils" - useful functions, and examples 
+ * @{
+ */
 
 #ifndef __PACKET2_H__
 #define __PACKET2_H__
@@ -30,7 +42,7 @@ extern "C"
      * Allocate new packet2. 
      * @param qwords Maximum data size in qwords (128bit). 
      * @param type Memory mapping type. 
-     * @param mode Packet mode. Normal or chain (so also vif/vu). 
+     * @param mode Packet mode. Normal or chain. 
      * @param tte Tag transfer enable. 
      * Used only for CHAIN mode! 
      * If >0 transfer tag is set during packet sending and 
@@ -82,24 +94,21 @@ extern "C"
     // Basic add
     // ---
 
-    /** NOTICE: vif_added_bytes increased by 16. */
+    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_u128(packet2_t *packet2, const u128 val)
     {
         *((u128 *)packet2->next)++ = val;
         packet2->vif_added_bytes += 16;
     }
 
-    /** NOTICE: vif_added_bytes increased by 16. */
+    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_s128(packet2_t *packet2, const s128 val)
     {
         *((s128 *)packet2->next)++ = val;
         packet2->vif_added_bytes += 16;
     }
 
-    /** 
-     * NOTICE: Alignment alert. Size of dword (1/2) 
-     * vif_added_bytes increased by 16. 
-     */
+    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_2x_s64(packet2_t *packet2, const s64 v1, const s64 v2)
     {
         *((s64 *)packet2->next)++ = v1;
@@ -108,7 +117,7 @@ extern "C"
     }
 
     /** 
-     * NOTICE: Alignment alert. Size of dword (1/2) 
+     * @note Alignment alert. Size of dword (1/2) 
      * vif_added_bytes increased by 8. 
      */
     static inline void packet2_add_u64(packet2_t *packet2, const u64 val)
@@ -118,7 +127,7 @@ extern "C"
     }
 
     /** 
-     * NOTICE: Alignment alert. Size of dword (1/2) 
+     * @note Alignment alert. Size of dword (1/2) 
      * vif_added_bytes increased by 8. 
      */
     static inline void packet2_add_s64(packet2_t *packet2, const s64 val)
@@ -128,7 +137,7 @@ extern "C"
     }
 
     /** 
-     * NOTICE: Alignment alert. Size of word (1/4) 
+     * @note Alignment alert. Size of word (1/4) 
      * vif_added_bytes increased by 4. 
      */
     static inline void packet2_add_u32(packet2_t *packet2, const u32 val)
@@ -138,7 +147,7 @@ extern "C"
     }
 
     /** 
-     * NOTICE: Alignment alert. Size of word (1/4) 
+     * @note Alignment alert. Size of word (1/4) 
      * vif_added_bytes increased by 4. 
      */
     static inline void packet2_add_s32(packet2_t *packet2, const s32 val)
@@ -148,7 +157,7 @@ extern "C"
     }
 
     /** 
-     * NOTICE: Alignment alert. Size of word (1/4)
+     * @note Alignment alert. Size of word (1/4)
      * vif_added_bytes increased by 4. 
      */
     static inline void packet2_add_float(packet2_t *packet2, const float val)
@@ -204,3 +213,5 @@ extern "C"
 #endif
 
 #endif /* __PACKET2_H__ */
+
+/** @} */ // end of packet2 group

--- a/ee/packet2/include/packet2_chain.h
+++ b/ee/packet2/include/packet2_chain.h
@@ -8,7 +8,13 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
-/** @file Chain mode related functions for packet2. */
+/** 
+ * @file Chain mode related functions for packet2.
+ * @defgroup packet2_chain Chain
+ * Chain mode related functions of libpacket2.
+ * @ingroup packet2
+ * @{
+ */
 
 #ifndef __PACKET2_CHAIN_H__
 #define __PACKET2_CHAIN_H__
@@ -104,7 +110,7 @@ extern "C"
 
     /** 
      * Add CNT tag. 
-     * NOTICE: packet2_chain_close_tag() required. Qwords 
+     * @note packet2_chain_close_tag() required. Qwords 
      * are counted automatically. 
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -119,10 +125,10 @@ extern "C"
 
     /** 
      * Add END tag. 
-     * NOTICE: packet2_chain_close_tag() required. Qwords 
+     * @note packet2_chain_close_tag() required. Qwords 
      * are counted automatically. 
      * For more details, check description of dma_tag_t. 
-     * NOTICE: Don't forget about close_tag()!
+     * @note Don't forget about close_tag()!
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default.
      * @param pce Priority Control Enable. 0 by default.
@@ -134,7 +140,7 @@ extern "C"
 
     /** 
      * Add REF tag. 
-     * NOTICE: Qwords are NOT counted automatically, so 
+     * @note Qwords are NOT counted automatically, so 
      * there is NO need to use packet2_chain_close_tag(); 
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -152,7 +158,7 @@ extern "C"
 
     /** 
      * Add NEXT tag. 
-     * NOTICE: packet2_chain_close_tag() required. Qwords 
+     * @note packet2_chain_close_tag() required. Qwords 
      * are counted automatically. 
      * For more details, check description of dma_tag_t. 
      * @param next_tag Pointer to next tag. 
@@ -168,7 +174,7 @@ extern "C"
 
     /** 
      * Add REFS tag.
-     * NOTICE: Qwords are NOT counted automatically, so 
+     * @note Qwords are NOT counted automatically, so 
      * there is NO need to use packet2_chain_close_tag();
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -186,7 +192,7 @@ extern "C"
 
     /** 
      * Add REFE tag.
-     * NOTICE: Qwords are NOT counted automatically, so 
+     * @note Qwords are NOT counted automatically, so 
      * there is NO need to use packet2_chain_close_tag();
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -204,7 +210,7 @@ extern "C"
 
     /** 
      * Add CALL tag. 
-     * NOTICE: packet2_chain_close_tag() required. Qwords 
+     * @note packet2_chain_close_tag() required. Qwords 
      * are counted automatically. 
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -221,7 +227,7 @@ extern "C"
 
     /** 
      * Add RET tag. 
-     * NOTICE: packet2_chain_close_tag() required. Qwords 
+     * @note packet2_chain_close_tag() required. Qwords 
      * are counted automatically. 
      * For more details, check description of dma_tag_t. 
      * @param packet2 Pointer to packet. 
@@ -238,3 +244,5 @@ extern "C"
 #endif
 
 #endif /* __PACKET2_CHAIN_H__ */
+
+/** @} */ // end of packet2_chain subgroup

--- a/ee/packet2/include/packet2_types.h
+++ b/ee/packet2/include/packet2_types.h
@@ -8,7 +8,13 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
-/** @file Structs and enums used in packet2 library. */
+/** 
+ * @file Structs and enums used in packet2 library
+ * @defgroup packet2_types Types
+ * Structures and enums used in libpacket2.
+ * @ingroup packet2
+ * @{
+ */
 
 #ifndef __PACKET2_DATA_TYPES_H__
 #define __PACKET2_DATA_TYPES_H__
@@ -55,13 +61,13 @@ enum DmaTagType
     /** 
      * Transfers the QWC qword from the ADDR field while controlling stalls 
      * and reads the qword following the tag as the next tag.
-     * NOTICE: Effective only on the VIF1, GIF, and SIF1 channels. 
+     * @note Effective only on the VIF1, GIF, and SIF1 channels. 
      */
     P2_DMA_TAG_REFS = 4,
     /** 
      * Transfers the QWC qword following the tag, pushes the next field into 
      * the Dn_ASR register, and reads the qword of the ADDR field as the next tag. 
-     * NOTICE: Effective only on the VIF0, VIF1, and GIF channels. 
+     * @note Effective only on the VIF0, VIF1, and GIF channels. 
      * Addresses can be pushed up to 2 levels 
      */
     P2_DMA_TAG_CALL = 5,
@@ -72,7 +78,7 @@ enum DmaTagType
      * Transfers the QWC qword following the tag, clears the 
      * Dn_CHCR.STR to 0, and ends transfer when there is no 
      * pushed address. 
-     * NOTICE: Effective only on the VIF0, VIF1, and GIF channels. 
+     * @note Effective only on the VIF0, VIF1, and GIF channels. 
      */
     P2_DMA_TAG_RET = 6,
     /** Transfers the QWC qword following the tag, clears the Dn_CHCR.STR to 0, and ends transfer. */
@@ -300,9 +306,11 @@ typedef struct
     /** Packet mode. */
     enum Packet2Mode mode;
     /** 
-     * Tag transfer enable.
-     * If >0 transfer tag is set during packet sending.
-     * Effective only in chain mode.
+     * Tag transfer enable. 
+     * Effective only in chain mode. 
+     * If >0 transfer tag is set during packet sending and 
+     * add_dma_tag() (so also every open_tag()) will move buffer by DWORD, 
+     * so remember to align memory!
      */
     u8 tte;
     /** Start position of the buffer. */
@@ -348,3 +356,5 @@ typedef struct
 } Mask;
 
 #endif /* __PACKET2_DATA_TYPES_H__ */
+
+/** @} */ // end of packet2_types subgroup

--- a/ee/packet2/include/packet2_utils.h
+++ b/ee/packet2/include/packet2_utils.h
@@ -8,7 +8,13 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
-/** @file Helper functions for packet2. */
+/** 
+ * @file Helper functions for packet2.
+ * @defgroup packet2_utils Utils
+ * Useful functions and examples for libpacket2.
+ * @ingroup packet2
+ * @{
+ */
 
 #ifndef __PACKET2_UTILS_H__
 #define __PACKET2_UTILS_H__
@@ -55,6 +61,7 @@ extern "C"
      * @param t_size Size in quadwords. 
      * @param t_use_top Unpack to current double buffer? 
      * When true, data will be loaded at destination address + beginning of current VU buffer. 
+     * @note vif_added_bytes increased by t_size * 16
      */
     static inline void packet2_utils_vu_add_unpack_data(packet2_t *packet2, u32 t_dest_address, void *t_data, u32 t_size, u8 t_use_top)
     {
@@ -250,3 +257,5 @@ extern "C"
 #endif
 
 #endif /* __PACKET2_UTILS_H__ */
+
+/** @} */ // end of packet2_utils subgroup

--- a/ee/packet2/include/packet2_vif.h
+++ b/ee/packet2/include/packet2_vif.h
@@ -8,7 +8,13 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
-/** @file VIF related functions for packet2. */
+/** 
+ * @file VIF related functions for packet2.
+ * @defgroup packet2_vif VIF
+ * VIF related functions of libpacket2.
+ * @ingroup packet2
+ * @{
+ */
 
 #ifndef __PACKET2_VIF_H__
 #define __PACKET2_VIF_H__
@@ -25,7 +31,7 @@ extern "C"
 
     /** 
      * Add UNPACK VIF opcode. 
-     * NOTICE: packet2_vif_close_unpack() required. Qwords 
+     * @note packet2_vif_close_unpack() required. Qwords 
      * are counted automatically. 
      * For more details, check description of vif_code_t. 
      * @param packet2 Pointer to packet. 
@@ -69,7 +75,7 @@ extern "C"
 
     /** 
      * Add DIRECT VIF opcode. 
-     * NOTICE: Direct must be closed via 
+     * @note Direct must be closed via 
      * packet2_vif_close_direct_manual() or
      * packet2_vif_close_direct_auto() function!
      * @param packet2 Pointer to packet. 
@@ -110,7 +116,7 @@ extern "C"
 
     /** 
      * Add NOP VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default. 
@@ -122,7 +128,7 @@ extern "C"
 
     /** 
      * Add MPG VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param num Number of 64-bit data. 
@@ -136,7 +142,7 @@ extern "C"
 
     /** 
      * Add STCYCL VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param wl WL field. 
@@ -150,7 +156,7 @@ extern "C"
 
     /** 
      * Add OFFSET VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param offset Offset. BASE+OFFSET will be the address of second buffer. 
@@ -163,7 +169,7 @@ extern "C"
 
     /** 
      * Add BASE VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param base Base address of double buffer. 
@@ -176,7 +182,7 @@ extern "C"
 
     /** 
      * Add FLUSH VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default. 
@@ -188,7 +194,7 @@ extern "C"
 
     /** 
      * Add MSCAL VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param addr Starting address. 
@@ -201,7 +207,7 @@ extern "C"
 
     /** 
      * Add MSCNT VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default. 
@@ -213,7 +219,7 @@ extern "C"
 
     /** 
      * Add ITOP VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param itops Value for VU XITOP instruction. 
@@ -226,7 +232,7 @@ extern "C"
 
     /** 
      * Add MSKPATH3 VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param mode Decompression mode. 
@@ -239,7 +245,7 @@ extern "C"
 
     /** 
      * Add MSKPATH3 VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param mask Mask. 
@@ -252,7 +258,7 @@ extern "C"
 
     /** 
      * Add MARK VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param value Value. 
@@ -265,7 +271,7 @@ extern "C"
 
     /** 
      * Add FLUSHE VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default. 
@@ -277,7 +283,7 @@ extern "C"
 
     /** 
      * Add FLUSHA VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param irq Interrupt Request. False by default. 
@@ -289,7 +295,7 @@ extern "C"
 
     /** 
      * Add MSCALF VIF opcode. 
-     * NOTICE: Alignment alert. Size of word (1/4). 
+     * @note Alignment alert. Size of word (1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param addr Address. 
@@ -302,7 +308,7 @@ extern "C"
 
     /** 
      * Add STMASK VIF opcode. 
-     * NOTICE: Alignment alert. Size of dword (1/2). 
+     * @note Alignment alert. Size of dword (1/2). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param mask Mask. 
@@ -316,7 +322,7 @@ extern "C"
 
     /** 
      * Add STROW VIF opcode. 
-     * NOTICE: Alignment alert. Size of 5 x word (1+1/4). 
+     * @note Alignment alert. Size of 5 x word (1+1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param row_arr Row array. 
@@ -333,7 +339,7 @@ extern "C"
 
     /** 
      * Add STCOL VIF opcode. 
-     * NOTICE: Alignment alert. Size of 5 x word (1+1/4). 
+     * @note Alignment alert. Size of 5 x word (1+1/4). 
      * For more details, check description of VIFOpcode. 
      * @param packet2 Pointer to packet. 
      * @param col_arr Column array. 
@@ -362,3 +368,5 @@ extern "C"
 #endif
 
 #endif /* __PACKET2_VIF_H__ */
+
+/** @} */ // end of packet2_vif subgroup


### PR DESCRIPTION
Hi.

Added some markups for doxygen, so now, libpacket2 documentation will be visible in github pages :)

<img src="https://user-images.githubusercontent.com/32263891/100148102-9389f580-2e9c-11eb-94f2-d86a4dccc81c.png" width="400px" height="auto" />

Thanks