### PR TITLE
IOP fixes for new GCC version

### DIFF
--- a/common/include/hdd-ioctl.h
+++ b/common/include/hdd-ioctl.h
@@ -122,7 +122,7 @@ typedef struct
 {
 	u32 lba;
 	u32 size;
-	u8 data[0];
+	u8 data[];
 } hddAtaTransfer_t;
 
 typedef struct

--- a/common/include/smapregs.h
+++ b/common/include/smapregs.h
@@ -99,11 +99,11 @@
 
 #define SMAP_EMAC3_SET(offset, val)			\
 		SMAP_EMAC3_WRITE(offset, val)		\
-		SMAP_EMAC3_GET(offset)
+		(void)SMAP_EMAC3_GET(offset)
 
 #define SMAP_EMAC3_SET32(offset, val)			\
 		SMAP_EMAC3_WRITE32(offset, val)		\
-		SMAP_EMAC3_GET32(offset)
+		(void)SMAP_EMAC3_GET32(offset)
 
 #define	SMAP_R_EMAC3_MODE0		0x00
 #define	  SMAP_E3_RXMAC_IDLE		(1<<31)

--- a/common/include/sys/ioctl.h
+++ b/common/include/sys/ioctl.h
@@ -90,7 +90,7 @@ typedef struct {
 typedef struct {
 	u32	lba;
 	u32	nsectors;
-	u8	buf[0];
+	u8	buf[];
 } hdd_ctl_driveio_t;
 
 /** ATA device read.  */

--- a/common/sbus/src/iop_sif2.c
+++ b/common/sbus/src/iop_sif2.c
@@ -51,7 +51,7 @@ void SIF2_sync_dma(void)
 
 int SIF2_RestartDma(void)
 {
-    volatile register u32 d;
+    volatile register u32 d __attribute__((unused));
     int bc, bs;
 
     if(!(*R_LOCAL_SBUS(PS2_SBUS_REG4) & 0x80)) { *R_LOCAL_SBUS(PS2_SBUS_REG4) = 0x80; }
@@ -126,7 +126,7 @@ int _sif2_intr_handler(void)
 
 int SIF2_init(void)
 {
-    volatile register u32 d;
+    volatile register u32 d __attribute__((unused));
     int oldStat, old_irq;
 
     if(_sif2_inited) { return(-1); }
@@ -157,7 +157,7 @@ int SIF2_init(void)
 
 int SIF2_deinit(void)
 {
-    volatile register u32 d;
+    volatile register u32 d __attribute__((unused));
     int oldStat, old_irq;
 
     if(!_sif2_inited) { return(-1); }

--- a/ee/sbv/include/slib.h
+++ b/ee/sbv/include/slib.h
@@ -25,7 +25,7 @@ typedef struct _slib_imp_list {
 	u16	version;
 	u16	flags;
 	u8	name[8];
-	void	*imports[0];
+	void	*imports[];
 } slib_imp_list_t;
 
 /** Describes an IRX export library.  */
@@ -35,7 +35,7 @@ typedef struct _slib_exp_lib {
 	u16	version;
 	u16	flags;
 	u8	name[8];
-	void	*exports[0];
+	void	*exports[];
 } slib_exp_lib_t;
 
 /**

--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -44,6 +44,16 @@ IOP_IETABLE_CFLAGS := -fno-toplevel-reorder
 endif
 endif
 
+# If gpopt is requested, use it if the GCC version is compatible
+ifneq (x$(IOP_PREFER_GPOPT),x)
+ifeq ($(IOP_CC_VERSION),3.2.2)
+IOP_CFLAGS += -DUSE_GP_REGISTER=1 -mgpopt -G$(IOP_PREFER_GPOPT)
+endif
+ifeq ($(IOP_CC_VERSION),3.2.3)
+IOP_CFLAGS += -DUSE_GP_REGISTER=1 -mgpopt -G$(IOP_PREFER_GPOPT)
+endif
+endif
+
 # Assembler flags
 IOP_ASFLAGS := $(ASFLAGS_TARGET) -EL -G0 $(IOP_ASFLAGS)
 

--- a/iop/cdvd/cdfs/src/cdfs_iop.c
+++ b/iop/cdvd/cdfs/src/cdfs_iop.c
@@ -390,7 +390,7 @@ static int cdfs_getVolumeDescriptor(void) {
         cdfs_readSect(volDescSector, 1, (u8*)&localVolDesc);
 
         // If this is still a volume Descriptor
-        if (strncmp(localVolDesc.volID, "CD001", 5) == 0) {
+        if (memcmp(localVolDesc.volID, "CD001", 5) == 0) {
             if ((localVolDesc.filesystemType == 1) ||
                 (localVolDesc.filesystemType == 2)) {
                 memcpy(&cdVolDesc, &localVolDesc, sizeof(struct CDVolDesc));

--- a/iop/cdvd/cdfs/src/cdfs_iop.c
+++ b/iop/cdvd/cdfs/src/cdfs_iop.c
@@ -32,7 +32,7 @@ struct DirTocEntry
     unsigned char fileProperties;
     unsigned char reserved2[6];
     unsigned char filenameLength;
-    unsigned char filename[128];
+    char filename[128];
 } __attribute__((packed));  // This is the internal format on the CD
 // a file with a single character filename will have a 34byte toc entry
 // (max 60 entries per sector)6
@@ -52,7 +52,7 @@ struct CacheInfoDir
     unsigned int cache_offset;  // The offset from sector_start of the cached area
     unsigned int cache_size;    // The size of the cached directory area (in sectors)
 
-    char *cache;  // The actual cached data
+    u8 *cache;  // The actual cached data
 };
 
 struct RootDirTocHeader
@@ -260,7 +260,7 @@ static int findPath(char *pathname) {
             // If we have a null toc entry, then we've either reached the end of the dir, or have reached a sector boundary
             if (tocEntryPointer->length == 0) {
                 DPRINTF("Got a null pointer entry, so either reached end of dir, or end of sector\n\n");
-                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((char *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
             }
 
             if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
@@ -686,7 +686,7 @@ int cdfs_prepare(void) {
     cacheInfoDir.cache_size = 0;        // The size of the cached directory area (in sectors)
 
     if (cacheInfoDir.cache == NULL)
-        cacheInfoDir.cache = (char *)AllocSysMemory(0, MAX_DIR_CACHE_SECTORS * 2048, NULL);
+        cacheInfoDir.cache = (u8 *)AllocSysMemory(0, MAX_DIR_CACHE_SECTORS * 2048, NULL);
 
      // setup the cdReadMode structure
     cdReadMode.trycount = 0;
@@ -727,7 +727,7 @@ int cdfs_findfile(const char *fname, struct TocEntry *tocEntry) {
         for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
             if (tocEntryPointer->length == 0) {
                 DPRINTF("Got a null pointer entry, so either reached end of dir, or end of sector\n");
-                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((char *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
             }
 
             if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
@@ -778,8 +778,8 @@ int cdfs_findfile(const char *fname, struct TocEntry *tocEntry) {
         for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
             if (tocEntryPointer->length == 0) {
                 DPRINTF("Got a null pointer entry, so either reached end of dir, or end of sector\n");
-                DPRINTF("Offset into cache = %d bytes\n", (char *)tocEntryPointer - cacheInfoDir.cache);
-                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((char *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+                DPRINTF("Offset into cache = %d bytes\n", (u8 *)tocEntryPointer - cacheInfoDir.cache);
+                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
             }
 
             if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
@@ -935,7 +935,7 @@ int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode 
                     // then we've either reached the end of the sector, or the end of the dir
                     // so point to next sector (if there is one - will be checked by next condition)
 
-                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((char *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
                 }
 
                 if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
@@ -1013,7 +1013,7 @@ int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode 
                     // then we've either reached the end of the sector, or the end of the dir
                     // so point to next sector (if there is one - will be checked by next condition)
 
-                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((char *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
                 }
 
                 if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {

--- a/iop/cdvd/cdfs/src/imports.lst
+++ b/iop/cdvd/cdfs/src/imports.lst
@@ -24,6 +24,7 @@ I_strrchr
 I_strcat
 I_strlen
 I_memset
+I_memcmp
 I_memcpy
 I_memmove
 sysclib_IMPORTS_end

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -146,7 +146,7 @@ static int fio_read(iop_file_t *f, void *buffer, int size)
     int num_sectors;
 
     int read = 0;
-    static char local_buffer[9 * 2048];
+    static u8 local_buffer[9 * 2048];
 
     DPRINTF("CDFS: fio_read called\n\n");
     DPRINTF("      kernel_fd... %p\n", f);

--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -958,7 +958,7 @@ finish:
 static void ata_device_probe(ata_devinfo_t *devinfo)
 {
 	USE_ATA_REGS;
-	u16 nsector, sector, lcyl, hcyl, select;
+	u16 nsector, sector, lcyl, hcyl;
 
 	devinfo->exists = 0;
 	devinfo->has_packet = 2;
@@ -970,7 +970,7 @@ static void ata_device_probe(ata_devinfo_t *devinfo)
 	sector = ata_hwport->r_sector & 0xff;
 	lcyl = ata_hwport->r_lcyl & 0xff;
 	hcyl = ata_hwport->r_hcyl & 0xff;
-	select = ata_hwport->r_select;
+	(void)ata_hwport->r_select;
 
 	if ((nsector != 1) || (sector != 1))
 		return;

--- a/iop/dev9/hdpro_atad/src/hdproatad.c
+++ b/iop/dev9/hdpro_atad/src/hdproatad.c
@@ -662,7 +662,7 @@ int ata_device_sce_sec_unlock(int device, void *password)
 
 static void ata_device_probe(ata_devinfo_t *devinfo)
 {
-	u16 nsector, lcyl, hcyl, sector, select;
+	u16 nsector, lcyl, hcyl, sector;
 
 	devinfo->exists = 0;
 	devinfo->has_packet = 2;
@@ -674,7 +674,7 @@ static void ata_device_probe(ata_devinfo_t *devinfo)
 	sector = hdpro_io_read(ATAreg_SECTOR_RD) & 0xff;
 	lcyl = hdpro_io_read(ATAreg_LCYL_RD) & 0xff;
 	hcyl = hdpro_io_read(ATAreg_HCYL_RD) & 0xff;
-	select = hdpro_io_read(ATAreg_SELECT_RD) & 0xff;
+	(void)(hdpro_io_read(ATAreg_SELECT_RD) & 0xff);
 
 	/*	The original HDPro driver did not check sector.
 		However, by the ATA-4 specification (9.1), sector should be 1.

--- a/iop/fs/http/src/imports.lst
+++ b/iop/fs/http/src/imports.lst
@@ -22,6 +22,7 @@ I_lwip_connect
 I_lwip_send
 I_lwip_close
 I_lwip_gethostbyname
+I_inet_addr
 ps2ip_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/iop/fs/http/src/ps2http.c
+++ b/iop/fs/http/src/ps2http.c
@@ -268,7 +268,7 @@ static int _ResolveHostname(const char *hostname , struct in_addr* ip)
  */
 const char *resolveAddress( struct sockaddr_in *server, const char * url, char *hostAddr )
 {
-	unsigned char w,x,y,z;
+	unsigned char w;
 	const char *char_ptr;
 	char addr[128];
 	char port[6] = "80"; // default port of 80(HTTP)
@@ -310,31 +310,7 @@ const char *resolveAddress( struct sockaddr_in *server, const char * url, char *
 			}
         }
     else {
-		// turn '.' characters in ip string into null characters
-		for(i = 0, w = 0; i < 16; i++)
-			if(addr[i] == '.') { addr[i] = '\0'; w++; }
-
-        if(w != 3) { // w is used as a simple error check here
-            printf("HTTP: invalid IP address '%s'\n", hostAddr);
-            return(NULL);
-            }
-
-		i = 0;
-
-		// Extract individual ip number octets from string
-		w = (int)strtol(&addr[i],NULL, 10);
-		i += (strlen(&addr[i]) + 1);
-
-		x = (int)strtol(&addr[i],NULL, 10);
-		i += (strlen(&addr[i]) + 1);
-
-		y = (int)strtol(&addr[i],NULL, 10);
-		i += (strlen(&addr[i]) + 1);
-
-		z = (int)strtol(&addr[i],NULL, 10);
-		i += (strlen(&addr[i]) + 1);
-
-		IP4_ADDR( (struct ip4_addr *)&(server->sin_addr) ,w,x,y,z );
+		server->sin_addr.s_addr = inet_addr(addr);
 	}
 
     i = (int) strtol(port, NULL, 10); // set the port

--- a/iop/kernel/include/defs.h
+++ b/iop/kernel/include/defs.h
@@ -29,6 +29,15 @@
 #define KSEG1		0xa0000000
 #define KSEG1ADDR(a)	((__typeof__(a))(((u32)(a) & 0x1fffffff) | KSEG1))
 
+#if !defined(USE_GP_REGISTER)
+#if __GNUC__ > 3
+#define USE_GP_REGISTER 0
+#else
+#define USE_GP_REGISTER 1
+#endif
+#endif
+
+#if USE_GP_REGISTER
 static __inline__ void *ChangeGP(void *gp)
 {
 	void *OldGP;
@@ -64,6 +73,7 @@ static __inline__ void *GetGP(void)
 
 	return gp;
 }
+#endif
 
 static inline void *iop_memcpy(void *dest, const void *src, int size)
 {

--- a/iop/kernel/include/irx.h
+++ b/iop/kernel/include/irx.h
@@ -42,7 +42,7 @@ struct irx_import_table
 	u16	version;
 	u16	mode;
 	char	name[8];
-	void	*stubs[0];
+	void	*stubs[];
 } __attribute ((packed));
 
 struct irx_import_stub
@@ -89,7 +89,7 @@ struct irx_export_table {
 	u16	version;
 	u16	mode;
 	u8	name[8];
-	void	*fptrs[0];
+	void	*fptrs[];
 };
 
 #define DECLARE_EXPORT_TABLE(modname, major, minor)	\

--- a/iop/kernel/include/loadcore.h
+++ b/iop/kernel/include/loadcore.h
@@ -50,7 +50,7 @@ typedef struct _iop_library {
 	u16	version;
 	u16	flags;
 	char	name[8];
-	void	*exports[0];
+	void	*exports[];
 } iop_library_t;
 
 /** Loadcore internal data structure. Based on the one from loadcore.c of the FPS2BIOS project from PCSX2. */
@@ -67,7 +67,7 @@ typedef struct {
 	u16	value;
 	u8	id;
 	u8	len;
-	u32	data[0];
+	u32	data[];
 } iop_bootmode_t;
 
 

--- a/iop/memorycard/mcman/src/main.c
+++ b/iop/memorycard/mcman/src/main.c
@@ -8,6 +8,7 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
+#define SIO2MAN_EXPORTS_IMPLEMENTATION
 #include <mcman.h>
 #include "mcman-internal.h"
 

--- a/iop/memorycard/mcman/src/sio2man_imports.h
+++ b/iop/memorycard/mcman/src/sio2man_imports.h
@@ -9,12 +9,17 @@
 #define XSIO2MAN 	1
 #define XSIO2MAN_V2 	2
 
+#ifndef SIO2MAN_EXPORTS_IMPLEMENTATION
+#define SIO2MAN_EXPORTS_EXTERN extern
+#else
+#define SIO2MAN_EXPORTS_EXTERN
+#endif
 // sio2man exports
-/* 24 */ void (*psio2_mc_transfer_init)(void);
-/* 25 */ int  (*psio2_transfer)(sio2_transfer_data_t *sio2data);
+/* 24 */ SIO2MAN_EXPORTS_EXTERN void (*psio2_mc_transfer_init)(void);
+/* 25 */ SIO2MAN_EXPORTS_EXTERN int  (*psio2_transfer)(sio2_transfer_data_t *sio2data);
 
 // xsio2man exports
-/* 26 */ void (*psio2_transfer_reset)(void);
-/* 55/57 */ int  (*psio2_mtap_change_slot)(s32 *arg);
+/* 26 */ SIO2MAN_EXPORTS_EXTERN void (*psio2_transfer_reset)(void);
+/* 55/57 */ SIO2MAN_EXPORTS_EXTERN int  (*psio2_mtap_change_slot)(s32 *arg);
 
 #endif

--- a/iop/network/smap/Makefile
+++ b/iop/network/smap/Makefile
@@ -9,7 +9,8 @@
 # Build for use with a DHCP-enabled LWIP stack.
 LWIP_DHCP = 1
 
-IOP_CFLAGS += -mgpopt -G16384 -mno-check-zero-division
+IOP_PREFER_GPOPT = 16384 
+IOP_CFLAGS += -mno-check-zero-division
 
 ifdef LWIP_DHCP
 IOP_CFLAGS += -DLWIP_DHCP=1

--- a/iop/network/smap/src/smap.c
+++ b/iop/network/smap/src/smap.c
@@ -496,14 +496,18 @@ static void IntrHandlerThread(struct SmapDriverData *SmapDrivPrivData){
 }
 
 static int Dev9IntrCb(int flag){
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 
 	dev9IntrDisable(DEV9_SMAP_ALL_INTR_MASK);
 	iSetEventFlag(SmapDriverData.Dev9IntrEventFlag, SMAP_EVENT_INTR);
 
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return 0;
 }
@@ -537,26 +541,34 @@ static void Dev9PostDmaCbHandler(int bcr, int dir){
 }
 
 int SMAPStart(void){
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 
 	SetEventFlag(SmapDriverData.Dev9IntrEventFlag, SMAP_EVENT_START);
 
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return 0;
 }
 
 void SMAPStop(void){
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 
 	SetEventFlag(SmapDriverData.Dev9IntrEventFlag, SMAP_EVENT_STOP);
 	SmapDriverData.NetDevStopFlag=1;
 
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 }
 
 static void ClearPacketQueue(struct SmapDriverData *SmapDrivPrivData){
@@ -575,9 +587,11 @@ static void ClearPacketQueue(struct SmapDriverData *SmapDrivPrivData){
 }
 
 void SMAPXmit(void){
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 
 	if(SmapDriverData.LinkStatus){
 		if(QueryIntrContext())
@@ -589,7 +603,9 @@ void SMAPXmit(void){
 		ClearPacketQueue(&SmapDriverData);
 	}
 
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 }
 
 static int SMAPGetLinkMode(void){
@@ -663,9 +679,11 @@ static inline int SMAPGetLinkStatus(void){
 
 int SMAPIoctl(unsigned int command, void *args, unsigned int args_len, void *output, unsigned int length){
 	int result;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 
 	switch(command){
 		case NETMAN_NETIF_IOCTL_ETH_GET_MAC:
@@ -720,7 +738,9 @@ int SMAPIoctl(unsigned int command, void *args, unsigned int args_len, void *out
 			result=-1;
 	}
 
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return result;
 }

--- a/iop/network/smbman/src/smb.c
+++ b/iop/network/smbman/src/smb.c
@@ -421,7 +421,7 @@ negotiate_error:
 }
 
 //-------------------------------------------------------------------------
-static int AddPassword(char *Password, int PasswordType, int AuthType, u16 *AnsiPassLen, u16 *UnicodePassLen, u8 *Buffer)
+static int AddPassword(char *Password, int PasswordType, int AuthType, void *AnsiPassLen, void *UnicodePassLen, u8 *Buffer)
 {
 	u8 passwordhash[16];
 	u8 LMresponse[24];

--- a/iop/network/smbman/src/smb.c
+++ b/iop/network/smbman/src/smb.c
@@ -266,7 +266,7 @@ static int asciiToUtf16(char *out, const char *in)
 {
 	int len;
 	const char *pIn;
-	u8 *pOut;
+	char *pOut;
 
 	for(pIn = in, pOut = out, len = 0; *pIn != '\0'; pIn++, pOut += 2, len += 2)
 	{
@@ -284,7 +284,7 @@ static int asciiToUtf16(char *out, const char *in)
 static int utf16ToAscii(char *out, const char *in, int inbytes)
 {
 	int len, bytesProcessed;
-	const u8 *pIn;
+	const char *pIn;
 	char *pOut;
 	u16 wchar;
 
@@ -407,7 +407,7 @@ negotiate_retry:
 	server_specs.MaxMpxCount = NPRsp->MaxMpxCount;
 	server_specs.SessionKey = NPRsp->SessionKey;
 	memcpy(server_specs.EncryptionKey, NPRsp->ByteField, NPRsp->KeyLength);
-	getStringField(server_specs.PrimaryDomainServerName, &NPRsp->ByteField[NPRsp->KeyLength], 0);
+	getStringField(server_specs.PrimaryDomainServerName, (char *)&NPRsp->ByteField[NPRsp->KeyLength], 0);
 
 	return 0;
 
@@ -521,10 +521,10 @@ lbl_session_setup:
 	}
 
 	// Add User name
-	offset += setStringField(&SSR->ByteField[offset], User);
+	offset += setStringField((char *)&SSR->ByteField[offset], User);
 
 	// PrimaryDomain, acquired from Negotiate Protocol Response data
-	offset += setStringField(&SSR->ByteField[offset], server_specs.PrimaryDomainServerName);
+	offset += setStringField((char *)&SSR->ByteField[offset], server_specs.PrimaryDomainServerName);
 
 	// NativeOS
 	if (useUnicode && ((offset & 1) != 0))
@@ -532,7 +532,7 @@ lbl_session_setup:
 		SSR->ByteField[offset] = '\0';
 		offset++;
 	}
-	offset += setStringField(&SSR->ByteField[offset], "PlayStation 2");
+	offset += setStringField((char *)&SSR->ByteField[offset], "PlayStation 2");
 
 	// NativeLanMan
 	if (useUnicode && ((offset & 1) != 0))
@@ -540,7 +540,7 @@ lbl_session_setup:
 		SSR->ByteField[offset] = '\0';
 		offset++;
 	}
-	offset += setStringField(&SSR->ByteField[offset], "SMBMAN");
+	offset += setStringField((char *)&SSR->ByteField[offset], "SMBMAN");
 
 	SSR->ByteCount = offset;
 
@@ -614,7 +614,7 @@ lbl_tree_connect:
 	}
 
 	// Add share name
-	offset += setStringField(&TCR->ByteField[offset], ShareName);
+	offset += setStringField((char *)&TCR->ByteField[offset], ShareName);
 
 	memcpy(&TCR->ByteField[offset], "?????\0", 6); 	// Service, any type of device
 	offset += 6;
@@ -913,7 +913,7 @@ int smb_NTCreateAndX(int UID, int TID, char *filename, s64 *filesize, int mode)
 	}
 
 	// Add filename
-	NTCR->NameLength = setStringField(&NTCR->ByteField[offset], filename);
+	NTCR->NameLength = setStringField((char *)&NTCR->ByteField[offset], filename);
 	offset += NTCR->NameLength;
 
 	NTCR->ByteCount = offset;
@@ -988,7 +988,7 @@ int smb_OpenAndX(int UID, int TID, char *filename, s64 *filesize, int mode)
 	}
 
 	// Add filename
-	offset += setStringField(&OR->ByteField[offset], filename);
+	offset += setStringField((char *)&OR->ByteField[offset], filename);
 	OR->ByteCount = offset;
 
 	nb_SetSessionMessage(sizeof(OpenAndXRequest_t) + offset + 1);
@@ -1323,7 +1323,7 @@ int smb_Rename(int UID, int TID, char *oldPath, char *newPath)
 	// Add oldPath
 	RR->ByteField[offset] = 0x04;			// BufferFormat
 	offset++;
-	offset += setStringField(&RR->ByteField[offset], oldPath);
+	offset += setStringField((char *)&RR->ByteField[offset], oldPath);
 
 	// Add newPath
 	RR->ByteField[offset] = 0x04;			// BufferFormat
@@ -1333,7 +1333,7 @@ int smb_Rename(int UID, int TID, char *oldPath, char *newPath)
 		RR->ByteField[offset] = '\0';
 		offset++;				// pad needed for unicode
 	}
-	offset += setStringField(&RR->ByteField[offset], newPath);
+	offset += setStringField((char *)&RR->ByteField[offset], newPath);
 
 	RR->ByteCount = offset;
 

--- a/iop/network/smbman/src/smb.h
+++ b/iop/network/smbman/src/smb.h
@@ -303,7 +303,7 @@ typedef struct {
 	int SID;
 	int EOS;
 	PathInformation_t fileInfo;
-	char FileName[0];
+	char FileName[];
 } SearchInfo_t;
 
 typedef struct {
@@ -357,7 +357,7 @@ typedef struct {
 	u8	smbWordcount;
 	u16	ByteCount;
 	u8	DialectFormat;
-	char	DialectName[0];
+	char	DialectName[];
 } __attribute__((packed)) NegotiateProtocolRequest_t;
 
 typedef struct {
@@ -375,7 +375,7 @@ typedef struct {
 	u16	ServerTimeZone;
 	u8	KeyLength;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) NegotiateProtocolResponse_t;
 
 typedef struct {
@@ -393,7 +393,7 @@ typedef struct {
 	u32	reserved;
 	u32	Capabilities;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) SessionSetupAndXRequest_t;
 
 typedef struct {
@@ -415,7 +415,7 @@ typedef struct {
 	u16	Flags;
 	u16	PasswordLength;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) TreeConnectAndXRequest_t;
 
 typedef struct {
@@ -445,7 +445,7 @@ typedef struct {
 	u8	smbWordcount;
 	SMBTransactionRequest_t smbTrans;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) NetShareEnumRequest_t;
 
 typedef struct {
@@ -453,7 +453,7 @@ typedef struct {
 	u8	smbWordcount;
 	SMBTransactionResponse_t smbTrans;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) NetShareEnumResponse_t;
 
 typedef struct {
@@ -479,7 +479,7 @@ typedef struct {
 	u8	smbWordcount;
 	u16	EchoCount;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) EchoRequest_t;
 
 typedef struct {
@@ -487,14 +487,14 @@ typedef struct {
 	u8	smbWordcount;
 	u16	SequenceNumber;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) EchoResponse_t;
 
 typedef struct {
 	SMBHeader_t smbH;
 	u8	smbWordcount;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) QueryInformationDiskRequest_t;
 
 typedef struct {
@@ -511,7 +511,7 @@ typedef struct {
 typedef struct {
 	u16	LevelOfInterest;
 	u32	Reserved;
-	char	FileName[0];
+	char	FileName[];
 } __attribute__((packed)) QueryPathInformationRequestParam_t;
 
 typedef struct {
@@ -520,7 +520,7 @@ typedef struct {
 	SMBTransactionRequest_t smbTrans;
 	u16	SubCommand;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) QueryPathInformationRequest_t;
 
 typedef struct {
@@ -528,7 +528,7 @@ typedef struct {
 	u8	smbWordcount;
 	SMBTransactionResponse_t smbTrans;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) QueryPathInformationResponse_t;
 
 typedef struct {
@@ -553,7 +553,7 @@ typedef struct {
 	u16	Flags;
 	u16	LevelOfInterest;
 	u32	StorageType;
-	char	SearchPattern[0];
+	char	SearchPattern[];
 } __attribute__((packed)) FindFirst2RequestParam_t;
 
 typedef struct {
@@ -562,7 +562,7 @@ typedef struct {
 	u16	LevelOfInterest;
 	u32	ResumeKey;
 	u16	Flags;
-	char	SearchPattern[0];
+	char	SearchPattern[];
 } __attribute__((packed)) FindNext2RequestParam_t;
 
 typedef struct {
@@ -571,7 +571,7 @@ typedef struct {
 	SMBTransactionRequest_t smbTrans;
 	u16	SubCommand;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) FindFirstNext2Request_t;
 
 typedef struct {
@@ -596,7 +596,7 @@ typedef struct {
 	u32	EAListLength;
 	u16	ShortFileNameLen;
 	u8	ShortFileName[24];
-	char	FileName[0];
+	char	FileName[];
 } __attribute__((packed)) FindFirst2ResponseData_t;
 
 typedef struct {
@@ -604,7 +604,7 @@ typedef struct {
 	u8	smbWordcount;
 	SMBTransactionResponse_t smbTrans;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) FindFirstNext2Response_t;
 
 typedef struct {
@@ -626,7 +626,7 @@ typedef struct {
 	u32	ImpersonationLevel;
 	u8	SecurityFlags;
 	u16	ByteCount;
-	char	ByteField[0];
+	char	ByteField[];
 } __attribute__((packed)) NTCreateAndXRequest_t;
 
 typedef struct {
@@ -666,7 +666,7 @@ typedef struct {
 	u32	AllocationSize;
 	u32	reserved[2];
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) OpenAndXRequest_t;
 
 typedef struct {
@@ -773,7 +773,7 @@ typedef struct {
 	u16	SearchAttributes;
 	u16	ByteCount;
 	u8	BufferFormat;
-	char	FileName[0];
+	char	FileName[];
 } __attribute__((packed)) DeleteRequest_t;
 
 typedef struct {
@@ -787,7 +787,7 @@ typedef struct {
 	u8	smbWordcount;
 	u16	ByteCount;
 	u8	BufferFormat;
-	char	DirectoryName[0];
+	char	DirectoryName[];
 } __attribute__((packed)) ManageDirectoryRequest_t;
 
 typedef struct {
@@ -801,7 +801,7 @@ typedef struct {
 	u8	smbWordcount;
 	u16	SearchAttributes;
 	u16	ByteCount;
-	u8	ByteField[0];
+	u8	ByteField[];
 } __attribute__((packed)) RenameRequest_t;
 
 typedef struct {

--- a/iop/network/smbman/src/smb.h
+++ b/iop/network/smbman/src/smb.h
@@ -277,7 +277,7 @@ typedef struct {
 	u16	MaxMpxCount;
 	u8	SecurityMode;		// 0 = share level, 1 = user level
 	u8	PasswordType;		// 0 = PlainText passwords, 1 = use challenge/response
-	u8	PrimaryDomainServerName[64];
+	char	PrimaryDomainServerName[64];
 	u8	EncryptionKey[8];
 } server_specs_t;
 
@@ -511,7 +511,7 @@ typedef struct {
 typedef struct {
 	u16	LevelOfInterest;
 	u32	Reserved;
-	u8	FileName[0];
+	char	FileName[0];
 } __attribute__((packed)) QueryPathInformationRequestParam_t;
 
 typedef struct {
@@ -553,7 +553,7 @@ typedef struct {
 	u16	Flags;
 	u16	LevelOfInterest;
 	u32	StorageType;
-	u8	SearchPattern[0];
+	char	SearchPattern[0];
 } __attribute__((packed)) FindFirst2RequestParam_t;
 
 typedef struct {
@@ -562,7 +562,7 @@ typedef struct {
 	u16	LevelOfInterest;
 	u32	ResumeKey;
 	u16	Flags;
-	u8	SearchPattern[0];
+	char	SearchPattern[0];
 } __attribute__((packed)) FindNext2RequestParam_t;
 
 typedef struct {
@@ -596,7 +596,7 @@ typedef struct {
 	u32	EAListLength;
 	u16	ShortFileNameLen;
 	u8	ShortFileName[24];
-	u8	FileName[0];
+	char	FileName[0];
 } __attribute__((packed)) FindFirst2ResponseData_t;
 
 typedef struct {
@@ -773,7 +773,7 @@ typedef struct {
 	u16	SearchAttributes;
 	u16	ByteCount;
 	u8	BufferFormat;
-	u8	FileName[0];
+	char	FileName[0];
 } __attribute__((packed)) DeleteRequest_t;
 
 typedef struct {
@@ -787,7 +787,7 @@ typedef struct {
 	u8	smbWordcount;
 	u16	ByteCount;
 	u8	BufferFormat;
-	u8	DirectoryName[0];
+	char	DirectoryName[0];
 } __attribute__((packed)) ManageDirectoryRequest_t;
 
 typedef struct {

--- a/iop/tcpip/tcpips/src/ps2ips.c
+++ b/iop/tcpip/tcpips/src/ps2ips.c
@@ -44,7 +44,7 @@ IRX_ID(MODNAME, 1, 1);
 
 static SifRpcDataQueue_t ps2ips_queue;
 static SifRpcServerData_t ps2ips_server;
-static int _rpc_buffer[512];
+static u8 _rpc_buffer[512 * 4];
 
 static char lwip_buffer[BUFF_SIZE + 32];
 static rests_pkt rests;

--- a/iop/usb/camera/src/ps2cam.c
+++ b/iop/usb/camera/src/ps2cam.c
@@ -924,7 +924,7 @@ int PS2CamGetIRXVersion(void)
 	static unsigned short	ver[2];
 	int						*ret;
 
-	ret		= (int *)&ver[2];
+	ret		= (int *)&ver[0];
 	ver[0]	=DRIVER_VERSON_MAJOR;
 	ver[1]	=DRIVER_VERSON_MINOR;
 

--- a/iop/usb/usbd/Makefile
+++ b/iop/usb/usbd/Makefile
@@ -7,7 +7,7 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 IOP_OBJS = hcd.o hub.o interface.o mem.o usbd.o usbio.o driver.o imports.o exports.o
-IOP_CFLAGS += -mgpopt -G16384
+IOP_PREFER_GPOPT = 16384
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make

--- a/iop/usb/usbd/src/driver.c
+++ b/iop/usb/usbd/src/driver.c
@@ -37,9 +37,13 @@ int callUsbDriverFunc(int (*func)(int devId), int devId, void *gp) {
 
 	if (func) {
 		usbdUnlock();
+#if USE_GP_REGISTER
 		ChangeGP(gp);
+#endif
 		res = func(devId);
+#if USE_GP_REGISTER
 		SetGP(&_gp);
+#endif
 		usbdLock();
 		return res;
 	} else
@@ -229,9 +233,13 @@ void callbackThreadFunc(void *arg) {
 
 				if (reqCopy.userCallbackProc)
 				{
+#if USE_GP_REGISTER
 					SetGP(req->gpSeg);
+#endif
 					reqCopy.userCallbackProc(reqCopy.resultCode, reqCopy.transferedBytes, reqCopy.userCallbackArg);
+#if USE_GP_REGISTER
 					SetGP(&_gp);
+#endif
 				}
 			}
 		} while (req);

--- a/iop/usb/usbd/src/hub.c
+++ b/iop/usb/usbd/src/hub.c
@@ -59,7 +59,11 @@ int initHubDriver(void) {
 	}
 	hub->next = NULL;
 
+#if USE_GP_REGISTER
 	doRegisterDriver(&HubDriver, &_gp);
+#else
+	doRegisterDriver(&HubDriver, NULL);
+#endif
 	return 0;
 }
 

--- a/iop/usb/usbd/src/interface.c
+++ b/iop/usb/usbd/src/interface.c
@@ -28,90 +28,128 @@ extern int callbackTid;
 
 int sceUsbdRegisterLdd(sceUsbdLddOps *driver) {
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
+#if USE_GP_REGISTER
 	res = doRegisterDriver(driver, OldGP);
+#else
+	res = doRegisterDriver(driver, NULL);
+#endif
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
 
 int sceUsbdRegisterAutoloader(sceUsbdLddOps *drv) {
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
+#if USE_GP_REGISTER
 	res = doRegisterAutoLoader(drv, OldGP);
+#else
+	res = doRegisterAutoLoader(drv, NULL);
+#endif
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
 
 int sceUsbdUnregisterLdd(sceUsbdLddOps *driver) {
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER		
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
 	res = doUnregisterDriver(driver);
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
 
 int sceUsbdUnregisterAutoloader(void) {
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
 	res = doUnregisterAutoLoader();
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
 
 void *sceUsbdScanStaticDescriptor(int devId, void *data, u8 type) {
 	void *res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return NULL;
 	}
 
 	res = doGetDeviceStaticDescriptor(devId, data, type);
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -119,11 +157,15 @@ void *sceUsbdScanStaticDescriptor(int devId, void *data, u8 type) {
 int sceUsbdGetDeviceLocation(int devId, u8 *path) {
 	Device *dev;
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
@@ -134,7 +176,9 @@ int sceUsbdGetDeviceLocation(int devId, u8 *path) {
 		res = USB_RC_BADDEV;
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -142,11 +186,15 @@ int sceUsbdGetDeviceLocation(int devId, u8 *path) {
 int sceUsbdSetPrivateData(int devId, void *data) {
 	Device *dev;
 	int res = USB_RC_OK;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
@@ -157,7 +205,9 @@ int sceUsbdSetPrivateData(int devId, void *data) {
 		res = USB_RC_BADDEV;
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -165,11 +215,15 @@ int sceUsbdSetPrivateData(int devId, void *data) {
 void *sceUsbdGetPrivateData(int devId) {
 	Device *dev;
 	void *res = NULL;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return NULL;
 	}
 
@@ -178,7 +232,9 @@ void *sceUsbdGetPrivateData(int devId) {
 		res = dev->privDataField;
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -187,11 +243,15 @@ int sceUsbdOpenPipe(int devId, UsbEndpointDescriptor *desc) {
 	Device *dev;
 	Endpoint *ep;
 	int res = -1;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return -1;
 	}
 
@@ -203,7 +263,9 @@ int sceUsbdOpenPipe(int devId, UsbEndpointDescriptor *desc) {
 	}
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -211,11 +273,15 @@ int sceUsbdOpenPipe(int devId, UsbEndpointDescriptor *desc) {
 int sceUsbdClosePipe(int id) {
 	Endpoint *ep;
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return -1;
 	}
 
@@ -226,7 +292,9 @@ int sceUsbdClosePipe(int id) {
 		res = USB_RC_BADPIPE;
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -236,11 +304,15 @@ int sceUsbdTransferPipe(int id, void *data, u32 len, void *option, sceUsbdDoneCa
 	IoRequest *req;
 	Endpoint *ep;
 	int res = 0;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
@@ -268,7 +340,9 @@ int sceUsbdTransferPipe(int id, void *data, u32 len, void *option, sceUsbdDoneCa
 	if (res == 0) {
 		req->userCallbackProc = callback;
 		req->userCallbackArg = cbArg;
+#if USE_GP_REGISTER
 		req->gpSeg = GetGP(); // gp of the calling module
+#endif
 		if (ep->endpointType == TYPE_CONTROL) {
 			if (!ctrlPkt) {
 				res = USB_RC_BADOPTION;
@@ -289,7 +363,9 @@ int sceUsbdTransferPipe(int id, void *data, u32 len, void *option, sceUsbdDoneCa
 	}
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
@@ -298,11 +374,15 @@ int sceUsbdOpenPipeAligned(int devId, UsbEndpointDescriptor *desc) {
 	Device *dev;
 	Endpoint *ep;
 	int res = -1;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return -1;
 	}
 
@@ -314,18 +394,24 @@ int sceUsbdOpenPipeAligned(int devId, UsbEndpointDescriptor *desc) {
 	}
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }
 
 int sceUsbdChangeThreadPriority(int prio1, int prio2) {
 	int res;
+#if USE_GP_REGISTER
 	void *OldGP;
 
 	OldGP = SetModuleGP();
+#endif
 	if (usbdLock() != 0) {
+#if USE_GP_REGISTER
 		SetGP(OldGP);
+#endif
 		return USB_RC_BADCONTEXT;
 	}
 
@@ -342,7 +428,9 @@ int sceUsbdChangeThreadPriority(int prio1, int prio2) {
 	}
 
 	usbdUnlock();
+#if USE_GP_REGISTER
 	SetGP(OldGP);
+#endif
 
 	return res;
 }

--- a/iop/usb/usbd/src/usbdpriv.h
+++ b/iop/usb/usbd/src/usbdpriv.h
@@ -78,7 +78,9 @@ typedef struct _ioRequest {
 	u32 waitFrames; // number of frames to wait for isochronous transfers
 	sceUsbdDoneCallback userCallbackProc;
 	void   *userCallbackArg;
+#if USE_GP_REGISTER
     void   *gpSeg;
+#endif
 } IoRequest;
 
 typedef struct _device {

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -41,6 +41,16 @@ IOP_IETABLE_CFLAGS := -fno-toplevel-reorder
 endif
 endif
 
+# If gpopt is requested, use it if the GCC version is compatible
+ifneq (x$(IOP_PREFER_GPOPT),x)
+ifeq ($(IOP_CC_VERSION),3.2.2)
+IOP_CFLAGS += -DUSE_GP_REGISTER=1 -mgpopt -G$(IOP_PREFER_GPOPT)
+endif
+ifeq ($(IOP_CC_VERSION),3.2.3)
+IOP_CFLAGS += -DUSE_GP_REGISTER=1 -mgpopt -G$(IOP_PREFER_GPOPT)
+endif
+endif
+
 # Assembler flags
 IOP_ASFLAGS := $(ASFLAGS_TARGET) -EL -G0 $(IOP_ASFLAGS)
 


### PR DESCRIPTION
Various fixes for various warnings.  

Also, a method to disable usage of GP-relative accesses (and thus disable the save/restore code) was added. For a smooth transition, this will remain enabled for GCC 3.2.3, while it will be properly disabled in GCC 11.