### PR TITLE
Fix assemby compilation

### DIFF
--- a/iop/debug/iopdebug/src/iop_dbg_low.S
+++ b/iop/debug/iopdebug/src/iop_dbg_low.S
@@ -16,6 +16,7 @@
 
 #include <iop_cop0_defs.h>
 #include "iopdebug_defs.h"
+#include "as_reg_compat.h"
 
 .set push
 .set noreorder

--- a/iop/debug/iopdebug/src/iop_exceptions.S
+++ b/iop/debug/iopdebug/src/iop_exceptions.S
@@ -16,6 +16,7 @@
 
 #include <iop_cop0_defs.h>
 #include "iopdebug_defs.h"
+#include "as_reg_compat.h"
 
 .set push
 .set noreorder


### PR DESCRIPTION
## Description
If we don't merge these changes, afer merging this one https://github.com/ps2dev/ps2toolchain-iop/pull/2 the `PS2SDK` compilation will fail. However, it can be merged before the `Binutils` PR.

What this PR is doing is importing a missing file in the files that use intrinsic IOP assembly for a proper register name use.


Thanks