### PR TITLE
Improve as_reg_compat.h and gcc10 compatibility

### DIFF
--- a/common/include/as_reg_compat.h
+++ b/common/include/as_reg_compat.h
@@ -10,45 +10,80 @@
 
 /**
  * @file
- * Header used for compatibility from binutils 2.9 and 2.14
+ * Header used to force register names to a specific ABI
  */
 
 #ifndef __AS_REG_COMPAT_H__
 #define __AS_REG_COMPAT_H__
 
-/* register defines for the GNU assembler */
+#ifdef _IOP
+#define ABI_EABI64
+#endif
 
-#define zero    0
-#define at      1
-#define v0      2
-#define v1      3
-#define a0      4
-#define a1      5
-#define a2      6
-#define a3      7
-#define t0      8
-#define t1      9
-#define t2      10
-#define t3      11
-#define t4      12
-#define t5      13
-#define t6      14
-#define t7      15
-#define s0      16
-#define s1      17
-#define s2      18
-#define s3      19
-#define s4      20
-#define s5      21
-#define s6      22
-#define s7      23
-#define t8      24
-#define t9      25
-#define k0      26
-#define k1      27
-#define gp      28
-#define sp      29
-#define fp      30
-#define ra      31
+#if !defined(ABI_EABI64) && !defined(ABI_N32)
+  // No ABI defined
+  #error "Must define ABI_EABI64 or ABI_N32"
+#endif
+
+#if defined(ABI_EABI64) && defined(ABI_N32)
+  // Both ABI's defined
+  #error "Must define ABI_EABI64 or ABI_N32"
+#endif
+
+#define zero     0 // Hardware zero
+#define at       1 // Assembler temporary   Caller-saved
+#define v0       2 // Function results      Caller-saved
+#define v1       3 // Function results      Caller-saved
+#define a0       4 // Subprogram arguments  Caller-saved
+#define a1       5 // Subprogram arguments  Caller-saved
+#define a2       6 // Subprogram arguments  Caller-saved
+#define a3       7 // Subprogram arguments  Caller-saved
+
+#ifdef ABI_EABI64
+#define a4      INVALID_REG
+#define a5      INVALID_REG
+#define a6      INVALID_REG
+#define a7      INVALID_REG
+#define t0       8 // Temporaries           Caller-saved <- watch out!
+#define t1       9 // Temporaries           Caller-saved <- watch out!
+#define t2      10 // Temporaries           Caller-saved <- watch out!
+#define t3      11 // Temporaries           Caller-saved <- watch out!
+#define t4      12 // Temporaries           Caller-saved
+#define t5      13 // Temporaries           Caller-saved
+#define t6      14 // Temporaries           Caller-saved
+#define t7      15 // Temporaries           Caller-saved
+#endif
+
+#ifdef ABI_N32
+#define a4       8 // Subprogram arguments  Caller-saved
+#define a5       9 // Subprogram arguments  Caller-saved
+#define a6      10 // Subprogram arguments  Caller-saved
+#define a7      11 // Subprogram arguments  Caller-saved
+#define t0      12 // Temporaries           Caller-saved <- watch out!
+#define t1      13 // Temporaries           Caller-saved <- watch out!
+#define t2      14 // Temporaries           Caller-saved <- watch out!
+#define t3      15 // Temporaries           Caller-saved <- watch out!
+#define t4      INVALID_REG
+#define t5      INVALID_REG
+#define t6      INVALID_REG
+#define t7      INVALID_REG
+#endif
+
+#define s0      16 // Saved                 Callee-saved
+#define s1      17 // Saved                 Callee-saved
+#define s2      18 // Saved                 Callee-saved
+#define s3      19 // Saved                 Callee-saved
+#define s4      20 // Saved                 Callee-saved
+#define s5      21 // Saved                 Callee-saved
+#define s6      22 // Saved                 Callee-saved
+#define s7      23 // Saved                 Callee-saved
+#define t8      24 // Temporary             Caller-saved
+#define t9      25 // Temporary             Caller-saved
+#define k0      26 // Reserved for kernel
+#define k1      27 // Reserved for kernel
+#define gp      28 // Global pointer        Callee-saved
+#define sp      29 // Stack pointer         Callee-saved
+#define fp      30 // Frame pointer         Callee-saved
+#define ra      31 // Return address        Caller-saved
 
 #endif /* __AS_REG_COMPAT_H__ */

--- a/ee/debug/src/hwbp.S
+++ b/ee/debug/src/hwbp.S
@@ -10,6 +10,7 @@
 # Hardware breakpoint functions
 #
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
 #include "as_reg_compat.h"
 
 	.text

--- a/ee/eedebug/src/ee_dbg_low.S
+++ b/ee/eedebug/src/ee_dbg_low.S
@@ -17,6 +17,9 @@
 #include <ee_cop0_defs.h>
 #include "eedebug_defs.h"
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .text
 
 .set push

--- a/ee/eedebug/src/ee_exceptions.S
+++ b/ee/eedebug/src/ee_exceptions.S
@@ -42,17 +42,10 @@ _ee_save_frame:
                         sq          $t1,   0x090($s0)
                         sq          $t2,   0x0A0($s0)
                         sq          $t3,   0x0B0($s0)
-.ifdef .gasversion.
-                        sq          $a4,   0x0C0($s0)
-                        sq          $a5,   0x0D0($s0)
-                        sq          $a6,   0x0E0($s0)
-                        sq          $a7,   0x0F0($s0)
-.else
                         sq          $t4,   0x0C0($s0)
                         sq          $t5,   0x0D0($s0)
                         sq          $t6,   0x0E0($s0)
                         sq          $t7,   0x0F0($s0)
-.endif
 #                        sq          $s0,   0x100($s0) # s0 already saved
                         sq          $s1,   0x110($s0)
                         sq          $s2,   0x120($s0)
@@ -150,17 +143,10 @@ _ee_load_frame:
                         lq          $t1,   0x090($s0)
                         lq          $t2,   0x0A0($s0)
                         lq          $t3,   0x0B0($s0)
-.ifdef .gasversion.
-                        lq          $a4,   0x0C0($s0)
-                        lq          $a5,   0x0D0($s0)
-                        lq          $a6,   0x0E0($s0)
-                        lq          $a7,   0x0F0($s0)
-.else
                         lq          $t4,   0x0C0($s0)
                         lq          $t5,   0x0D0($s0)
                         lq          $t6,   0x0E0($s0)
                         lq          $t7,   0x0F0($s0)
-.endif
 #                        lq          $s0,   0x100($s0)
                         lq          $s1,   0x110($s0)
                         lq          $s2,   0x120($s0)

--- a/ee/eedebug/src/ee_exceptions.S
+++ b/ee/eedebug/src/ee_exceptions.S
@@ -17,6 +17,9 @@
 #include <ee_cop0_defs.h>
 #include "eedebug_defs.h"
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .text
 
 .set push

--- a/ee/mpeg/src/libmpeg_core.s
+++ b/ee/mpeg/src/libmpeg_core.s
@@ -6,6 +6,9 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .set noreorder
 .set nomacro
 .set noat

--- a/ee/rpc/cdvd/src/libcdvd.c
+++ b/ee/rpc/cdvd/src/libcdvd.c
@@ -120,8 +120,6 @@ extern u32 searchFileRecvBuff;
 #ifdef F_sceCdInit
 s32 sceCdInit(s32 mode)
 {
-	int i;
-
 	if (_CdSyncS(1))
 		return 0;
 	SifInitRpc(0);
@@ -139,8 +137,7 @@ s32 sceCdInit(s32 mode)
 		} else if (clientInit.server != 0)
 			break;
 
-		i = 0x10000;
-		while (i--);
+		nopdelay();
 	}
 
 	bindInit = 0;
@@ -183,8 +180,6 @@ u32 sceCdPosToInt(sceCdlLOCCD * p)
 #ifdef F_sceCdSearchFile
 s32 sceCdSearchFile(sceCdlFILE * file, const char *name)
 {
-	int i;
-
 	_CdSemaInit();
 	if (PollSema(nCmdSemaId) != nCmdSemaId)
 		return 0;
@@ -204,8 +199,7 @@ s32 sceCdSearchFile(sceCdlFILE * file, const char *name)
 			if (clientSearchFile.server != 0)
 				break;
 
-			i = 0x10000;
-			while (i--);
+			nopdelay();
 		}
 		bindSearchFile = 0;
 	}
@@ -243,8 +237,6 @@ s32 sceCdSearchFile(sceCdlFILE * file, const char *name)
 #ifdef F_sceCdDiskReady
 s32 sceCdDiskReady(s32 mode)
 {
-	int i;
-
 	if (CdDebug > 0)
 		printf("DiskReady 0\n");
 
@@ -266,8 +258,7 @@ s32 sceCdDiskReady(s32 mode)
 			if (clientDiskReady.server != 0)
 				break;
 
-			i = 0x10000;
-			while (i--);
+			nopdelay();
 		}
 	}
 	bindDiskReady = 0;

--- a/ee/rpc/cdvd/src/ncmd.c
+++ b/ee/rpc/cdvd/src/ncmd.c
@@ -786,7 +786,6 @@ int sceCdSync(int mode)
 #ifdef F__CdCheckNCmd
 int _CdCheckNCmd(int cmd)
 {
-	int i;
 	_CdSemaInit();
 	if (PollSema(nCmdSemaId) != nCmdSemaId) {
 		if (CdDebug > 0)
@@ -814,9 +813,7 @@ int _CdCheckNCmd(int cmd)
 		if (clientNCmd.server != 0)
 			break;
 
-		i = 0x10000;
-		while (i--)
-			;
+		nopdelay();
 	}
 
 	bindNCmd = 0;

--- a/ee/rpc/cdvd/src/scmd.c
+++ b/ee/rpc/cdvd/src/scmd.c
@@ -441,7 +441,6 @@ int sceCdChangeThreadPriority(int priority)
 #ifdef F__CdCheckSCmd
 int _CdCheckSCmd(int cur_cmd)
 {
-	int i;
 	_CdSemaInit();
 	if (PollSema(sCmdSemaId) != sCmdSemaId) {
 		if (CdDebug > 0)
@@ -466,9 +465,7 @@ int _CdCheckSCmd(int cur_cmd)
 		if (clientSCmd.server != 0)
 			break;
 
-		i = 0x10000;
-		while (i--)
-			;
+		nopdelay();
 	}
 
 	bindSCmd = 0;

--- a/ee/rpc/multitap/src/libmtap.c
+++ b/ee/rpc/multitap/src/libmtap.c
@@ -33,8 +33,6 @@ static int mtapInited = 0;
 
 int mtapInit(void)
 {
-	int i;
-
 	if(mtapInited) return -1;
 
 	while(1)
@@ -42,8 +40,7 @@ int mtapInit(void)
 		if (SifBindRpc(&clientPortOpen, MTAPSERV_PORT_OPEN, 0) < 0) return -1;
  		if (clientPortOpen.server != 0) break;
 
-    	i = 0x10000;
-    	while(i--);
+	nopdelay();
 	}
 
 	while(1)
@@ -51,8 +48,7 @@ int mtapInit(void)
 		if (SifBindRpc(&clientPortClose, MTAPSERV_PORT_CLOSE, 0) < 0) return -1;
  		if (clientPortClose.server != 0) break;
 
-    	i = 0x10000;
-    	while(i--);
+	nopdelay();
 	}
 
 	while(1)
@@ -60,8 +56,7 @@ int mtapInit(void)
 		if (SifBindRpc(&clientGetConnection, MTAPSERV_GET_CONNECTION, 0) < 0) return -1;
  		if (clientGetConnection.server != 0) break;
 
-    	i = 0x10000;
-    	while(i--);
+	nopdelay();
 	}
 
 	mtapInited = 1;

--- a/ee/rpc/ps2snd/src/ps2snd.c
+++ b/ee/rpc/ps2snd/src/ps2snd.c
@@ -36,7 +36,7 @@ int sceSdInit(int flag)
  			if (sd_client.server != NULL)
 				break;
 
-			for(int i=0;i<0x10000;i++);
+			nopdelay();
 		}
 
 	}

--- a/ee/rpc/tcpips/src/ps2ipc.c
+++ b/ee/rpc/tcpips/src/ps2ipc.c
@@ -60,7 +60,6 @@ const ip_addr_t ip_addr_any = IPADDR4_INIT(IPADDR_ANY);
 int ps2ip_init(void)
 {
 	ee_sema_t sema;
-	int i;
 
 	while(1)
 	{
@@ -70,7 +69,7 @@ int ps2ip_init(void)
 		if(_ps2ip.server != NULL)
 			break;
 
-		for(i = 0x10000; i > 0; i--);
+		nopdelay();
 	}
 
 	sema.init_count = 1;


### PR DESCRIPTION
It can be difficult to find out the register names used by ABI EABI64 and N32. The file as_reg_compat.h should now show crearly the differences, and can also be used to force a .S file to use a specific ABI.

Also all SifBindRpc loops have been made equal, working for both the old and new toolchain. The delay loop with sinple integer counters where optimized by gcc10.