### PR TITLE
Improved apa/pfs time handling in POSIX environment

### DIFF
--- a/iop/hdd/libapa/src/misc.c
+++ b/iop/hdd/libapa/src/misc.c
@@ -101,7 +101,7 @@ int apaGetTime(apa_ps2time_t *tm)
 	tm->min=timeinfo->tm_min;
 	tm->hour=timeinfo->tm_hour;
 	tm->day=timeinfo->tm_mday;
-	tm->month=timeinfo->tm_mon;
+	tm->month=timeinfo->tm_mon+1;
 	tm->year=timeinfo->tm_year+1900;
 #endif
 

--- a/iop/hdd/libapa/src/misc.c
+++ b/iop/hdd/libapa/src/misc.c
@@ -93,16 +93,18 @@ int apaGetTime(apa_ps2time_t *tm)
 	memcpy(tm, &timeBuf, sizeof(apa_ps2time_t));
 #else
 	time_t rawtime;
-	struct tm * timeinfo;
-	time (&rawtime);
-	timeinfo=localtime (&rawtime);
+	struct tm timeinfo;
+	time(&rawtime);
+	// Convert to JST
+	rawtime += (-9 * 60 * 60);
+	gmtime_r(&rawtime, &timeinfo);
 
-	tm->sec=timeinfo->tm_sec;
-	tm->min=timeinfo->tm_min;
-	tm->hour=timeinfo->tm_hour;
-	tm->day=timeinfo->tm_mday;
-	tm->month=timeinfo->tm_mon+1;
-	tm->year=timeinfo->tm_year+1900;
+	tm->sec = timeinfo.tm_sec;
+	tm->min = timeinfo.tm_min;
+	tm->hour = timeinfo.tm_hour;
+	tm->day = timeinfo.tm_mday;
+	tm->month = timeinfo.tm_mon + 1;
+	tm->year = timeinfo.tm_year + 1900;
 #endif
 
 	return 0;

--- a/iop/hdd/libpfs/src/misc.c
+++ b/iop/hdd/libpfs/src/misc.c
@@ -94,16 +94,18 @@ int pfsGetTime(pfs_datetime_t *tm)
 	memcpy(tm, &timeBuf, sizeof(pfs_datetime_t));
 #else
 	time_t rawtime;
-	struct tm * timeinfo;
-	time (&rawtime);
-	timeinfo=localtime (&rawtime);
+	struct tm timeinfo;
+	time(&rawtime);
+	// Convert to JST
+	rawtime += (-9 * 60 * 60);
+	gmtime_r(&rawtime, &timeinfo);
 
-	tm->sec=timeinfo->tm_sec;
-	tm->min=timeinfo->tm_min;
-	tm->hour=timeinfo->tm_hour;
-	tm->day=timeinfo->tm_mday;
-	tm->month=timeinfo->tm_mon+1;
-	tm->year=timeinfo->tm_year+1900;
+	tm->sec = timeinfo.tm_sec;
+	tm->min = timeinfo.tm_min;
+	tm->hour = timeinfo.tm_hour;
+	tm->day = timeinfo.tm_mday;
+	tm->month = timeinfo.tm_mon + 1;
+	tm->year = timeinfo.tm_year + 1900;
 #endif
 
 	return 0;

--- a/iop/hdd/libpfs/src/misc.c
+++ b/iop/hdd/libpfs/src/misc.c
@@ -102,7 +102,7 @@ int pfsGetTime(pfs_datetime_t *tm)
 	tm->min=timeinfo->tm_min;
 	tm->hour=timeinfo->tm_hour;
 	tm->day=timeinfo->tm_mday;
-	tm->month=timeinfo->tm_mon;
+	tm->month=timeinfo->tm_mon+1;
 	tm->year=timeinfo->tm_year+1900;
 #endif
 


### PR DESCRIPTION
Improved APA/PFS time handling in POSIX environment. Months are no longer off-by-one and timezone is correct.