### PR TITLE
Improve docker tagging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   repository_dispatch:
     types: [run_build]
 
@@ -14,13 +16,34 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: docker/build-push-action@v1
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.GITHUB_REPOSITORY }}
-        tags: latest
-        build_args: BASE_DOCKER_IMAGE=${{ github.repository_owner }}/ps2toolchain:latest
+    
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ github.repository }}:${{ env.DOCKER_TAG }}
+        build-args: |
+          BASE_DOCKER_IMAGE=${{ github.repository_owner }}/ps2toolchain:${{ env.DOCKER_TAG }}
     
     - name: Send Compile action
       run: |


### PR DESCRIPTION
This PR will automatically create a specific docker tag, if a git tag is created in the repo if the tag starts by v.
So for instance, if we create a tag in the repo as v1.2.0 this will create a new docker layer image named ps2dev/ps2sdk:v1.2.0

If not, as usual, every single change will create a tag named ps2dev/ps2sdk:latest

Thanks