### PR TITLE
Add support for specific HDD layout of DESR

### DIFF
--- a/iop/hdd/apa-xosd/Makefile
+++ b/iop/hdd/apa-xosd/Makefile
@@ -6,7 +6,10 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = apa apa-osd apa-xosd pfs pfs-osd pfs-xosd
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/hdd/apa/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_BIN ?= ps2hdd-xosd.irx
+
+IOP_CFLAGS += -DAPA_XOSD_VER
+
+include $(PS2SDKSRC)/iop/hdd/apa/Makefile

--- a/iop/hdd/apa/src/apa-opt.h
+++ b/iop/hdd/apa/src/apa-opt.h
@@ -11,6 +11,11 @@
 	4. The starting LBA of the partition will be returned in
 		the private_5 field of the stat structure (returned by getstat and dread). */
 
+#ifdef APA_XOSD_VER
+#define APA_OSD_VER
+#define APA_SUPPORT_BHDD
+#endif
+
 #ifdef APA_OSD_VER
 #define APA_STAT_RETURN_PART_LBA	1
 #define APA_FORMAT_LOCK_MBR		1

--- a/iop/hdd/apa/src/hdd.c
+++ b/iop/hdd/apa/src/hdd.c
@@ -70,6 +70,15 @@ static iop_device_t hddFioDev={
 	"HDD",
 	(struct _iop_device_ops *)&hddOps,
 };
+#ifdef APA_SUPPORT_BHDD
+static iop_device_t bhddFioDev={
+	"bhdd",
+	IOP_DT_BLOCK | IOP_DT_FSEXT,
+	1,
+	"HDD",
+	(struct _iop_device_ops *)&hddOps,
+};
+#endif
 
 apa_device_t hddDevices[2]={
 	{0, 0, 0, 3},
@@ -293,14 +302,21 @@ int _start(int argc, char **argv)
 	DelDrv("hdd");
 	if(AddDrv(&hddFioDev) == 0)
 	{
-#ifdef APA_OSD_VER
-		APA_PRINTF(APA_DRV_NAME": version %04x driver start. This is OSD version!\n", IRX_VER(APA_MODVER_MAJOR, APA_MODVER_MINOR));
-#else
-		APA_PRINTF(APA_DRV_NAME": version %04x driver start.\n", IRX_VER(APA_MODVER_MAJOR, APA_MODVER_MINOR));
+#ifdef APA_SUPPORT_BHDD
+		DelDrv("bhdd");
+		if(AddDrv(&bhddFioDev) == 0)
 #endif
-		return MODULE_RESIDENT_END;
+		{
+#if defined(APA_XOSD_VER)
+			APA_PRINTF(APA_DRV_NAME": version %04x driver start. This is XOSD LBA48 VERSION !!!!!!!!!!!\n", IRX_VER(APA_MODVER_MAJOR, APA_MODVER_MINOR));
+#elif defined(APA_OSD_VER)
+			APA_PRINTF(APA_DRV_NAME": version %04x driver start. This is OSD version!\n", IRX_VER(APA_MODVER_MAJOR, APA_MODVER_MINOR));
+#else
+			APA_PRINTF(APA_DRV_NAME": version %04x driver start.\n", IRX_VER(APA_MODVER_MAJOR, APA_MODVER_MINOR));
+#endif
+			return MODULE_RESIDENT_END;
+		}
 	}
-	else
 	{
 		APA_PRINTF(APA_DRV_NAME": error: add device failed.\n");
 		return hddInitError();

--- a/iop/hdd/libapa/src/apa.c
+++ b/iop/hdd/libapa/src/apa.c
@@ -24,6 +24,10 @@
 #include "apa-opt.h"
 #include "libapa.h"
 
+#ifdef APA_SUPPORT_BHDD
+extern apa_device_t hddDevices[];
+#endif
+
 const char apaMBRMagic[]="Sony Computer Entertainment Inc.";
 
 void apaSaveError(s32 device, void *buffer, u32 lba, u32 err_lba)
@@ -168,8 +172,14 @@ apa_cache_t *apaInsertPartition(s32 device, const apa_params_t *params, u32 sect
 apa_cache_t *apaFindPartition(s32 device, const char *id, int *err)
 {
 	apa_cache_t *clink;
+	u32 sector = 0;
 
-	clink=apaCacheGetHeader(device, 0, APA_IO_MODE_READ, err);
+#ifdef APA_SUPPORT_BHDD
+	if (strcmp(id, "__xcontents") == 0 || strcmp(id, "__extend") == 0 || strcmp(id, "__xdata") == 0)
+		sector = hddDevices[device].totalLBA;
+#endif
+
+	clink=apaCacheGetHeader(device, sector, APA_IO_MODE_READ, err);
 	while(clink)
 	{
 		if(!(clink->header->flags & APA_FLAG_SUB)) {

--- a/iop/hdd/libpfs/include/libpfs.h
+++ b/iop/hdd/libpfs/include/libpfs.h
@@ -219,6 +219,9 @@ typedef struct
 #define PFS_SUPER_BACKUP_SECTOR		8193
 
 int pfsCheckZoneSize(u32 zone_size);
+#ifdef PFS_SUPPORT_BHDD
+int pfsCheckExtendedZoneSize(u32 zone_size);
+#endif
 u32 pfsGetBitmapSizeSectors(int zoneScale, u32 partSize);
 u32 pfsGetBitmapSizeBlocks(int scale, u32 mainsize);
 int pfsFormatSub(pfs_block_device_t *blockDev, int fd, u32 sub, u32 reserved, u32 scale, u32 fragment);

--- a/iop/hdd/libpfs/src/cache.c
+++ b/iop/hdd/libpfs/src/cache.c
@@ -236,7 +236,12 @@ void pfsCacheClose(pfs_mount_t *pfsMount)
 {
 	unsigned int i;
 
-	pfsCacheFlushAllDirty(pfsMount);
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") != 0)
+#endif
+	{
+		pfsCacheFlushAllDirty(pfsMount);
+	}
 	for(i=1; i < pfsCacheNumBuffers+1;i++){
 		if(pfsCacheBuf[i].pfsMount==pfsMount)
 			pfsCacheBuf[i].pfsMount=NULL;

--- a/iop/hdd/libpfs/src/journal.c
+++ b/iop/hdd/libpfs/src/journal.c
@@ -46,6 +46,11 @@ void pfsJournalWrite(pfs_mount_t *pfsMount, pfs_cache_t *clink, u32 pfsCacheNumB
 	u32 i=0;
 	u32 logSector=2;
 
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+		return;
+#endif
+
 	for(i=0; i <pfsCacheNumBuffers;i++)
 	{
 		if((clink[i].flags & PFS_CACHE_FLAG_DIRTY) && clink[i].pfsMount == pfsMount) {
@@ -68,6 +73,11 @@ void pfsJournalWrite(pfs_mount_t *pfsMount, pfs_cache_t *clink, u32 pfsCacheNumB
 int pfsJournalReset(pfs_mount_t *pfsMount)
 {
 	int rv;
+
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+		return 0;
+#endif
 
 	memset(&pfsJournalBuf, 0, sizeof(pfs_journal_t));
 	pfsJournalBuf.magic=PFS_JOUNRNAL_MAGIC;
@@ -92,6 +102,11 @@ int pfsJournalFlush(pfs_mount_t *pfsMount)
 {// this write any thing that in are journal buffer :)
 	int rv;
 
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+		return 0;
+#endif
+
 	pfsMount->blockDev->flushCache(pfsMount->fd);
 
 	pfsJournalBuf.checksum=pfsJournalChecksum(&pfsJournalBuf);
@@ -109,6 +124,11 @@ int pfsJournalRestore(pfs_mount_t *pfsMount)
 	int result;
 	pfs_cache_t *clink;
 	u32 i;
+
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+		return 0;
+#endif
 
 	// Read journal buffer from disk
 	rv = pfsMount->blockDev->transfer(pfsMount->fd, &pfsJournalBuf, 0,

--- a/iop/hdd/libpfs/src/misc.c
+++ b/iop/hdd/libpfs/src/misc.c
@@ -183,7 +183,11 @@ static u32 pfsHddGetPartSize(int fd, u32 sub/*0=main 1+=subs*/);
 static void pfsHddSetPartError(int fd);
 static int pfsHddFlushCache(int fd);
 
+#ifdef PFS_SUPPORT_BHDD
+#define NUM_SUPPORTED_DEVICES	2
+#else
 #define NUM_SUPPORTED_DEVICES	1
+#endif
 pfs_block_device_t pfsBlockDeviceCallTable[NUM_SUPPORTED_DEVICES] = {
 	{
 		"hdd",
@@ -192,7 +196,17 @@ pfs_block_device_t pfsBlockDeviceCallTable[NUM_SUPPORTED_DEVICES] = {
 		&pfsHddGetPartSize,
 		&pfsHddSetPartError,
 		&pfsHddFlushCache,
-	}
+	},
+#ifdef PFS_SUPPORT_BHDD
+	{
+		"bhdd",
+		&pfsHddTransfer,
+		&pfsHddGetSubCount,
+		&pfsHddGetPartSize,
+		&pfsHddSetPartError,
+		&pfsHddFlushCache,
+	},
+#endif
 };
 
 pfs_block_device_t *pfsGetBlockDeviceTable(const char *name)

--- a/iop/hdd/libpfs/src/super.c
+++ b/iop/hdd/libpfs/src/super.c
@@ -36,6 +36,19 @@ int pfsCheckZoneSize(u32 zone_size)
 	return 1;
 }
 
+#ifdef PFS_SUPPORT_BHDD
+int pfsCheckExtendedZoneSize(u32 zone_size)
+{
+	if ((zone_size & (zone_size - 1)) || (zone_size < (2 * 1024)) || (zone_size > (128 * 8192)))
+	{
+		PFS_PRINTF(PFS_DRV_NAME": error: invalid  extended zone size %d,%d\n", (zone_size & (zone_size - 1)) == 0, zone_size);
+		return 0;
+	}
+	
+	return 1;
+}
+#endif
+
 // Returns the number of sectors (512 byte units) which will be used
 // for bitmaps, given the zone size and partition size
 u32 pfsGetBitmapSizeSectors(int zoneScale, u32 partSize)

--- a/iop/hdd/libpfs/src/superWrite.c
+++ b/iop/hdd/libpfs/src/superWrite.c
@@ -201,8 +201,19 @@ int pfsMountSuperBlock(pfs_mount_t *pfsMount)
 		return -EIO;
 	}
 
-	if(!pfsCheckZoneSize(superblock->zone_size))
-		result = -EIO;
+
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+	{
+		if(!pfsCheckExtendedZoneSize(superblock->zone_size))
+			result = -EIO;
+	}
+	else
+#endif
+	{
+		if(!pfsCheckZoneSize(superblock->zone_size))
+			result = -EIO;
+	}
 
 	if((superblock->pfsFsckStat & PFS_FSCK_STAT_WRITE_ERROR) && (pfsMount->flags & PFS_FIO_ATTR_EXECUTABLE))
 		result = -EIO;

--- a/iop/hdd/pfs-xosd/Makefile
+++ b/iop/hdd/pfs-xosd/Makefile
@@ -6,7 +6,10 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = apa apa-osd apa-xosd pfs pfs-osd pfs-xosd
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/hdd/pfs/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_BIN ?= ps2fs-Xosd.irx
+
+IOP_CFLAGS += -DPFS_XOSD_VER
+
+include $(PS2SDKSRC)/iop/hdd/pfs/Makefile

--- a/iop/hdd/pfs/src/pfs-opt.h
+++ b/iop/hdd/pfs/src/pfs-opt.h
@@ -11,6 +11,11 @@
 #define PFS_MAJOR	2
 #define PFS_MINOR	2
 
+#ifdef PFS_XOSD_VER
+#define PFS_OSD_VER		1
+#define PFS_SUPPORT_BHDD	1
+#endif
+
 /*	Define PFS_OSD_VER in your Makefile to build an OSD version, which will:
 	1. Enable the PIOCINVINODE IOCTL2 function.
 	2. (Unofficial) Return the LBA of the inode in private_5 and sub number in private_4 fields of the stat structure (returned by getstat and dread). */

--- a/iop/hdd/pfs/src/pfs.c
+++ b/iop/hdd/pfs/src/pfs.c
@@ -226,7 +226,9 @@ int _start(int argc, char *argv[])
 
 	DelDrv("pfs");
 	if(AddDrv(&pfsFioDev) == 0) {
-#ifdef PFS_OSD_VER
+#if defined(PFS_XOSD_VER)
+		PFS_PRINTF(PFS_DRV_NAME" version %04x driver start. This is OSD LBA48 VERSION !!!!!!!!!!!\n", IRX_VER(PFS_MAJOR, PFS_MINOR));
+#elif defined(PFS_OSD_VER)
 		PFS_PRINTF(PFS_DRV_NAME" version %04x driver start. This is OSD version!\n", IRX_VER(PFS_MAJOR, PFS_MINOR));
 #else
 		PFS_PRINTF(PFS_DRV_NAME" version %04x driver start.\n", IRX_VER(PFS_MAJOR, PFS_MINOR));

--- a/iop/hdd/pfs/src/pfs_fioctl.c
+++ b/iop/hdd/pfs/src/pfs_fioctl.c
@@ -68,7 +68,13 @@ int pfsFioDevctl(iop_file_t *f, const char *name, int cmd, void *arg, size_t arg
 
 	if(!(pfsMount=pfsFioGetMountedUnit(f->unit)))
 		return -ENODEV;
-
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+	{
+		SignalSema(pfsFioSema);
+		return -ENODEV;
+	}
+#endif
 	switch(cmd)
 	{
 	case PDIOC_ZONESZ:
@@ -138,7 +144,10 @@ int pfsFioIoctl2(iop_file_t *f, int cmd, void *arg, size_t arglen,	void *buf, si
 	if((rv=pfsFioCheckFileSlot(fileSlot))<0)
 		return rv;
 	pfsMount=fileSlot->clink->pfsMount;
-
+#ifdef PFS_SUPPORT_BHDD
+	if (strcmp(pfsMount->blockDev->devName, "bhdd") == 0)
+		return -EBADF;
+#endif
 	switch(cmd)
 	{
 	case PIOCALLOC:


### PR DESCRIPTION
Add support for specific HDD layout for DESR.

ATAD has been changed so it always returns the non-48-bit total LBA for (emulated) Sony drives. This will allow the added `bhdd` functionality of the APA driver to work correctly. Functionality for drives without the specific security commands should continue to work normally without `bhdd` functionality.

APA and PFS have added support for the `bhdd` device, which will append the total reported non-48-bit LBA and will block writes to `bhdd` (they should be done through `dvr_hdd` and `dvr_pfs` anyways, which I haven't finished reversing how to initialize those interfaces yet).

This will allow access to `__xdata`, `__xcontents` partitions.  