### PR TITLE
dev9: add functionality for controlling bits 1 and 2 of SPD_R_PIO_DATA

### DIFF
--- a/common/include/hdd-ioctl.h
+++ b/common/include/hdd-ioctl.h
@@ -26,6 +26,8 @@
 
 #define DDIOC_MODEL		0x4401
 #define DDIOC_OFF		0x4402
+#define DDIOC_SETPIO3	0x4403
+#define DDIOC_LED2CTL	0x4404
 
 ///////////////////////////////////////////////////////////////////////////////
 //	HDD.IRX

--- a/iop/dev9/dev9/include/dev9.h
+++ b/iop/dev9/dev9/include/dev9.h
@@ -36,6 +36,8 @@ void dev9IntrDisable(int mask);
 int dev9GetEEPROM(u16 *buf);
 
 void dev9LEDCtl(int ctl);
+void dev9LED2Ctl(int ctl);
+void dev9ControlPIO3(int ctl);
 
 int dev9RegisterShutdownCb(int idx, dev9_shutdown_cb_t cb);
 
@@ -56,5 +58,7 @@ void dev9RegisterPostDmaCb(int ctrl, dev9_dma_cb_t cb);
 #define I_dev9RegisterShutdownCb DECLARE_IMPORT(11, dev9RegisterShutdownCb)
 #define I_dev9RegisterPreDmaCb   DECLARE_IMPORT(12, dev9RegisterPreDmaCb)
 #define I_dev9RegisterPostDmaCb  DECLARE_IMPORT(13, dev9RegisterPostDmaCb)
+#define I_dev9ControlPIO3        DECLARE_IMPORT(14, dev9ControlPIO3)
+#define I_dev9LED2Ctl            DECLARE_IMPORT(15, dev9LED2Ctl)
 
 #endif /* __DEV9_H__ */

--- a/iop/dev9/dev9/src/exports.tab
+++ b/iop/dev9/dev9/src/exports.tab
@@ -15,6 +15,8 @@ DECLARE_EXPORT_TABLE(dev9, 1, 9)
 	DECLARE_EXPORT(dev9RegisterShutdownCb)
 	DECLARE_EXPORT(dev9RegisterPreDmaCb)
 	DECLARE_EXPORT(dev9RegisterPostDmaCb)
+	DECLARE_EXPORT(dev9ControlPIO3)
+	DECLARE_EXPORT(dev9LED2Ctl)
 END_EXPORT_TABLE
 
 void _retonly() {}

--- a/iop/dev9/dev9/src/ps2dev9.c
+++ b/iop/dev9/dev9/src/ps2dev9.c
@@ -124,6 +124,12 @@ static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, un
         case DDIOC_OFF:
             dev9Shutdown();
             return 0;
+        case DDIOC_SETPIO3:
+            dev9ControlPIO3(((u32 *)args)[0]);
+            return 0;
+        case DDIOC_LED2CTL:
+            dev9LED2Ctl(((u32 *)args)[0]);
+            return 0;
         default:
             return 0;
     }
@@ -536,11 +542,47 @@ int dev9GetEEPROM(u16 *buf)
     return 0;
 }
 
+// Exerpt from Wisi's SPEED.txt:
+// 1:0  Dev9 LED Control. 0=On/1=Off.
+// Clearing either to 0 will light the LED.
+// Each is connected to the cathode of a diode, sharing a common anode.
+// The anode has a 10kohm pull-up to Vcc, and is connected to the base of an PNP transistor,
+// with collector grounded and emitter, connecting through a 240ohm resistor to the ACS_LED
+// pin (90) of the Expansion Bay connector. It connects to the cathode of the HDD Activity LED
+// in the PS2, the anode of which connects through 180ohm resistor to +5V.  
+
+// The specific LED part used is the Citizen CITILED CL-200TLY-C, which has a "Lemon Yellow" color.
+
 /* Export 10 */
 void dev9LEDCtl(int ctl)
 {
     USE_SPD_REGS;
-    SPD_REG8(SPD_R_PIO_DATA) = (ctl == 0);
+    SPD_REG8(SPD_R_PIO_DIR) |= 1;
+    SPD_REG8(SPD_R_PIO_DATA) = (SPD_REG8(SPD_R_PIO_DATA) & 0xE) | (ctl ? 0 : 1);
+}
+
+/* Export 15 */
+void dev9LED2Ctl(int ctl)
+{
+    USE_SPD_REGS;
+    SPD_REG8(SPD_R_PIO_DIR) |= 2;
+    DelayThread(1);
+    SPD_REG8(SPD_R_PIO_DATA) = (SPD_REG8(SPD_R_PIO_DATA) & 0xD) | (ctl ? 0 : 2);
+    DelayThread(1);
+}
+
+// Exerpt from Wisi's SPEED.txt:
+// 3:2  On SCPH-70000, each is connected through 10kohm R to Vcc, so they were inputs once.
+// On the SCPH-10350 Network Adapter - as well.
+
+/* Export 14 */
+void dev9ControlPIO3(int ctl)
+{
+    USE_SPD_REGS;
+    SPD_REG8(SPD_R_PIO_DIR) |= 4;
+    DelayThread(1);
+    SPD_REG8(SPD_R_PIO_DATA) = (SPD_REG8(SPD_R_PIO_DATA) & 0xB) | (ctl ? 0 : 4);
+    DelayThread(1);
 }
 
 static void dev9RegisterIntrDispatchCb(dev9IntrDispatchCb_t callback)
@@ -594,6 +636,10 @@ static int dev9_init(int sema_attr)
 
     /* Read in the MAC address.  */
     read_eeprom_data();
+
+    dev9LED2Ctl(0);
+    dev9ControlPIO3(0);
+
     /* Turn the LED off.  */
     dev9LEDCtl(0);
     return 0;


### PR DESCRIPTION

Add functionality for controlling bits 1 and 2 of `SPD_R_PIO_DATA`  

Adjust `dev9LEDCtl` so that `SPD_R_PIO_DIR` will be set  
