### PR TITLE
pfs-xosd: Correct case of ps2fs-xosd.irx

### DIFF
--- a/iop/hdd/pfs-xosd/Makefile
+++ b/iop/hdd/pfs-xosd/Makefile
@@ -8,7 +8,7 @@
 
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/hdd/pfs/src/
 
-IOP_BIN ?= ps2fs-Xosd.irx
+IOP_BIN ?= ps2fs-xosd.irx
 
 IOP_CFLAGS += -DPFS_XOSD_VER
 


### PR DESCRIPTION
This will allow the correct name to use used under case-sensitive filesystems