### PR TITLE
Packet2: GCC11 improvements, refactor of close_unpack()

### DIFF
--- a/ee/draw/samples/Makefile
+++ b/ee/draw/samples/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = cube teapot texture
+SUBDIRS = cube teapot texture vu1
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/Rules.make

--- a/ee/packet2/include/packet2.h
+++ b/ee/packet2/include/packet2.h
@@ -91,90 +91,70 @@ extern "C"
     // ---
     // Basic add
     // ---
+
+    /** Move "next" pointer forward. */
     static inline void packet2_advance_next(packet2_t *packet2, u32 i)
     {
-        packet2->next = (qword_t *)((u8*)packet2->next + i);
-        packet2->vif_added_bytes += i;
+        packet2->next = (qword_t *)((u8 *)packet2->next + i);
     }
 
-    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_u128(packet2_t *packet2, const u128 val)
     {
         *((u128 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(u128));
     }
 
-    /**
-     * @note Alignment alert. Size of dword (1/2)
-     * vif_added_bytes increased by 8.
-     */
+    /** @note Alignment alert. Size of dword (1/2) */
     static inline void packet2_add_s64(packet2_t *packet2, const s64 val)
     {
         *((s64 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(s64));
     }
 
-    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_2x_s64(packet2_t *packet2, const s64 v1, const s64 v2)
     {
         packet2_add_s64(packet2, v1);
         packet2_add_s64(packet2, v2);
     }
 
-    /** @note vif_added_bytes increased by 16. */
     static inline void packet2_add_s128(packet2_t *packet2, const s128 val)
     {
         *((s128 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(s128));
     }
 
-    /** 
-     * @note Alignment alert. Size of dword (1/2) 
-     * vif_added_bytes increased by 8. 
-     */
+    /** @note Alignment alert. Size of dword (1/2) */
     static inline void packet2_add_u64(packet2_t *packet2, const u64 val)
     {
         *((u64 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(u64));
     }
 
-    /** 
-     * @note Alignment alert. Size of word (1/4) 
-     * vif_added_bytes increased by 4. 
-     */
+    /** @note Alignment alert. Size of word (1/4) */
     static inline void packet2_add_u32(packet2_t *packet2, const u32 val)
     {
         *((u32 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(u32));
     }
 
-    /** 
-     * @note Alignment alert. Size of word (1/4) 
-     * vif_added_bytes increased by 4. 
-     */
+    /** @note Alignment alert. Size of word (1/4) */
     static inline void packet2_add_s32(packet2_t *packet2, const s32 val)
     {
         *((s32 *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(s32));
     }
 
-    /** 
-     * @note Alignment alert. Size of word (1/4)
-     * vif_added_bytes increased by 4. 
-     */
+    /** @note Alignment alert. Size of word (1/4) */
     static inline void packet2_add_float(packet2_t *packet2, const float val)
     {
         *((float *)packet2->next) = val;
         packet2_advance_next(packet2, sizeof(float));
     }
 
-    /**
-     * vif_added_bytes increased by t_size*16.
-     */
     static inline void packet2_add_data(packet2_t *packet2, void *t_data, u32 t_size)
     {
         int i;
-        for(i=0; i<t_size; i++)
+        for (i = 0; i < t_size; i++)
             packet2_add_u128(packet2, ((u128 *)t_data)[i]);
     }
 
@@ -218,9 +198,6 @@ extern "C"
 
     /** Returns count of added qwords into packet. */
     static inline u32 packet2_get_qw_count(packet2_t *packet2) { return ((u32)packet2->next - (u32)packet2->base) >> 4; }
-
-    /** Returns count of added qwords into VU. */
-    static inline u32 packet2_get_vif_added_qws(packet2_t *packet2) { return packet2->vif_added_bytes >> 4; }
 
     /** True if packet doesnt have even number of quads. */
     static inline u8 packet2_doesnt_have_even_number_of_quads(packet2_t *packet2) { return ((u32)packet2->next & 0xF) != 0; }

--- a/ee/packet2/include/packet2_chain.h
+++ b/ee/packet2/include/packet2_chain.h
@@ -19,6 +19,7 @@
 #ifndef __PACKET2_CHAIN_H__
 #define __PACKET2_CHAIN_H__
 
+#include <packet2.h>
 #include <packet2_types.h>
 #include <assert.h>
 
@@ -86,9 +87,9 @@ extern "C"
             packet2->tag_opened_at = (dma_tag_t *)NULL;
         }
         if (!packet2->tte)
-            *((dma_tag_t *)packet2->next)++;
+            packet2_advance_next(packet2, sizeof(dma_tag_t));
         else
-            *((u64 *)packet2->next)++;
+            packet2_advance_next(packet2, sizeof(u64));
     }
 
     /** 

--- a/ee/packet2/include/packet2_types.h
+++ b/ee/packet2/include/packet2_types.h
@@ -335,24 +335,27 @@ typedef struct
 } packet2_t;
 
 /** Mask, used in VIF's STMASK opcode. */
-typedef struct
-{
-    unsigned int m0 : 2;
-    unsigned int m1 : 2;
-    unsigned int m2 : 2;
-    unsigned int m3 : 2;
-    unsigned int m4 : 2;
-    unsigned int m5 : 2;
-    unsigned int m6 : 2;
-    unsigned int m7 : 2;
-    unsigned int m8 : 2;
-    unsigned int m9 : 2;
-    unsigned int m10 : 2;
-    unsigned int m11 : 2;
-    unsigned int m12 : 2;
-    unsigned int m13 : 2;
-    unsigned int m14 : 2;
-    unsigned int m15 : 2;
+typedef union {
+    struct
+    {
+        unsigned int m0 : 2;
+        unsigned int m1 : 2;
+        unsigned int m2 : 2;
+        unsigned int m3 : 2;
+        unsigned int m4 : 2;
+        unsigned int m5 : 2;
+        unsigned int m6 : 2;
+        unsigned int m7 : 2;
+        unsigned int m8 : 2;
+        unsigned int m9 : 2;
+        unsigned int m10 : 2;
+        unsigned int m11 : 2;
+        unsigned int m12 : 2;
+        unsigned int m13 : 2;
+        unsigned int m14 : 2;
+        unsigned int m15 : 2;
+    };
+    unsigned int m;
 } Mask;
 
 #endif /* __PACKET2_DATA_TYPES_H__ */

--- a/ee/packet2/include/packet2_types.h
+++ b/ee/packet2/include/packet2_types.h
@@ -327,15 +327,11 @@ typedef struct
      * NULL, if no DIRECT/UNPACK is open. 
      */
     vif_code_t *vif_code_opened_at;
-    /** 
-     * Helper variable to control bytes that 
-     * was already "written" to VU. 
-     */
-    u32 vif_added_bytes;
 } packet2_t;
 
 /** Mask, used in VIF's STMASK opcode. */
-typedef union {
+typedef union
+{
     struct
     {
         unsigned int m0 : 2;

--- a/ee/packet2/include/packet2_utils.h
+++ b/ee/packet2/include/packet2_utils.h
@@ -20,6 +20,9 @@
 #define __PACKET2_UTILS_H__
 
 #include "packet2.h"
+#include "packet2_chain.h"
+#include "packet2_vif.h"
+
 #include <tamtypes.h>
 #include <draw3d.h>
 #include <draw_buffers.h>
@@ -88,7 +91,7 @@ extern "C"
     /** Close CNT tag + VU unpack. */
     static inline void packet2_utils_vu_close_unpack(packet2_t *packet2)
     {
-        packet2_align_to_qword(packet2);
+        packet2_vif_pad128(packet2);
         packet2_chain_close_tag(packet2);
         packet2_vif_close_unpack(packet2, packet2_get_vif_added_qws(packet2));
     }

--- a/ee/packet2/include/packet2_utils.h
+++ b/ee/packet2/include/packet2_utils.h
@@ -63,16 +63,13 @@ extern "C"
      * @param t_data Data pointer. 
      * @param t_size Size in quadwords. 
      * @param t_use_top Unpack to current double buffer? 
-     * When true, data will be loaded at destination address + beginning of current VU buffer. 
-     * @note vif_added_bytes increased by t_size * 16
      */
     static inline void packet2_utils_vu_add_unpack_data(packet2_t *packet2, u32 t_dest_address, void *t_data, u32 t_size, u8 t_use_top)
     {
         packet2_chain_ref(packet2, t_data, t_size, 0, 0, 0);
         packet2_vif_stcycl(packet2, 0, 0x0101, 0);
         packet2_vif_open_unpack(packet2, P2_UNPACK_V4_32, t_dest_address, t_use_top, 0, 1, 0);
-        packet2_vif_close_unpack(packet2, t_size);
-        packet2->vif_added_bytes += t_size << 4;
+        packet2_vif_close_unpack_manual(packet2, t_size);
     }
 
     /** 
@@ -88,12 +85,15 @@ extern "C"
         packet2_vif_open_unpack(packet2, P2_UNPACK_V4_32, t_dest_address, t_use_top, 0, 1, 0);
     }
 
-    /** Close CNT tag + VU unpack. */
-    static inline void packet2_utils_vu_close_unpack(packet2_t *packet2)
+    /** 
+     * Close CNT tag + VU unpack. 
+     * @returns Unpacked qwords count
+     */
+    static inline u32 packet2_utils_vu_close_unpack(packet2_t *packet2)
     {
         packet2_vif_pad128(packet2);
         packet2_chain_close_tag(packet2);
-        packet2_vif_close_unpack(packet2, packet2_get_vif_added_qws(packet2));
+        return packet2_vif_close_unpack_auto(packet2, 0, 0x0101);
     }
 
     /** 

--- a/ee/packet2/include/packet2_vif.h
+++ b/ee/packet2/include/packet2_vif.h
@@ -19,6 +19,7 @@
 #ifndef __PACKET2_VIF_H__
 #define __PACKET2_VIF_H__
 
+#include <packet2.h>
 #include <packet2_types.h>
 #include <assert.h>
 
@@ -50,10 +51,10 @@ extern "C"
     {
         assert(packet2->vif_code_opened_at == NULL); // All previous UNPACK/DIRECT are closed.
         packet2->vif_code_opened_at = (vif_code_t *)packet2->next;
-        *((u32 *)packet2->next)++ =
+        packet2_add_u32(packet2,
             MAKE_VIF_CODE(vuAddr | ((u32)usigned << 14) | ((u32)dblBuffered << 15),
                           0,
-                          mode | ((u32)masked << 4) | 0x60, irq);
+                          mode | ((u32)masked << 4) | 0x60, irq));
     }
 
     /** 
@@ -77,15 +78,13 @@ extern "C"
      * Add DIRECT VIF opcode. 
      * @note Direct must be closed via 
      * packet2_vif_close_direct_manual() or
-     * packet2_vif_close_direct_auto() function!
-     * @param packet2 Pointer to packet. 
-     * @param irq Interrupt Request. False by default.
+     * packet2_vif_close   : "memory"
      */
     static inline void packet2_vif_open_direct(packet2_t *packet2, u8 irq)
     {
         assert(packet2->vif_code_opened_at == NULL); // All previous UNPACK/DIRECT are closed.
         packet2->vif_code_opened_at = (vif_code_t *)packet2->next;
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_DIRECT, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_DIRECT, irq));
     }
 
     /** 
@@ -123,7 +122,7 @@ extern "C"
      */
     static inline void packet2_vif_nop(packet2_t *packet2, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_NOP, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_NOP, irq));
     }
 
     /**
@@ -132,8 +131,7 @@ extern "C"
      */
     static inline void packet2_vif_pad96(packet2_t *packet2)
     {
-        while ((((u32)packet2->next + 4) & 0xf) != 0)
-            packet2_vif_nop(packet2, 0);
+        packet2_pad96(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_NOP, 0));
     }
 
     /**
@@ -142,8 +140,7 @@ extern "C"
      */
     static inline void packet2_vif_pad128(packet2_t *packet2)
     {
-        while (((u32)packet2->next & 0xf) != 0)
-            packet2_vif_nop(packet2, 0);
+        packet2_pad128(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_NOP, 0));
     }
 
     /** 
@@ -157,7 +154,7 @@ extern "C"
      */
     static inline void packet2_vif_mpg(packet2_t *packet2, u32 num, u32 addr, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(addr, num, P2_VIF_MPG, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(addr, num, P2_VIF_MPG, irq));
     }
 
     /** 
@@ -171,7 +168,7 @@ extern "C"
      */
     static inline void packet2_vif_stcycl(packet2_t *packet2, u32 wl, u32 cl, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(cl | (wl << 8), 0, P2_VIF_STCYCL, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(cl | (wl << 8), 0, P2_VIF_STCYCL, irq));
     }
 
     /** 
@@ -184,7 +181,7 @@ extern "C"
      */
     static inline void packet2_vif_offset(packet2_t *packet2, u32 offset, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(offset, 0, P2_VIF_OFFSET, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(offset, 0, P2_VIF_OFFSET, irq));
     }
 
     /** 
@@ -197,7 +194,7 @@ extern "C"
      */
     static inline void packet2_vif_base(packet2_t *packet2, u32 base, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(base, 0, P2_VIF_BASE, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(base, 0, P2_VIF_BASE, irq));
     }
 
     /** 
@@ -209,7 +206,7 @@ extern "C"
      */
     static inline void packet2_vif_flush(packet2_t *packet2, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_FLUSH, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_FLUSH, irq));
     }
 
     /** 
@@ -222,7 +219,7 @@ extern "C"
      */
     static inline void packet2_vif_mscal(packet2_t *packet2, u32 addr, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(addr, 0, P2_VIF_MSCAL, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(addr, 0, P2_VIF_MSCAL, irq));
     }
 
     /** 
@@ -234,7 +231,7 @@ extern "C"
      */
     static inline void packet2_vif_mscnt(packet2_t *packet2, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_MSCNT, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_MSCNT, irq));
     }
 
     /** 
@@ -247,7 +244,7 @@ extern "C"
      */
     static inline void packet2_vif_itop(packet2_t *packet2, u32 itops, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(itops, 0, P2_VIF_ITOP, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(itops, 0, P2_VIF_ITOP, irq));
     }
 
     /** 
@@ -260,7 +257,7 @@ extern "C"
      */
     static inline void packet2_vif_stmod(packet2_t *packet2, u32 mode, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(mode, 0, P2_VIF_STMOD, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(mode, 0, P2_VIF_STMOD, irq));
     }
 
     /** 
@@ -273,7 +270,7 @@ extern "C"
      */
     static inline void packet2_vif_mskpath3(packet2_t *packet2, u32 mask, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(mask, 0, P2_VIF_MSKPATH3, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(mask, 0, P2_VIF_MSKPATH3, irq));
     }
 
     /** 
@@ -286,7 +283,7 @@ extern "C"
      */
     static inline void packet2_vif_mark(packet2_t *packet2, u32 value, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(value, 0, P2_VIF_MARK, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(value, 0, P2_VIF_MARK, irq));
     }
 
     /** 
@@ -298,7 +295,7 @@ extern "C"
      */
     static inline void packet2_vif_flushe(packet2_t *packet2, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_FLUSHE, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_FLUSHE, irq));
     }
 
     /** 
@@ -310,7 +307,7 @@ extern "C"
      */
     static inline void packet2_vif_flusha(packet2_t *packet2, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_FLUSHA, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_FLUSHA, irq));
     }
 
     /** 
@@ -323,7 +320,7 @@ extern "C"
      */
     static inline void packet2_vif_mscalf(packet2_t *packet2, u32 addr, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(addr, 0, P2_VIF_MSCALF, irq);
+        packet2_add_u32(packet2, MAKE_VIF_CODE(addr, 0, P2_VIF_MSCALF, irq));
     }
 
     /** 
@@ -336,8 +333,8 @@ extern "C"
      */
     static inline void packet2_vif_stmask(packet2_t *packet2, Mask mask, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_STMASK, irq);
-        *((Mask *)packet2->next)++ = mask;
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_STMASK, irq));
+        packet2_add_u32(packet2, mask.m);
     }
 
     /** 
@@ -348,13 +345,13 @@ extern "C"
      * @param row_arr Row array. 
      * @param irq Interrupt Request. False by default. 
      */
-    static inline void packet2_vif_strow(packet2_t *packet2, const void *row_arr, u8 irq)
+    static inline void packet2_vif_strow(packet2_t *packet2, const u32 *row_arr, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_STROW, irq);
-        *((u32 *)packet2->next)++ = ((u32 *)row_arr)[0];
-        *((u32 *)packet2->next)++ = ((u32 *)row_arr)[1];
-        *((u32 *)packet2->next)++ = ((u32 *)row_arr)[2];
-        *((u32 *)packet2->next)++ = ((u32 *)row_arr)[3];
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_STROW, irq));
+        packet2_add_u32(packet2, row_arr[0]);
+        packet2_add_u32(packet2, row_arr[1]);
+        packet2_add_u32(packet2, row_arr[2]);
+        packet2_add_u32(packet2, row_arr[3]);
     }
 
     /** 
@@ -365,13 +362,13 @@ extern "C"
      * @param col_arr Column array. 
      * @param irq Interrupt Request. False by default. 
      */
-    static inline void packet2_vif_stcol(packet2_t *packet2, const void *col_arr, u8 irq)
+    static inline void packet2_vif_stcol(packet2_t *packet2, const u32 *col_arr, u8 irq)
     {
-        *((u32 *)packet2->next)++ = MAKE_VIF_CODE(0, 0, P2_VIF_STCOL, irq);
-        *((u32 *)packet2->next)++ = ((u32 *)col_arr)[0];
-        *((u32 *)packet2->next)++ = ((u32 *)col_arr)[1];
-        *((u32 *)packet2->next)++ = ((u32 *)col_arr)[2];
-        *((u32 *)packet2->next)++ = ((u32 *)col_arr)[3];
+        packet2_add_u32(packet2, MAKE_VIF_CODE(0, 0, P2_VIF_STCOL, irq));
+        packet2_add_u32(packet2, col_arr[0]);
+        packet2_add_u32(packet2, col_arr[1]);
+        packet2_add_u32(packet2, col_arr[2]);
+        packet2_add_u32(packet2, col_arr[3]);
     }
 
     /** 

--- a/ee/packet2/src/packet2.c
+++ b/ee/packet2/src/packet2.c
@@ -32,7 +32,6 @@ packet2_t *packet2_create(u16 qwords, enum Packet2Type type, enum Packet2Mode mo
     packet2->type = type;
     packet2->mode = mode;
     packet2->tte = tte;
-    packet2->vif_added_bytes = 0;
     packet2->tag_opened_at = NULL;
     packet2->vif_code_opened_at = NULL;
 
@@ -91,7 +90,6 @@ void packet2_reset(packet2_t *packet2, u8 clear_mem)
     packet2->next = packet2->base;
     packet2->vif_code_opened_at = NULL;
     packet2->tag_opened_at = NULL;
-    packet2->vif_added_bytes = 0;
     if (clear_mem)
         memset(packet2->base, 0, packet2->max_qwords_count << 4);
 }
@@ -105,7 +103,6 @@ void packet2_add(packet2_t *a, packet2_t *b)
     assert(packet2_get_qw_count(a) + packet2_get_qw_count(b) <= a->max_qwords_count);
     memcpy(a->next, b->base, (u32)b->next - (u32)b->base);
     a->next = a->base + packet2_get_qw_count(b) + 1;
-    a->vif_added_bytes += b->vif_added_bytes;
 }
 
 void packet2_print(packet2_t *packet2, u32 qw_count)

--- a/ee/packet2/src/packet2_vif.c
+++ b/ee/packet2/src/packet2_vif.c
@@ -30,3 +30,46 @@ void packet2_vif_add_micro_program(packet2_t *packet2, u32 dest, u32 *start, u32
         dest += curr_count;
     }
 }
+
+u32 packet2_vif_close_unpack_auto(packet2_t *packet2, u32 wl, u32 cl)
+{
+    assert(packet2->vif_code_opened_at != NULL);               // There is open UNPACK/DIRECT.
+    assert(((u32)packet2->next & 0x3) == 0);                   // Make sure we're u32 aligned
+    assert((packet2->vif_code_opened_at->cmd & 0x60) == 0x60); // It was UNPACK
+
+    u32 vn = (packet2->vif_code_opened_at->cmd & 0xC) >> 2;
+    u32 vl = packet2->vif_code_opened_at->cmd & 0x3;
+
+    // "the goal here is to find the num field of the open unpack, which is the number of
+    // qwords ACTUALLY WRITTEN to vu memory (it does not count quads that are skipped in
+    // "skipping write" mode.)  But first forget about skipping/filling writes and compute the number
+    // of qwords that the data in this packet will expand to."
+    u32 bytes_count = (u32)packet2->next - (u32)packet2->vif_code_opened_at - 4;
+    u32 block_bytes_count = 4 >> vl;
+    u32 quad_blocks_count = vn + 1;
+
+    // "make sure that the data length is a multiple of 8, 16, or 32 bits, whichever is appropriate"
+    assert((bytes_count & (block_bytes_count - 1)) == 0);
+    u32 quads_count = (bytes_count / block_bytes_count) / quad_blocks_count;
+
+    // "We have the number of quads our data will directly expand to, so now we need to account for
+    // skipping/filling write modes.""
+
+    // "skipping write is easy -- we are already done"
+
+    // "filling write: now we get ambiguous -- what to do when quads_count == CL in the last
+    // block? I will say that in this case the vif should still do the full wl length block, filling
+    // with internal registers. If you want different behavior call packet2_vif_close_unpack_manual
+    // with a num field you've computed yourself"
+    if (cl < wl)
+    {
+        u32 wl_blocks_count = (quads_count / cl);
+        u32 last_block_quads = quads_count - wl_blocks_count * cl;
+        if (last_block_quads == cl)
+            last_block_quads = wl;
+        quads_count = wl_blocks_count * wl + last_block_quads;
+    }
+
+    packet2_vif_close_unpack_manual(packet2, quads_count);
+    return quads_count;
+}


### PR DESCRIPTION
Hi.

This is the continuation of PR #155 

@rickgaiser 
+ improvements on libpacket2
+ fixes for GCC11 compatibility

@h4570
+ libpacket2: removed `vif_added_bytes`
+ libpacket2: refactored `packet2_*_close_unpack_*`

Tested on hardware & PCSX2

Thanks!