### PR TITLE
GCC10 required updates

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Compile project
       run: |
         make clean all install
-        ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/ee/lib/libps2sdkc.a"
-        ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/ee/lib/libkernel.a"
+        ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a"
+        ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"
         
     - name: Compile samples
       if: ${{ success() }}

--- a/Defs.make
+++ b/Defs.make
@@ -14,7 +14,7 @@
 # Definitions for the EE toolchain.
 #
 
-EE_TOOL_PREFIX ?= ee-
+EE_TOOL_PREFIX ?= mips64r5900el-ps2-elf-
 EE_CC = $(EE_TOOL_PREFIX)gcc
 EE_CXX = $(EE_TOOL_PREFIX)g++
 EE_AS = $(EE_TOOL_PREFIX)as

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY . /src
 
 RUN apk add build-base
 RUN cd /src && make all install clean
-RUN ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/ee/lib/libps2sdkc.a"
-RUN ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/ee/lib/libkernel.a"
+RUN ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a"
+RUN ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"
 
 # Second stage of Dockerfile
 FROM alpine:latest  

--- a/common/sbus/src/sif2cmd.c
+++ b/common/sbus/src/sif2cmd.c
@@ -28,8 +28,6 @@ This file contains all common code for both EE and IOP SIF management.
 #define SIF2_XFER_RECV  (0)
 #define SIF2_XFER_SEND  (1)
 
-extern int sio_printf(const char *format, ...);
-
 static u32 _sif2_req_type = 0;
 static u32 _sif2_req_addr = 0;
 static u32 _sif2_req_size = 0;
@@ -107,7 +105,7 @@ void _sif2_irq_exec(void)
     else
     {
 #ifdef _EE
-        sio_printf("unknown command: %d!\n", cid);
+        //printf("unknown command: %d!\n", cid);
 #endif
     }
 }

--- a/common/tcpip/lwip-2.0.0/src/core/pbuf.c
+++ b/common/tcpip/lwip-2.0.0/src/core/pbuf.c
@@ -1234,7 +1234,7 @@ struct pbuf*
 pbuf_coalesce(struct pbuf *p, pbuf_layer layer)
 {
   struct pbuf *q;
-  err_t err;
+  //err_t err;
   if (p->next == NULL) {
     return p;
   }
@@ -1243,8 +1243,8 @@ pbuf_coalesce(struct pbuf *p, pbuf_layer layer)
     /* @todo: what do we do now? */
     return p;
   }
-  err = pbuf_copy(q, p);
-  LWIP_ASSERT("pbuf_copy failed", err == ERR_OK);
+  /*err =*/ pbuf_copy(q, p);
+  //LWIP_ASSERT("pbuf_copy failed", err == ERR_OK);
   pbuf_free(p);
   return q;
 }

--- a/ee/Makefile
+++ b/ee/Makefile
@@ -8,7 +8,7 @@
 
 SUBDIRS = erl kernel kernel-nopatch libc rpc debug \
 	eedebug sbv dma graph math3d \
-	packet packet2 draw erl-loader mpeg libgs \
+	packet packet2 draw libgs \
 	libvux font input inputx network iopreboot \
 	elf-loader
 

--- a/ee/debug/src/callstack.c
+++ b/ee/debug/src/callstack.c
@@ -199,36 +199,36 @@ void ps2GetStackTrace(unsigned int* results,int max)
         }
         else if (inst == RETURN)
           ra_limit = ra + 2;
-          ra++;
+        ra++;
       }
 
       if (sp_adjust == 0 && (found_const_upper || found_const_lower))
         sp_adjust = (const_upper << 16) | const_lower;
-        rc->raOffset = ra_offset;
-        rc->spAdjust = sp_adjust;
-      }
-      /* if something went wrong, punt */
-      if (rc->spAdjust <= 0)
-      {
-        *results++ = 0;
-        break;
-      }
+      rc->raOffset = ra_offset;
+      rc->spAdjust = sp_adjust;
+    }
+    /* if something went wrong, punt */
+    if (rc->spAdjust <= 0)
+    {
+      *results++ = 0;
+      break;
+    }
 
-      ra = (unsigned int *) sp[rc->raOffset>>2];
-      sp += rc->spAdjust >> 2;
+    ra = (unsigned int *) sp[rc->raOffset>>2];
+    sp += rc->spAdjust >> 2;
 
-      if (ra == 0)
-      {
-        *results++ = 0;
-        break;
-      }
+    if (ra == 0)
+    {
+      *results++ = 0;
+      break;
+    }
 
-      *results++ = ((unsigned int) ra) - 8;
-      if (ra[-2] == mainCall)
-      {
-        *results++ = 0;
-        break;
-      }
+    *results++ = ((unsigned int) ra) - 8;
+    if (ra[-2] == mainCall)
+    {
+      *results++ = 0;
+      break;
+    }
     max--;
   }
 }

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -83,7 +83,7 @@ GLUE_OBJS += SyncDCache.o iSyncDCache.o InvalidDCache.o iInvalidDCache.o
 ### SIO objects
 
 SIO_OBJS = sio_init.o sio_putc.o sio_getc.o sio_write.o sio_read.o sio_puts.o \
-	sio_gets.o sio_getc_block.o sio_flush.o sio_putsn.o sio_printf.o
+	sio_gets.o sio_getc_block.o sio_flush.o sio_putsn.o
 
 ### Config objects
 

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -155,7 +155,7 @@ KERNEL_OBJS = ResetEE.o SetGsCrt.o $(EXEC_SYSCALLS) \
 	SifGetReg.o $(EXECOSD_SYSCALL) Deci2Call.o PSMode.o MachineType.o GetMemorySize.o _GetGsDxDyOffset.o \
 	_InitTLB.o SetMemoryMode.o \
 	SifWriteBackDCache.o _SyncDCache.o _InvalidDCache.o __errno.o errno.o \
-	strncpy.o strlen.o memcpy.o memset.o __syscall.o
+	strncpy.o strlen.o memcpy.o memset.o __syscall.o GPfuncs.o
 
 EE_OBJS = $(KERNEL_OBJS) $(SIFCMD_OBJS) $(SIFRPC_OBJS) $(FILEIO_OBJS) \
 	$(LOADFILE_OBJS) $(IOPHEAP_OBJS) $(IOPCONTROL_OBJS) $(CONFIG_OBJS) \

--- a/ee/kernel/include/kernel.h
+++ b/ee/kernel/include/kernel.h
@@ -49,42 +49,13 @@
 
 #define ALIGNED(x) __attribute__((aligned((x))))
 
-// GP macros
-static __inline__ void *ChangeGP(void *gp)
-{
-	void *OldGP;
-
-	__asm__ volatile(	"move %0, $gp\n"
-				"move $gp, %1"
-				: "=&r"(OldGP)
-				: "r"(gp)
-				: "gp", "memory");
-
-	return OldGP;
-}
-
-static __inline__ void SetGP(void *gp)
-{
-	__asm__ volatile(	"move $gp, %0"
-				:
-				: "r"(gp)
-				: "gp", "memory");
-}
+// GP functions
+void *ChangeGP(void *gp);
+void SetGP(void *gp);
+void *GetGP(void);
 
 extern void *_gp;
 #define SetModuleGP()	ChangeGP(&_gp)
-
-static __inline__ void *GetGP(void)
-{
-	void *gp;
-
-	__asm__ volatile(	"move %0, $gp"
-				: "=r"(gp)
-				:
-				: "memory");
-
-	return gp;
-}
 
 /** Special thread ID for referring to the running thread.
     Unlike the IOP kernel, this is only supported by ReferThreadStatus() and ChangeThreadPriority().

--- a/ee/kernel/include/sio.h
+++ b/ee/kernel/include/sio.h
@@ -118,9 +118,6 @@ char *sio_gets(char *str);
 /** Flushes the input buffer. */
 void sio_flush(void);
 
-/** standard printf function to sio */
-int sio_printf(const char *format, ...);
-
 #ifdef __cplusplus
 }
 #endif

--- a/ee/kernel/src/kernel.S
+++ b/ee/kernel/src/kernel.S
@@ -735,6 +735,32 @@ SYSCALL(_InitTLB)
 SYSCALL(SetMemoryMode)
 #endif
 
+#ifdef F_GPfuncs
+	.text
+	.align	2
+.globl ChangeGP
+.ent ChangeGP
+ChangeGP:
+	move	$v0, $gp
+	jr	$ra
+	move	$gp, $a0
+.end ChangeGP
+
+.globl SetGP
+.ent SetGP
+SetGP:
+	jr	$ra
+	move	$gp, $a0
+.end SetGP
+
+.globl GetGP
+.ent GetGP
+GetGP:
+	jr	$ra
+	move	$v0, $gp
+.end GetGP
+#endif
+
 #ifdef F_SifWriteBackDCache
 
 	.globl	SifWriteBackDCache

--- a/ee/kernel/src/osdsrc/Makefile
+++ b/ee/kernel/src/osdsrc/Makefile
@@ -15,7 +15,7 @@ EE_OSDSRC_ELF := $(EE_OSDSRC_ELF:%=$(EE_BIN_DIR)%)
 EE_OBJS = osdsrc.o osd.o ExecPS2.o
 
 EE_INCS += -I$(PS2SDKSRC)/ee/rpc/cdvd/include
-EE_CFLAGS += -mno-gpopt -DREUSE_EXECPS2
+EE_CFLAGS += -mno-gpopt -DREUSE_EXECPS2 -fno-tree-loop-distribute-patterns
 
 $(EE_OSDSRC_BIN): $(EE_OSDSRC_ELF)
 	$(EE_OBJCOPY) -Obinary $< $@

--- a/ee/kernel/src/sio.c
+++ b/ee/kernel/src/sio.c
@@ -185,21 +185,3 @@ void sio_flush()
 	_lb(SIO_RXFIFO);
 }
 #endif
-
-#ifdef F_sio_printf
-#define SIO_PRINTF_STR_MAX 4096
-int sio_printf(const char *format, ...)
-{
-	static char buf[SIO_PRINTF_STR_MAX];
-	va_list args;
-	int size;
-
-	va_start(args, format);
-	size = vsnprintf(buf, PS2LIB_STR_MAX, format, args);
-	va_end(args);
-
-	sio_write(buf, size);
-
-	return size;
-}
-#endif

--- a/ee/kernel/src/srcfile/Makefile
+++ b/ee/kernel/src/srcfile/Makefile
@@ -14,7 +14,7 @@ EE_SRCFILE_ELF = srcfile.elf
 EE_SRCFILE_ELF := $(EE_SRCFILE_ELF:%=$(EE_BIN_DIR)%)
 EE_OBJS = srcfile.o alarm.o dispatch.o
 
-EE_CFLAGS += -mno-gpopt
+EE_CFLAGS += -mno-gpopt -fno-tree-loop-distribute-patterns
 
 $(EE_SRCFILE_BIN): $(EE_SRCFILE_ELF)
 	$(EE_OBJCOPY) -Obinary $< $@

--- a/ee/kernel/src/srcfile/src/dispatch.s
+++ b/ee/kernel/src/srcfile/src/dispatch.s
@@ -17,7 +17,7 @@ InvokeUserModeCallback:
 	daddu $v1, $zero, $a1
 	daddu $a0, $zero, $a2
 	daddu $a1, $zero, $a3
-	daddu $a2, $zero, $t0
+	daddu $a2, $zero, $a4
 	mfc0 $k0, $12
 	ori $k0, $k0, 0x12
 	mtc0 $k0, $12

--- a/ee/kernel/src/srcfile/src/dispatch.s
+++ b/ee/kernel/src/srcfile/src/dispatch.s
@@ -42,6 +42,28 @@ ResumeIntrDispatch:
 	lw $sp, %lo(dispatch_sp)($k0)
 .end ResumeIntrDispatch
 
+.globl ChangeGP
+.ent ChangeGP
+ChangeGP:
+	move	$v0, $gp
+	jr	$ra
+	move	$gp, $a0
+.end ChangeGP
+
+.globl SetGP
+.ent SetGP
+SetGP:
+	jr	$ra
+	move	$gp, $a0
+.end SetGP
+
+.globl GetGP
+.ent GetGP
+GetGP:
+	jr	$ra
+	move	$v0, $gp
+.end GetGP
+
 .data
 dispatch_ra: .quad 0
 dispatch_sp: .quad 0

--- a/ee/libc/include/ps2sdkapi.h
+++ b/ee/libc/include/ps2sdkapi.h
@@ -20,7 +20,7 @@ extern int (*_ps2sdk_close)(int);
 extern int (*_ps2sdk_open)(const char*, int, ...);
 extern int (*_ps2sdk_read)(int, void*, int);
 extern int (*_ps2sdk_lseek)(int, int, int);
-extern long (*_ps2sdk_lseek64)(int, long, int);
+extern int64_t (*_ps2sdk_lseek64)(int, int64_t, int);
 extern int (*_ps2sdk_write)(int, const void*, int);
 extern int (*_ps2sdk_ioctl)(int, int, void*);
 extern int (*_ps2sdk_remove)(const char*);

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -27,6 +27,7 @@
 // - compiler (gcc)
 // - libc (newlib)
 #include <stdint.h>
+#include <limits.h>
 #include <inttypes.h>
 #include <tamtypes.h>
 
@@ -205,27 +206,28 @@ int (*_ps2sdk_closedir)(DIR *dir) = fioClosedirHelper;
 #ifndef LONG_MAX
 	#error "LONG_MAX not defined"
 #endif
-#if LONG_MAX == 0x7fffffffL
-	#error "LONG_MAX == 0x7fffffffL"
-#endif
-#if LONG_MAX != 9223372036854775807L
-	#error "LONG_MAX != 9223372036854775807L"
+#if LONG_MAX != 0x7fffffffL
+	#error "LONG_MAX != 0x7fffffffL"
 #endif
 
 #define ct_assert(e) {enum { ct_assert_value = 1/(!!(e)) };}
 void compile_time_check() {
-	// Compiler
+	// Compiler (ABI n32)
 	ct_assert(sizeof(unsigned char)==1);
 	ct_assert(sizeof(unsigned short)==2);
 	ct_assert(sizeof(unsigned int)==4);
-	ct_assert(sizeof(unsigned long)==8);
+	ct_assert(sizeof(unsigned long)==4);
+	ct_assert(sizeof(unsigned long long)==8);
 	ct_assert(sizeof(unsigned int __attribute__(( mode(TI) )))==16);
+	ct_assert(sizeof(void *)==4);
+
 	// Defined in tamtypes.h (ps2sdk)
 	ct_assert(sizeof(u8)==1);
 	ct_assert(sizeof(u16)==2);
 	ct_assert(sizeof(u32)==4);
 	ct_assert(sizeof(u64)==8);
 	ct_assert(sizeof(u128)==16);
+
 	// Defined in inttypes.h/stdint.h (newlib)
 	ct_assert(sizeof(uint8_t)==1);
 	ct_assert(sizeof(uint16_t)==2);

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -432,7 +432,7 @@ int closedir(DIR *dir)
     return _ps2sdk_closedir(dir);
 }
 
-int isatty(int fd) {
+int _isatty(int fd) {
 	struct stat buf;
 
 	if (_fstat (fd, &buf) < 0) {

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -157,16 +157,15 @@ static void fioRewinddirHelper(DIR *dir)
 
 static int fioClosedirHelper(DIR *dir)
 {
-	int rv;
-
 	if(dir == NULL) {
 		//errno = EBADF;
 		return -1;
 	}
 
-	rv = fioDclose(dir->dd_fd); // Check return value?
-        free(dir->dd_buf);
-        free(dir);
+	fioDclose(dir->dd_fd); // Check return value?
+	free(dir->dd_buf);
+	free(dir);
+
 	return 0;
 }
 
@@ -174,7 +173,7 @@ int (*_ps2sdk_close)(int) = fioClose;
 int (*_ps2sdk_open)(const char*, int, ...) = (void *)fioOpen;
 int (*_ps2sdk_read)(int, void*, int) = fioRead;
 int (*_ps2sdk_lseek)(int, int, int) = fioLseek;
-long (*_ps2sdk_lseek64)(int, long, int) = NULL;
+int64_t (*_ps2sdk_lseek64)(int, int64_t, int) = NULL;
 int (*_ps2sdk_write)(int, const void*, int) = fioWrite;
 int (*_ps2sdk_ioctl)(int, int, void*) = fioIoctl;
 int (*_ps2sdk_remove)(const char*) = fioRemove;

--- a/ee/libc/src/timezone.c
+++ b/ee/libc/src/timezone.c
@@ -20,7 +20,7 @@
 #define OSD_CONFIG_NO_LIBCDVD
 #include "osd_config.h"
 
-static char _ps2sdk_tzname[11];
+static char _ps2sdk_tzname[15];
 
 __attribute__((weak))
 void _ps2sdk_timezone_update()

--- a/ee/libc/src/timezone.c
+++ b/ee/libc/src/timezone.c
@@ -14,6 +14,7 @@
  */
 
 #include <time.h>
+#include <sys/_tz_structs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #define OSD_CONFIG_NO_LIBCDVD

--- a/ee/network/tcpip/src/include/arch/cc.h
+++ b/ee/network/tcpip/src/include/arch/cc.h
@@ -4,8 +4,6 @@
 #include <errno.h>
 #include <stddef.h>
 
-#define BYTE_ORDER LITTLE_ENDIAN
-
 typedef unsigned char		u8_t;
 typedef signed char		s8_t;
 typedef unsigned short int	u16_t;

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -81,6 +81,23 @@ static mode_t iox_to_posix_mode(unsigned int ps2mode)
         return posixmode;
 }
 
+static void fill_stat(struct stat *stat, const iox_stat_t *fiostat)
+{
+        stat->st_dev = 0;
+        stat->st_ino = 0;
+        stat->st_mode = iox_to_posix_mode(fiostat->mode);
+        stat->st_nlink = 0;
+        stat->st_uid = 0;
+        stat->st_gid = 0;
+        stat->st_rdev = 0;
+        stat->st_size = ((off_t)fiostat->hisize << 32) | (off_t)fiostat->size;
+        stat->st_atime = io_to_posix_time(fiostat->atime);
+        stat->st_mtime = io_to_posix_time(fiostat->mtime);
+        stat->st_ctime = io_to_posix_time(fiostat->ctime);
+        stat->st_blksize = 16*1024;
+        stat->st_blocks = stat->st_size / 512;
+}
+
 static int fileXioGetstatHelper(const char *path, struct stat *buf) {
         iox_stat_t fiostat;
 
@@ -89,19 +106,7 @@ static int fileXioGetstatHelper(const char *path, struct stat *buf) {
                 return -1;
         }
 
-        buf->st_dev = 0;
-        buf->st_ino = 0;
-        buf->st_mode = iox_to_posix_mode(fiostat.mode);
-        buf->st_nlink = 0;
-        buf->st_uid = 0;
-        buf->st_gid = 0;
-        buf->st_rdev = 0;
-        buf->st_size = ((off_t)fiostat.hisize << 32) | (off_t)fiostat.size;
-        buf->st_atime = io_to_posix_time(fiostat.atime);
-        buf->st_mtime = io_to_posix_time(fiostat.mtime);
-        buf->st_ctime = io_to_posix_time(fiostat.ctime);
-        buf->st_blksize = 16*1024;
-        buf->st_blocks = buf->st_size / 512;
+        fill_stat(buf, &fiostat);
 
         return 0;
 }
@@ -120,11 +125,7 @@ static DIR *fileXioOpendirHelper(const char *path)
 
 	dir = malloc(sizeof(DIR));
         dir->dd_fd = dd;
-        dir->dd_loc = 0;
-        dir->dd_size = 0;
-        dir->dd_buf = malloc(sizeof(struct dirent) + 255);
-        dir->dd_len = 0;
-        dir->dd_seek = 0;
+        dir->dd_buf = malloc(sizeof(struct dirent));
 
 	return dir;
 }
@@ -147,9 +148,7 @@ static struct dirent *fileXioReaddirHelper(DIR *dir)
 		return NULL;
 	}
 
-        de->d_ino = 0;
-        de->d_off = 0;
-        de->d_reclen = 0;
+	fill_stat(&de->d_stat, &fiode.stat);
 	strncpy(de->d_name, fiode.name, 255);
 	de->d_name[255] = 0;
 

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -163,14 +163,12 @@ static void fileXioRewinddirHelper(DIR *dir)
 
 static int fileXioClosedirHelper(DIR *dir)
 {
-	int rv;
-
 	if(dir == NULL) {
 		// FIXME: set errno
 		return -1;
 	}
 
-	rv = fileXioDclose(dir->dd_fd); // Check return value?
+	fileXioDclose(dir->dd_fd); // Check return value?
 	free(dir->dd_buf);
 	free(dir);
 	return 0;

--- a/ee/rpc/hdd/src/libhdd.c
+++ b/ee/rpc/hdd/src/libhdd.c
@@ -164,7 +164,7 @@ int hddGetFilesystemList(t_hddFilesystem hddFs[], int maxEntries)
 		}
 
 		memset(&hddFs[count], 0, sizeof(t_hddFilesystem));
-		sprintf(hddFs[count].filename, "hdd0:%s", dirEnt.name);
+		snprintf(hddFs[count].filename, 40, "hdd0:%.34s", dirEnt.name);
 
 		// Work out filesystem type
 		if((dirEnt.name[0] == '_') && (dirEnt.name[1] == '_'))

--- a/ee/startup/Makefile
+++ b/ee/startup/Makefile
@@ -6,12 +6,15 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = erl kernel kernel-nopatch libc rpc startup debug \
-	eedebug sbv dma graph math3d \
-	packet packet2 draw libgs \
-	libvux font input inputx network iopreboot \
-	elf-loader
+all:
 
 include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+include $(PS2SDKSRC)/ee/Rules.make
 include $(PS2SDKSRC)/ee/Rules.release
+
+clean:
+
+release:
+	$(ECHO) Installing $(EE_SRC_DIR)linkfile into $(PS2SDK)/ee/startup
+	cp -f $(EE_SRC_DIR)linkfile $(PS2SDK)/ee/startup
+

--- a/ee/startup/src/linkfile
+++ b/ee/startup/src/linkfile
@@ -1,0 +1,100 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Linkfile script for ee-ld
+*/
+
+ENTRY(_start);
+
+SECTIONS {
+	.text 0x00100000: {
+		_ftext = . ;
+		*(.text)
+		*(.text.*)
+		*(.gnu.linkonce.t*)
+		KEEP(*(.init))
+		KEEP(*(.fini))
+		QUAD(0)
+	}
+
+	PROVIDE(_etext = .);
+	PROVIDE(etext = .);
+
+	.reginfo : { *(.reginfo) }
+
+	/* Global/static constructors and deconstructors. */
+	.ctors ALIGN(16): {
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	}
+	.dtors ALIGN(16): {
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	}
+
+	/* Static data.  */
+	.rodata ALIGN(128): {
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
+	}
+
+	.data ALIGN(128): {
+		_fdata = . ;
+		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
+		SORT(CONSTRUCTORS)
+	}
+
+	.rdata ALIGN(128): { *(.rdata) }
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) }
+
+	_gp = ALIGN(128) + 0x7ff0;
+	.lit4 ALIGN(128): { *(.lit4) }
+	.lit8 ALIGN(128): { *(.lit8) }
+
+	.sdata ALIGN(128): {
+		*(.sdata)
+		*(.sdata.*)
+		*(.gnu.linkonce.s*)
+	}
+
+	_edata = .;
+	PROVIDE(edata = .);
+
+	/* Uninitialized data.  */
+	.sbss ALIGN(128) : {
+		_fbss = . ;
+		*(.sbss)
+		*(.sbss.*)
+		*(.gnu.linkonce.sb*)
+		*(.scommon)
+	}
+
+	.bss ALIGN(128) : {
+		*(.bss)
+		*(.bss.*)
+		*(.gnu.linkonce.b*)
+		*(COMMON)
+	}
+	_end_bss = .;
+
+	_end = . ;
+	PROVIDE(end = .);
+
+	/* Symbols needed by crt0.s.  */
+	PROVIDE(_heap_size = -1);
+	PROVIDE(_stack = -1);
+	PROVIDE(_stack_size = 128 * 1024);
+}

--- a/ee/startup/src/linkfile
+++ b/ee/startup/src/linkfile
@@ -12,6 +12,10 @@
 
 ENTRY(__start);
 
+PHDRS {
+  text PT_LOAD;
+}
+
 SECTIONS {
 	.text 0x00100000: {
 		_ftext = . ;
@@ -21,7 +25,7 @@ SECTIONS {
 		KEEP(*(.init))
 		KEEP(*(.fini))
 		QUAD(0)
-	}
+	} :text
 
 	PROVIDE(_etext = .);
 	PROVIDE(etext = .);

--- a/ee/startup/src/linkfile
+++ b/ee/startup/src/linkfile
@@ -10,7 +10,7 @@
 # Linkfile script for ee-ld
 */
 
-ENTRY(_start);
+ENTRY(__start);
 
 SECTIONS {
 	.text 0x00100000: {

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -43,7 +43,7 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
 $(EE_BIN): $(EE_OBJS)
-	$(EE_CXX) -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+	$(EE_CXX) -T$(PS2SDK)/ee/startup/linkfile -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_ERL): $(EE_OBJS)
 	$(EE_CC) -mno-crt0 -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -43,7 +43,7 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
 $(EE_BIN): $(EE_OBJS)
-	$(EE_CC) -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
+	$(EE_CC) -T$(PS2SDK)/ee/startup/linkfile -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_ERL): $(EE_OBJS)
 	$(EE_CC) -mno-crt0 -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d

--- a/samples/Makefile.pref_sample
+++ b/samples/Makefile.pref_sample
@@ -10,7 +10,7 @@
 # Change the settings, so they match yours         #
 ####################################################
 
-EE_PREFIX ?= ee-
+EE_PREFIX ?= mips64r5900el-ps2-elf-
 EE_CC = $(EE_PREFIX)gcc
 EE_CXX= $(EE_PREFIX)g++
 EE_AS = $(EE_PREFIX)as


### PR DESCRIPTION
This PR will update ps2sdk to be compatible with the new GCC10 toolchain for the EE. The current CI (using old toolchain) will fail, becouse not all of these changes are compatible with the old toolchain.

Mostly these are just compatibility fixes, but there are a few things that have been disabled:
- erl-loader: This has never been used as far as I know, and it's been broken for a long time
- mpeg: no-one will probably notice, but I think this should someday be made working with the new toolchain. I will create a github issue about this.
- sio_printf: a function that has been broken since the newlib port. For this I will also create a github issue.

By now the most important ps2 projects (ps2link, RA, OPL, uLE) are compatible with the gcc10 toolchain, so I think it's time to move towards using gcc10 as the default compiler for the EE on the PS2.