### PR TITLE
Update ps2ip.h

### DIFF
--- a/ee/network/tcpip/include/ps2ip.h
+++ b/ee/network/tcpip/include/ps2ip.h
@@ -29,6 +29,7 @@ void ps2ipDeinit(void);
 void ps2ipSetHsyncTicksPerMSec(unsigned char ticks);
 
 /* From include/lwip/sockets.h:  */
+struct timeval *timeout;
 int lwip_accept(int s, struct sockaddr *addr, socklen_t *addrlen);
 int lwip_bind(int s, const struct sockaddr *name, socklen_t namelen);
 int lwip_shutdown(int s, int how);

--- a/ee/network/tcpip/include/ps2ip.h
+++ b/ee/network/tcpip/include/ps2ip.h
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <tcpip.h>
+#include <time.h>
 
 /** Initializes PS2IP. Specify a dummy address like "169.254.0.1" if DHCP is to be used, before enabling DHCP via ps2ip_setconfig(). */
 int ps2ipInit(struct ip4_addr *ip_address, struct ip4_addr *subnet_mask, struct ip4_addr *gateway);
@@ -29,7 +30,6 @@ void ps2ipDeinit(void);
 void ps2ipSetHsyncTicksPerMSec(unsigned char ticks);
 
 /* From include/lwip/sockets.h:  */
-struct timeval *timeout;
 int lwip_accept(int s, struct sockaddr *addr, socklen_t *addrlen);
 int lwip_bind(int s, const struct sockaddr *name, socklen_t namelen);
 int lwip_shutdown(int s, int how);


### PR DESCRIPTION
This fixes the following compiler warning:
"/usr/local/ps2dev/ps2sdk/ee/include/ps2ip.h:49: warning: `struct timeval' declared inside parameter list
/usr/local/ps2dev/ps2sdk/ee/include/ps2ip.h:49: warning: its scope is only this definition or declaration, which is probably not what you want"