### PR TITLE
Prepare makefiles for using newlib nano

### DIFF
--- a/ee/elf-loader/src/loader/Makefile
+++ b/ee/elf-loader/src/loader/Makefile
@@ -18,9 +18,13 @@ STACKADDR = 0x1720000
 STACKSIZE = 0x08000
 endif
 
+EE_CFLAGS += -fdata-sections -ffunction-sections
+
 LDPARAMS := -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 
 EE_LDFLAGS += -Wl,-Ttext -Wl,$(LOADADDR) -s $(LDPARAMS)
+EE_LDFLAGS += -s -Wl,--gc-sections
+EE_LDFLAGS += -nodefaultlibs -lm_nano -Wl,--start-group -lc_nano -lps2sdkc -lkernel -Wl,--end-group -lgcc
 
 EE_BIN = loader.elf
 

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -14,6 +14,15 @@
 #include <errno.h>
 
 //--------------------------------------------------------------
+// Redefinition of init/deinit libc:
+//--------------------------------------------------------------
+// DON'T REMOVE is for reducing binary size. 
+// These funtios are defined as weak in /libc/src/init.c
+//--------------------------------------------------------------
+   void _ps2sdk_libc_init() {}
+   void _ps2sdk_libc_deinit() {}
+
+//--------------------------------------------------------------
 //Start of function code:
 //--------------------------------------------------------------
 // Clear user memory

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -6,6 +6,27 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+# Helpers to make easy the use of lkernel-nopatch and newlib-nano
+NODEFAULTLIBS = 0
+LKERNEL = -lkernel
+ifeq ($(KERNEL_NOPATCH), 1)
+   NODEFAULTLIBS = 1
+   LKERNEL = -lkernel-nopatch
+endif
+
+LIBC = -lc
+LIBM = -lm
+ifeq ($(NEWLIB_NANO), 1)
+   NODEFAULTLIBS = 1
+   LIBC = -lc_nano
+   LIBM = -lm_nano
+endif
+
+EXTRA_LDFLAGS =
+ifeq ($(NODEFAULTLIBS), 1)
+   EXTRA_LDFLAGS = -nodefaultlibs $(LIBM) -Wl,--start-group $(LIBC) -lps2sdkc $(LKERNEL) -Wl,--end-group -lgcc
+endif
+
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)
 
@@ -16,7 +37,7 @@ EE_CFLAGS := -D_EE -O2 -G0 -Wall $(EE_CFLAGS)
 EE_CXXFLAGS := -D_EE -O2 -G0 -Wall $(EE_CXXFLAGS)
 
 # Linker flags
-EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)
+EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EXTRA_LDFLAGS) $(EE_LDFLAGS)
 
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -6,6 +6,27 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+# Helpers to make easy the use of lkernel-nopatch and newlib-nano
+NODEFAULTLIBS = 0
+LKERNEL = -lkernel
+ifeq ($(KERNEL_NOPATCH), 1)
+   NODEFAULTLIBS = 1
+   LKERNEL = -lkernel-nopatch
+endif
+
+LIBC = -lc
+LIBM = -lm
+ifeq ($(NEWLIB_NANO), 1)
+   NODEFAULTLIBS = 1
+   LIBC = -lc_nano
+   LIBM = -lm_nano
+endif
+
+EXTRA_LDFLAGS =
+ifeq ($(NODEFAULTLIBS), 1)
+   EXTRA_LDFLAGS = -nodefaultlibs $(LIBM) -Wl,--start-group $(LIBC) -lps2sdkc $(LKERNEL) -Wl,--end-group -lgcc
+endif
+
 # Include directories
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I. $(EE_INCS)
 
@@ -16,7 +37,7 @@ EE_CFLAGS := -D_EE -O2 -G0 -Wall $(EE_CFLAGS)
 EE_CXXFLAGS := -D_EE -O2 -G0 -Wall $(EE_CXXFLAGS)
 
 # Linker flags
-EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)
+EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EXTRA_LDFLAGS) $(EE_LDFLAGS)
 
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)


### PR DESCRIPTION
## Description

This PR prepare makefiles allowing developer easily to choose if they want to use the newlib nano, using the variable `NEWLIB_NANO = 1` and/or using `libkernel-nopatch` through the variable `KERNEL_NOPATCH = 1`

Additionally, the `elf-loader` is using `libc_nano.a` reducing drastically the size

Thanks

This PR need to be merged after https://github.com/ps2dev/ps2toolchain-ee/pull/11