### PR TITLE
Improve elf-loader

### DIFF
--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -22,6 +22,15 @@ extern "C" {
 
 // Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
+/* partition is useful when you're launching an ELF from HDD. If this is the case a example could be:
+*   filename = pfs:something/myprogram.elf
+*   partition = hdd0:__common:
+* What iternally we will do is to concatenate partition + filename, and send it in the argv[0], which is used by CWD
+* So folowing the previous example. when elf is launched argv[0] = hdd0:__common:pfs:something/myprogram.elf
+* If you aren't going to load from HDD you can pass in partition either NULL or ""
+*/
+
+int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
 
 #ifdef __cplusplus
 }

--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -22,14 +22,32 @@ extern "C" {
 
 // Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
-/* partition is useful when you're launching an ELF from HDD. If this is the case a example could be:
-*   filename = pfs:something/myprogram.elf
-*   partition = hdd0:__common:
-* What iternally we will do is to concatenate partition + filename, and send it in the argv[0], which is used by CWD
-* So folowing the previous example. when elf is launched argv[0] = hdd0:__common:pfs:something/myprogram.elf
-* If you aren't going to load from HDD you can pass in partition either NULL or ""
-*/
 
+/** Modify argv[0] when partition info should be kept
+ *
+ * @param filename  path to the file itself
+ * @param partition block device + partition name
+ * @param argc      Number of arguments.
+ * @param argv      Pointer to array of arguments.
+ * @returns         positive on success, zero value on failure
+ *
+ * You should prepare filename and partition before parsing in function 
+ *
+ * filename should be changed to <fs_type>:/path_to_file_without_mountpoint
+ * for example `pfs3:/TEST.ELF` (where `pfs3` is mountpoint name) will become
+ * `pfs:/TEST.ELF` (where `pfs` - filesystem type)
+ *
+ * partition should be in form <block_device><partition_name>:
+ * for example `hdd0:__common:`
+ * block_device - can be `hdd0:`, `hdd1:` , `dvr_hdd0:`
+ * <partition_name> - name of APA partition on particular block device
+ * dont forget about leading ":"
+ *
+ * It is not necessary that filename should be on that partition
+ * filename - mass:/TEST.ELF
+ * partition - pfs:/__common
+ * will be valid usage
+ */
 int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
 
 #ifdef __cplusplus

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -30,25 +30,47 @@ static bool file_exists(const char *filename) {
 	return (stat (filename, &buffer) == 0);
 }
 
-int LoadELFFromFile(const char *filename, int argc, char *argv[])
-{
+/* IMPORTANT: This method wipe memory where the loader is going to be allocated 
+* This values come from the linkfile used by the loader.c
+MEMORY {
+	bios	: ORIGIN = 0x00000000, LENGTH = 528K --- 0x00000000 - 0x00084000: BIOS memory
+	bram	: ORIGIN = 0x00084000, LENGTH = 496K --- 0x00084000 - 0x00100000: BIOS unused memory
+	gram	: ORIGIN = 0x00100000, LENGTH =  31M --- 0x00100000 - 0x02000000: GAME memory
+}
+*/
+
+static void wipe_bramMem(void) {
+	int i;
+	for (i = 0x00084000; i < 0x100000; i += 64) {
+		asm volatile(
+			"\tsq $0, 0(%0) \n"
+			"\tsq $0, 16(%0) \n"
+			"\tsq $0, 32(%0) \n"
+			"\tsq $0, 48(%0) \n" ::"r"(i));
+	}
+}
+
+int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]) {
 	u8 *boot_elf;
 	elf_header_t *eh;
 	elf_pheader_t *eph;
 	void *pdata;
 	int i;
-	int new_argc = argc + 1;
+	int new_argc = argc + 2;
 	
 	// We need to check that the ELF file before continue
 	if (!file_exists(filename)) {
 		return -1; // ELF file doesn't exists
 	}
 	// ELF Exists
-	char *new_argv[new_argc];
+	wipe_bramMem();
 
+	// Preparing filename and partition to be sent in the argv
+	char *new_argv[argc + 2];
 	new_argv[0] = (char *)filename;
+	new_argv[1] = partition != NULL ? (char *)partition : "";
 	for (i = 0; i < argc; i++) {
-		new_argv[i + 1] = argv[i];
+		new_argv[i + 2] = argv[i];
 	}
 	
 	/* NB: LOADER.ELF is embedded  */
@@ -77,4 +99,9 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[])
 	FlushCache(2);
 	
 	return ExecPS2((void *)eh->entry, NULL, new_argc, new_argv);
+}
+
+int LoadELFFromFile(const char *filename, int argc, char *argv[])
+{
+	return LoadELFFromFileWithPartition(filename, NULL, argc, argv);
 }

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -67,8 +67,8 @@ int LoadELFFromFileWithPartition(const char *filename, const char *partition, in
 
 	// Preparing filename and partition to be sent in the argv
 	char *new_argv[argc + 2];
-	new_argv[0] = (char *)filename;
-	new_argv[1] = partition != NULL ? (char *)partition : "";
+	new_argv[0] = partition != NULL ? (char *)partition : "";
+	new_argv[1] = (char *)filename;
 	for (i = 0; i < argc; i++) {
 		new_argv[i + 2] = argv[i];
 	}

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -72,18 +72,19 @@ int main(int argc, char *argv[])
 	elfdata.epc = 0;
 
 	GS_BGCOLOUR = WHITE_BG;
-	// arg[0]=path to ELF
-	// arg[1] partition if exists otherwise is ""
+	// arg[0] partition if exists, otherwise is ""
+	// arg[1]=path to ELF
 	if (argc < 2) {  
 		GS_BGCOLOUR = RED_BG;
 		return -EINVAL;
 	}
 
 	char *new_argv[argc - 1];
-	int fullPath_length = 1 + strlen(argv[1]) + strlen(argv[0]);
+	int fullPath_length = 1 + strlen(argv[0]) + strlen(argv[1]);
 	char fullPath[fullPath_length];
-	strcpy(fullPath, argv[1]);
-	strcat(fullPath, argv[0]);
+	strcpy(fullPath, argv[0]);
+	strcat(fullPath, argv[1]);
+	// final new_argv[0] is partition + path to elf
 	new_argv[0] = fullPath;
 	for (i = 2; i < argc; i++) {
 		new_argv[i - 1] = argv[i];
@@ -99,7 +100,7 @@ int main(int argc, char *argv[])
 	FlushCache(0);
 	GS_BGCOLOUR = GREEN_BG;
 	SifLoadFileInit();
-	ret = SifLoadElf(argv[0], &elfdata);
+	ret = SifLoadElf(argv[1], &elfdata);
 	SifLoadFileExit();
 	GS_BGCOLOUR = BLUE_BG;
 	if (ret == 0 && elfdata.epc != 0) {

--- a/ee/elf-loader/src/loader/loader.c
+++ b/ee/elf-loader/src/loader/loader.c
@@ -8,8 +8,12 @@
 # Review ps2sdk README & LICENSE files for further details.
 */
 
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 #include <kernel.h>
 #include <loadfile.h>
+#include <iopcontrol.h>
 #include <sifrpc.h>
 #include <errno.h>
 
@@ -22,6 +26,7 @@
 #define BLUE_BG 0xFF0000 // after SifLoadELF
 #define YELLOW_BG 0x00FFFF // good SifLoadELF return
 #define MAGENTA_BG 0xFF00FF // wrong SifLoadELF return
+#define BROWN_BG 0x2A2AA5  // after reset IOP
 #define PURPBLE_BG 0x800080  // before ExecPS2
 
 
@@ -57,17 +62,33 @@ static void wipeUserMem(void)
 //End of func:  void wipeUserMem(void)
 //--------------------------------------------------------------
 // *** MAIN ***
+// 
 //--------------------------------------------------------------
 int main(int argc, char *argv[])
 {
 	static t_ExecData elfdata;
-	int ret;
+	int ret, i;
+
+	elfdata.epc = 0;
 
 	GS_BGCOLOUR = WHITE_BG;
-	if (argc < 1) {  // arg1=path to ELF
+	// arg[0]=path to ELF
+	// arg[1] partition if exists otherwise is ""
+	if (argc < 2) {  
 		GS_BGCOLOUR = RED_BG;
 		return -EINVAL;
 	}
+
+	char *new_argv[argc - 1];
+	int fullPath_length = 1 + strlen(argv[1]) + strlen(argv[0]);
+	char fullPath[fullPath_length];
+	strcpy(fullPath, argv[1]);
+	strcat(fullPath, argv[0]);
+	new_argv[0] = fullPath;
+	for (i = 2; i < argc; i++) {
+		new_argv[i - 1] = argv[i];
+	}
+
 	GS_BGCOLOUR = CYAN_BG;
 
 	// Initialize
@@ -77,17 +98,36 @@ int main(int argc, char *argv[])
 	//Writeback data cache before loading ELF.
 	FlushCache(0);
 	GS_BGCOLOUR = GREEN_BG;
+	SifLoadFileInit();
 	ret = SifLoadElf(argv[0], &elfdata);
+	SifLoadFileExit();
 	GS_BGCOLOUR = BLUE_BG;
-	if (ret == 0) {
+	if (ret == 0 && elfdata.epc != 0) {
 		GS_BGCOLOUR = YELLOW_BG;
-		SifExitRpc();
+
+		// Let's reset IOP because ELF was already loaded in memory
+		while(!SifIopReset(NULL, 0)){};
+		while (!SifIopSync()) {};
+
+		GS_BGCOLOUR = RED_BG;
+
+        SifInitRpc(0);
+        // Load modules.
+        SifLoadFileInit();
+        SifLoadModule("rom0:SIO2MAN", 0, NULL);
+        SifLoadModule("rom0:MCMAN", 0, NULL);
+        SifLoadModule("rom0:MCSERV", 0, NULL);
+        SifLoadFileExit();
+        SifExitRpc();
+
+		GS_BGCOLOUR = BROWN_BG;
+
 		FlushCache(0);
 		FlushCache(2);
 
 		GS_BGCOLOUR = PURPBLE_BG;
-		// Following the standard the first parameter of a argv is the executable itself
-		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+		
+		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc-1, new_argv);
 	} else {
 		GS_BGCOLOUR = MAGENTA_BG;
 		SifExitRpc();


### PR DESCRIPTION
## Description

This PR makes some "improvements" for having a safer scenario when we are going to load another `elf` file.
The PR does:
- Clean `bram` (BIOS RAM) space, before the tiny loader is loaded.
- I have copied some code from `OPL` and `wLE`, now the `IOP` is reset and turned to cleaned state before `ExecPS2` is executed
-  Finally, in order to have a better `cwd` value when launching from `HDD`, I have exposed a new function where you can also specify the partition where the `elf` is.

Additional info:
I have implemented all these changes because I was suffering freezes when launching `RA` from `HDD`. 
How `RA` works, every time a rom is loaded, it `re-load` the whole `elf` (they do this, for avoiding possible memory leaks that belong to the specific core).
So the scenario that was failing, was to "execute the loader" from an elf file that is inside of the `HDD`. 

However, all the changes above didn't make the execution work, the freezes were still happening, then I faced that main problem was that I was forgetting to `deinit` audio and controllers before calling this `elf-loader` in my own app (`RA`).

With this info, I just to make emphasize, that the current `elf-loader` doesn't work under all the circumstances, you as a developer, somehow need to prepare things in your program before calling `ExecPS2`.

Thanks, @uyjulian for helping me debugging this.

Pinging, @rickgaiser @sp193 @uyjulian @parrado 
