### PR TITLE
Remove not needed functions from ps2sdklibc because now they are part of newlib

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -22,6 +22,7 @@ jobs:
         make clean all install
         ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a"
         ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"
+        ln -sf "$PS2SDK/ee/lib/libcdvd.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcdvd.a"
         
     - name: Compile samples
       if: ${{ success() }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add build-base
 RUN cd /src && make all install clean
 RUN ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a"
 RUN ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"
+RUN ln -sf "$PS2SDK/ee/lib/libcdvd.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcdvd.a"
 
 # Second stage of Dockerfile
 FROM alpine:latest  

--- a/README.md
+++ b/README.md
@@ -21,10 +21,22 @@ At the time of writing PS2SDK includes the following libraries and features, all
 - TCP/IP stack & DNS resolution compatible with PS2 Ethernet Adapter.
 - Full PS2 compatible Hard Disk Drive file system.
 - Access to CD and DVD.
-- Mini optimised C library for most string operations.
+- Required implementation by `newlib`, for fulfilling `libc` functionality.
 - Access to sound library on all PS2 using freesd.
 - HTTP client file system.
 - Network File System to load files from HOST pc.
+
+## Standard Libraries
+
+In a countinously effort to make `PS2SDK` and the whole `PS2DEV` a `POSIX` environment; there are some libraries needed to be included inside of the [standard libraries](https://gcc.gnu.org/onlinedocs/gcc/Standard-Libraries.html), whick means, libraries than by default are included in any compilation program. From `PS2SDK` we have:
+
+- `lkernel`: Contains the calls to BIOS functions
+- `lps2sdkc`: Implements most of the required methods by `newlib`
+- `lcdvd`: Implements `ps2time` function indirectly required by `newlib`
+
+If you wanna compile a program without using the `standard libraries` take a look to the [compiler flags](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html) (`-nodefaultlibs`, `-nolibc` and `-nostdlib`).
+
+## License
 
 PS2SDK has been developed by a large number of individuals who have provided their time and effort. The `AUTHORS` file includes this list.
 

--- a/ee/elf-loader/src/loader/Makefile
+++ b/ee/elf-loader/src/loader/Makefile
@@ -13,7 +13,7 @@ MAPFILE = loader.map
 
 # Include directories
 EE_INCS := $(EE_INCS) -I$(PS2SDKSRC)/ee/kernel/include -I$(PS2SDKSRC)/common/include -I$(PS2SDKSRC)/ee/libc/include
-EE_LIBS := $(EE_LIBS) -L$(PS2SDKSRC)/ee/kernel/lib -L$(PS2SDKSRC)/ee/libc/lib
+EE_LIBS := $(EE_LIBS) -L$(PS2SDKSRC)/ee/kernel/lib -L$(PS2SDKSRC)/ee/libc/lib -L$(PS2SDKSRC)/ee/rpc/cdvd/lib
 
 EE_CFLAGS = -D_EE -Os -G0 -Wall -Werror
 EE_CFLAGS += -fdata-sections -ffunction-sections

--- a/ee/erl-loader/Makefile
+++ b/ee/erl-loader/Makefile
@@ -13,7 +13,7 @@ LOADER_BIN = $(EE_BIN_DIR)erl-loader.elf
 
 # Since we are using non-builtin symbols
 NO_BUILTIN = memcmp memcpy memset printf strcat strchr strcmp strcpy strlen strncpy strrchr strncmp
-EE_CFLAGS += $(NO_BUILTIN:%=-fno-builtin-%) -L$(PS2SDKSRC)/ee/libc/lib -L$(PS2SDKSRC)/ee/kernel/lib
+EE_CFLAGS += $(NO_BUILTIN:%=-fno-builtin-%) -L$(PS2SDKSRC)/ee/rpc/cdvd/lib -L$(PS2SDKSRC)/ee/libc/lib -L$(PS2SDKSRC)/ee/kernel/lib
 
 EE_INCS += -I$(PS2SDKSRC)/ee/erl/include -I$(PS2SDKSRC)/ee/libc/include -I$(PS2SDKSRC)/ee/erl-loader/src
 

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -20,7 +20,7 @@ SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 
 TIME_OBJS = ps2_clock.o __time_internals.o
 
-PS2SDKAPI_OBJS = __direct_pwd.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
+PS2SDKAPI_OBJS = __direct_pwd.o __transform_errno.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
 	_fstat.o _stat.o access.o opendir.o readdir.o rewinddir.o closedir.o _isatty.o _lseek.o lseek64.o chdir.o mkdir.o \
 	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _time.o _gettimeofday.o _times.o random.o srandom.o
 

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -22,7 +22,7 @@ TIME_OBJS = ps2_clock.o __time_internals.o
 
 PS2SDKAPI_OBJS = __direct_pwd.o __transform_errno.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
 	_fstat.o _stat.o access.o opendir.o readdir.o rewinddir.o closedir.o _lseek.o lseek64.o chdir.o mkdir.o \
-	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o random.o srandom.o
+	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o
 
 EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(PS2SDKAPI_OBJS)
 

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -22,7 +22,7 @@ TIME_OBJS = ps2_clock.o __time_internals.o
 
 PS2SDKAPI_OBJS = __direct_pwd.o __transform_errno.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
 	_fstat.o _stat.o access.o opendir.o readdir.o rewinddir.o closedir.o _isatty.o _lseek.o lseek64.o chdir.o mkdir.o \
-	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _time.o _gettimeofday.o _times.o random.o srandom.o
+	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o random.o srandom.o
 
 EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(PS2SDKAPI_OBJS)
 

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -21,7 +21,7 @@ SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 TIME_OBJS = ps2_clock.o __time_internals.o
 
 PS2SDKAPI_OBJS = __direct_pwd.o __transform_errno.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
-	_fstat.o _stat.o access.o opendir.o readdir.o rewinddir.o closedir.o _isatty.o _lseek.o lseek64.o chdir.o mkdir.o \
+	_fstat.o _stat.o access.o opendir.o readdir.o rewinddir.o closedir.o _lseek.o lseek64.o chdir.o mkdir.o \
 	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _sbrk.o _gettimeofday.o _times.o random.o srandom.o
 
 EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(PS2SDKAPI_OBJS)

--- a/ee/libc/Makefile
+++ b/ee/libc/Makefile
@@ -12,7 +12,7 @@ CORE_OBJS = timezone.o
 
 INIT_OBJS = _ps2sdk_libc_init.o _ps2sdk_libc_deinit.o _ps2sdk_args_parse.o
 
-SLEEP_OBJS = nanosleep.o sleep.o 
+SLEEP_OBJS = nanosleep.o
 
 TERMINATE_OBJS = abort.o exit.o
 

--- a/ee/libc/samples/stdio_tests.c
+++ b/ee/libc/samples/stdio_tests.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "testsuite.h"
 
@@ -411,21 +413,33 @@ static const char *test_readdir_rewinddir(void *arg)
     return NULL;
 }
 
+static const char *test_failed_open(void *arg)
+{
+    int handle = open((char *)arg, O_RDONLY);
+    if (handle != -1)
+        return "wrong return error opening non existing file";
+
+    printf("\nSUCCESS: all checks passed\n");
+    return NULL;
+}
+
 int libc_add_tests(test_suite *p)
 {
-    const char *textfile, *textfile2;
+    const char *textfile, *textfile2, *invalidtextfile;
     const char *dir, *dir2;
 
 #ifdef _EE
-    textfile  = "host:testfiles/dummy";
-    textfile2 = "host:testfiles/dummy2";
-    dir       = "host:testfiles/";
-    dir2      = "host:dummydir/";
+    textfile        = "host:testfiles/dummy";
+    textfile2       = "host:testfiles/dummy2";
+    invalidtextfile = "host:testfiles/invalidtextfile"; // This file shouldn't exist
+    dir             = "host:testfiles/";
+    dir2            = "host:dummydir/";
 #else
-    textfile  = "testfiles/dummy";
-    textfile2 = "testfiles/dummy2";
-    dir       = "testfiles/";
-    dir2      = "dummydir/";
+    textfile        = "testfiles/dummy";
+    textfile2       = "testfiles/dummy2";
+    invalidtextfile = "testfiles/invalidtextfile";
+    dir             = "testfiles/";
+    dir2            = "dummydir/";
 #endif
 
     /* If testing using usbd/usbhdfsd or ps2hdd/ps2fs, this adds a 10
@@ -444,6 +458,7 @@ int libc_add_tests(test_suite *p)
     add_test(p, "rmdir\n", test_rmdir, (void *)dir2);
     add_test(p, "opendir, closedir\n", test_opendir_closedir, (void *)dir);
     add_test(p, "readdir, rewinddir\n", test_readdir_rewinddir, (void *)dir);
+    add_test(p, "failed open\n", test_failed_open, (void *)invalidtextfile);
 
     return 0;
 }

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -471,21 +471,6 @@ int closedir(DIR *dir)
 }
 #endif
 
-#ifdef F__isatty
-int _isatty(int fd) {
-	struct stat buf;
-
-	if (_fstat (fd, &buf) < 0) {
-		errno = EBADF;
-		return 0;
-	}
-	if (S_ISCHR (buf.st_mode))
-		return 1;
-	errno = ENOTTY;
-	return 0;
-}
-#endif
-
 #ifdef F__lseek
 int (*_ps2sdk_lseek)(int, int, int) = fioLseek;
 

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -634,17 +634,3 @@ clock_t _times(struct tms *buffer) {
 	return clk;
 }
 #endif
-
-#ifdef F_random
-long int random(void)
-{
-    return rand();
-}
-#endif
-
-#ifdef F_srandom
-void srandom(unsigned int seed)
-{
-    srand(seed);
-}
-#endif

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -605,40 +605,33 @@ void * _sbrk(size_t incr) {
 }
 #endif
 
-#ifdef F_time
-/*
- * newlib function, unfortunately depends on the 'cdvd' library.
- * In libc there is a dummy   'time' function declared as WEAK.
- * In cdvd there is a working 'time' function declared as STRONG
- * Include libcdvd if you need to use the time function.
- */
-time_t time(time_t *t) __attribute__((weak));
-time_t time(time_t *t)
-{
-        printf("ERROR: include libcdvd when using the time function\n");
-
-        if(t != NULL)
-                *t = -1;
-	return -1;
-}
-#endif
-
 #ifdef F__gettimeofday
 /*
  * Implement in terms of time, which means we can't
  * return the microseconds.
  */
+
+time_t ps2time(time_t *t);
+
 int _gettimeofday(struct timeval *tv, struct timezone *tz) {
-	if (tz) {
+	if (tv == NULL) {
+      errno = EINVAL;
+      return -1;
+    }
+
+  	tv->tv_sec = (time_t) ps2time((time_t *) NULL);
+  	tv->tv_usec = 0L;
+  	if (tz != NULL) {
+		/* TODO: impplement something similar at:
+		https://code.woboq.org/userspace/glibc/sysdeps/posix/gettimeofday.c.html
+		*/
+
 		/* Timezone not supported for gettimeofday */
 		tz->tz_minuteswest = 0;
 		tz->tz_dsttime = 0;
-	}
+    }
 
-	tv->tv_usec = 0;
-	tv->tv_sec = time(0);
-
-	return 0;
+  	return 0;
 }
 #endif
 

--- a/ee/libc/src/sleep.c
+++ b/ee/libc/src/sleep.c
@@ -96,21 +96,3 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
 	return 0;
 }
 #endif
-
-#ifdef F_sleep
-unsigned int sleep(unsigned int seconds)
-{
-    struct timespec ts;
-
-    ts.tv_sec = seconds;
-    ts.tv_nsec = 0;
-
-    if (!nanosleep(&ts, &ts))
-        return 0;
-
-    if (errno == EINTR)
-        return ts.tv_sec;
-
-    return -1;
-}
-#endif

--- a/ee/rpc/cdvd/Makefile
+++ b/ee/rpc/cdvd/Makefile
@@ -17,7 +17,7 @@ NCMD_OBJS += _ncmd_internals.o _CdAlignReadBuffer.o sceCdRead.o sceCdReadDVDV.o 
 	sceCdStStat.o sceCdStPause.o sceCdStResume.o sceCdStream.o sceCdCddaStream.o sceCdSync.o \
 	_CdCheckNCmd.o sceCdReadKey.o
 
-SCMD_OBJS += _scmd_internals.o sceCdReadClock.o time.o sceCdWriteClock.o sceCdGetDiskType.o \
+SCMD_OBJS += _scmd_internals.o sceCdReadClock.o ps2time.o sceCdWriteClock.o sceCdGetDiskType.o \
 	sceCdGetError.o sceCdTrayReq.o sceCdApplySCmd.o sceCdStatus.o sceCdBreak.o \
 	_CdCheckSCmd.o sceCdCtrlADout.o sceCdMV.o sceCdReadSUBQ.o \
 	sceCdForbidDVDP.o sceCdAutoAdjustCtrl.o sceCdDecSet.o sceCdSetHDMode.o sceCdOpenConfig.o sceCdCloseConfig.o \

--- a/ee/rpc/cdvd/src/scmd.c
+++ b/ee/rpc/cdvd/src/scmd.c
@@ -138,43 +138,43 @@ int sceCdReadClock(sceCdCLOCK * clock)
 }
 #endif
 
-#ifdef F_time
+#ifdef F_ps2time
 /*
  * newlib function, unfortunately depends on the 'cdvd' library.
- * In libc there is a dummy   'time' function declared as WEAK.
- * In cdvd there is a working 'time' function declared as STRONG
- * Include libcdvd if you need to use the time function.
+ * In libc there is a 'time' function wihch call the `_gettimeofday` function.
+ * `_gettimeofday` is declared in libps2sdkc (ee/libc folder inside of ps2sdk)
+ * `_gettimeofday` finally needs ps2time, to get proper time_t
  */
-time_t time(time_t *t)
+time_t ps2time(time_t *t)
 {
-        sceCdCLOCK ps2tim;
+	sceCdCLOCK ps2tim;
 	struct tm tim;
-        time_t tim2;
+    time_t tim2;
 
 	sceCdReadClock(&ps2tim);
-        configConvertToGmtTime(&ps2tim);
-        //configConvertToLocalTime(&ps2tim);
-        convertfrombcd(&ps2tim);
+	configConvertToGmtTime(&ps2tim);
+	//configConvertToLocalTime(&ps2tim);
+	convertfrombcd(&ps2tim);
 #ifdef DEBUG
-        printf("ps2time: %d-%d-%d %d:%d:%d\n",
-                ps2tim.day,
-                ps2tim.month,
-                ps2tim.year,
-                ps2tim.hour,
-                ps2tim.minute,
-                ps2tim.second);
+	printf("ps2time: %d-%d-%d %d:%d:%d\n",
+			ps2tim.day,
+			ps2tim.month,
+			ps2tim.year,
+			ps2tim.hour,
+			ps2tim.minute,
+			ps2tim.second);
 #endif
 	tim.tm_sec  = ps2tim.second;
-        tim.tm_min  = ps2tim.minute;
-        tim.tm_hour = ps2tim.hour;
-        tim.tm_mday = ps2tim.day;
-        tim.tm_mon  = ps2tim.month - 1;
-        tim.tm_year = ps2tim.year + 100;
+	tim.tm_min  = ps2tim.minute;
+	tim.tm_hour = ps2tim.hour;
+	tim.tm_mday = ps2tim.day;
+	tim.tm_mon  = ps2tim.month - 1;
+	tim.tm_year = ps2tim.year + 100;
 
-        tim2 = mktime(&tim);
+	tim2 = mktime(&tim);
 
-        if(t != NULL)
-                *t = tim2;
+	if(t != NULL)
+		*t = tim2;
 
 	return tim2;
 }


### PR DESCRIPTION
## Description 
This PR does some improvements:
- Remove some declared functions from `/src/ee/libc` because now they are included inside of `newlib`
- Remove the weak reference to time, because now `libcdvd` is one of the standard libraries.
- Fixes wrong return code in the I/O function, now we're setting the `errno` making the toolchain more POSIX and standard.
- Update readme explaining there the standard libraries used.
- Extend the regression test to check return value when error opening files.

This PR should be merged together with https://github.com/ps2dev/ps2toolchain-ee/pull/13

Once this PR is accepted and before get merged, we need to update GCC and newlib branch references.