### PR TITLE
iop: Add stdint.h

### DIFF
--- a/iop/kernel/include/stdint.h
+++ b/iop/kernel/include/stdint.h
@@ -1,0 +1,55 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * C99 integer types
+ */
+
+#ifndef __STDINT_H__
+#define __STDINT_H__
+
+typedef signed char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef signed char int_least8_t;
+typedef short int_least16_t;
+typedef long int_least32_t;
+typedef long long int_least64_t;
+
+typedef unsigned char uint_least8_t;
+typedef unsigned short uint_least16_t;
+typedef unsigned long uint_least32_t;
+typedef unsigned long long uint_least64_t;
+
+typedef signed char int_fast8_t;
+typedef long int_fast16_t;
+typedef long int_fast32_t;
+typedef long long int_fast64_t;
+
+typedef unsigned char uint_fast8_t;
+typedef unsigned long uint_fast16_t;
+typedef unsigned long uint_fast32_t;
+typedef unsigned long long uint_fast64_t;
+
+typedef long intptr_t;
+typedef unsigned long uintptr_t;
+
+typedef long long intmax_t;
+typedef unsigned long long uintmax_t;
+
+#endif /* __STDINT_H__ */


### PR DESCRIPTION
I noticed that we don't have an implementation of the C99 fixed-size integer types. I needed a few of them so I figured I'd add the rest and contribute them all.