### PR TITLE
More CDVD definitions

### DIFF
--- a/common/include/libcdvd-common.h
+++ b/common/include/libcdvd-common.h
@@ -289,6 +289,14 @@ int sceCdReadCDDA(u32 lbn, u32 sectors, void *buffer, sceCdRMode *mode);
  */
 int sceCdGetToc(u8 *toc);
 
+/** Alternate TOC retrieving function with parameter
+ *
+ * @param toc buffer to hold toc (1024 bytes)
+ * @param param Parameter
+ * @return 1 on success, 0 on failure.
+ */
+int sceCdGetToc2(u8 *toc, int param);
+
 /** seek to given sector on disc
  * non-blocking, requires sceCdSync() call
  * 
@@ -599,6 +607,16 @@ int sceCdReadKey(unsigned char arg1, unsigned char arg2, unsigned int command, u
  * @return 1 on success, 0 on failure.
  */
 int sceCdSetHDMode(u32 mode);
+
+/** Opens a specified configuration block, within NVRAM. Each block is 15 bytes long.
+ *
+ * @param block Block number.
+ * @param mode Mode (0 = read, 1 = write).
+ * @param NumBlocks Number of blocks.
+ * @param status Result code.
+ * @return 1 on success, 0 on failure.
+ */
+int sceCdOpenConfig(int block, int mode, int NumBlocks, u32 *status);
 
 /** Closes the configuration block.
  *

--- a/ee/rpc/cdvd/include/libcdvd.h
+++ b/ee/rpc/cdvd/include/libcdvd.h
@@ -63,16 +63,6 @@ int sceCdApplySCmd(u8 cmdNum, const void* inBuff, u16 inBuffSize, void *outBuff,
  */
 int sceCdApplyNCmd(u8 cmdNum, const void* inBuff, u16 inBuffSize, void* outBuff, u16 outBuffSize);
 
-/** Opens a specified configuration block, within NVRAM. Each block is 15 bytes long.
- *
- * @param block Block number.
- * @param mode Mode (0 = read, 1 = write).
- * @param NumBlocks Number of blocks.
- * @param status Result code.
- * @return 1 on success, 0 on failure.
- */
-int sceCdOpenConfig(int block, int mode, int NumBlocks, u32 *status);
-
 /** Controls spindle speed? Not sure what it really does.
  * SUPPORTED IN XCDVDMAN/XCDVDFSV ONLY
  *

--- a/iop/kernel/include/cdvdman.h
+++ b/iop/kernel/include/cdvdman.h
@@ -71,15 +71,6 @@ int sceCdApplySCmd2(u8 cmdNum, const void* inBuff, unsigned long int inBuffSize,
  */
 int sceCdApplyNCmd(u8 cmdNum, const void* inBuff, u16 inBuffSize, void* outBuff);
 
-/** Opens a specified configuration block, within NVRAM. Each block is 15 bytes long.
- *
- * @param block Block number.
- * @param mode Mode (0 = read, 1 = write).
- * @param NumBlocks Number of blocks.
- * @return 1 on success, 0 on failure.
- */
-int sceCdOpenConfig(int block, int mode, int NumBlocks);
-
 /** Controls spindle speed? Not sure what it really does.
  * SUPPORTED IN XCDVDMAN ONLY
  *


### PR DESCRIPTION
Added `sceCdGetToc2` definition  
Corrected `sceCdOpenConfig` definition (it is the same for EE and IOP)  