### PR TITLE
fileXio Init improvements

### DIFF
--- a/ee/rpc/filexio/include/fileXio_rpc.h
+++ b/ee/rpc/filexio/include/fileXio_rpc.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 
 int fileXioInit(void);
+int fileXioInitSkipOverride(void);
 void fileXioExit(void);
 void fileXioSetBlockMode(int blocking);
 int fileXioWaitAsync(int mode, int *retVal);

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -173,7 +173,7 @@ static int fileXioClosedirHelper(DIR *dir)
 	return 0;
 }
 
-int fileXioInit(void)
+static int fileXioInitHelper(int overrideNewlibMethods)
 {
 	int res;
 	ee_sema_t sp;
@@ -212,26 +212,39 @@ int fileXioInit(void)
 	fileXioInited = 1;
 	fileXioBlockMode = FXIO_WAIT;
 
-	_ps2sdk_close = fileXioClose;
-	_ps2sdk_open = fileXioOpen;
-	_ps2sdk_read = fileXioRead;
-	_ps2sdk_lseek = fileXioLseek;
-	_ps2sdk_lseek64 = fileXioLseek64;
-	_ps2sdk_write = fileXioWrite;
-	_ps2sdk_ioctl = fileXioIoctl;
-	_ps2sdk_remove= fileXioRemove;
-	_ps2sdk_rename= fileXioRename;
-	_ps2sdk_mkdir = fileXioMkdir;
-	_ps2sdk_rmdir = fileXioRmdir;
+	if (overrideNewlibMethods) 
+	{
+		_ps2sdk_close = fileXioClose;
+		_ps2sdk_open = fileXioOpen;
+		_ps2sdk_read = fileXioRead;
+		_ps2sdk_lseek = fileXioLseek;
+		_ps2sdk_lseek64 = fileXioLseek64;
+		_ps2sdk_write = fileXioWrite;
+		_ps2sdk_ioctl = fileXioIoctl;
+		_ps2sdk_remove= fileXioRemove;
+		_ps2sdk_rename= fileXioRename;
+		_ps2sdk_mkdir = fileXioMkdir;
+		_ps2sdk_rmdir = fileXioRmdir;
 
-	_ps2sdk_stat = fileXioGetstatHelper;
+		_ps2sdk_stat = fileXioGetstatHelper;
 
-	_ps2sdk_opendir = fileXioOpendirHelper;
-	_ps2sdk_readdir = fileXioReaddirHelper;
-	_ps2sdk_rewinddir = fileXioRewinddirHelper;
-	_ps2sdk_closedir = fileXioClosedirHelper;
+		_ps2sdk_opendir = fileXioOpendirHelper;
+		_ps2sdk_readdir = fileXioReaddirHelper;
+		_ps2sdk_rewinddir = fileXioRewinddirHelper;
+		_ps2sdk_closedir = fileXioClosedirHelper;
+	}
 
 	return 0;
+}
+
+int fileXioInit(void)
+{
+	return fileXioInitHelper(1);
+}
+
+int fileXioInitSkipOverride(void)
+{
+	return fileXioInitHelper(0);
 }
 
 void fileXioExit(void)


### PR DESCRIPTION
## Description
As many of us have suffered already, `PCSX2` stops printing `print` messages. So this PR could help to mitigate this issue.

Let me try to explain it:

As you know we are using `newlib`, in our apps. The connection between `newlib` and the `ps2sdk` is mainly done here:
https://github.com/ps2dev/ps2sdk/blob/master/ee/libc/src/ps2sdkapi.c

if you take a look, by default, we are `connecting` to `fio` methods, as for instance we have:

```c
#ifdef F__write
int (*_ps2sdk_write)(int, const void*, int) = fioWrite;

int _write(int fd, const void *buf, size_t nbytes) {
	return __transform_errno(_ps2sdk_write(fd, buf, nbytes));
}
#endif
```
We can see here how a `_write` function (coming from `newlib`) is redirected to `_ps2sdk_write` which currently is pointing to `fioWrite`.

Till this moment, everything is fine, however, if we want to use HDD, we must use `fileXio`.
Then we must also `init` `fileXio` by using `fileXioInit()`
If you take a look at the `fileXioInit()` we have:

```c
int fileXioInit(void)
{
........
	_ps2sdk_close = fileXioClose;
	_ps2sdk_open = fileXioOpen;
	_ps2sdk_read = fileXioRead;
	_ps2sdk_lseek = fileXioLseek;
	_ps2sdk_lseek64 = fileXioLseek64;
	_ps2sdk_write = fileXioWrite;
	_ps2sdk_ioctl = fileXioIoctl;
	_ps2sdk_remove= fileXioRemove;
	_ps2sdk_rename= fileXioRename;
	_ps2sdk_mkdir = fileXioMkdir;
	_ps2sdk_rmdir = fileXioRmdir;

	_ps2sdk_stat = fileXioGetstatHelper;

	_ps2sdk_opendir = fileXioOpendirHelper;
	_ps2sdk_readdir = fileXioReaddirHelper;
	_ps2sdk_rewinddir = fileXioRewinddirHelper;
	_ps2sdk_closedir = fileXioClosedirHelper;

	return 0;
}
```

Where we're overriding the `_ps2sdk_write` definition.

And this is a **HUGE** issue in my opinion. 

We're changing on the fly the method used by `newlib`. And this is one of the reasons why `PCSX2` stops printing messages.

This PR just made optionally the overriding of the `newlib` methods, because there are scenarios, as the one that I'm suffering in RA, where I just want to use `fileXio` for `mount/unmount` partition, but the rest of functions I would like to keep using `fio`

Thanks
