### PR TITLE
setjmp header file

### DIFF
--- a/iop/kernel/include/setjmp.h
+++ b/iop/kernel/include/setjmp.h
@@ -20,15 +20,9 @@
 
 #include <tamtypes.h>
 
-#ifdef _EE
-/* we need some room after the gpr, to store some fp registers. */
-#define _JBLEN 14
-#define _JBTYPE u128
-#else
 /* seems the IOP's sysclib does have one more value than the newlib's version... */
 #define _JBLEN 12
 #define _JBTYPE u32
-#endif
 
 typedef _JBTYPE jmp_buf[_JBLEN];
 


### PR DESCRIPTION
# Description
This PR basically moves `setjmp.h` header from `common` to `IOP` folder, because the `EE` one is used from `newlib`

Additionally this specific changes has been neded to do in `newlib`
https://github.com/ps2dev/newlib/pull/2

Thanks