### PR TITLE
Revert "dev9: add functionality for controlling bits 1 and 2 of SPD_R_PIO_DATA"

### DIFF
--- a/common/include/hdd-ioctl.h
+++ b/common/include/hdd-ioctl.h
@@ -26,8 +26,6 @@
 
 #define DDIOC_MODEL		0x4401
 #define DDIOC_OFF		0x4402
-#define DDIOC_SETPIO3	0x4403
-#define DDIOC_LED2CTL	0x4404
 
 ///////////////////////////////////////////////////////////////////////////////
 //	HDD.IRX

--- a/iop/dev9/dev9/include/dev9.h
+++ b/iop/dev9/dev9/include/dev9.h
@@ -36,8 +36,6 @@ void dev9IntrDisable(int mask);
 int dev9GetEEPROM(u16 *buf);
 
 void dev9LEDCtl(int ctl);
-void dev9LED2Ctl(int ctl);
-void dev9ControlPIO3(int ctl);
 
 int dev9RegisterShutdownCb(int idx, dev9_shutdown_cb_t cb);
 
@@ -58,7 +56,5 @@ void dev9RegisterPostDmaCb(int ctrl, dev9_dma_cb_t cb);
 #define I_dev9RegisterShutdownCb DECLARE_IMPORT(11, dev9RegisterShutdownCb)
 #define I_dev9RegisterPreDmaCb   DECLARE_IMPORT(12, dev9RegisterPreDmaCb)
 #define I_dev9RegisterPostDmaCb  DECLARE_IMPORT(13, dev9RegisterPostDmaCb)
-#define I_dev9ControlPIO3        DECLARE_IMPORT(14, dev9ControlPIO3)
-#define I_dev9LED2Ctl            DECLARE_IMPORT(15, dev9LED2Ctl)
 
 #endif /* __DEV9_H__ */

--- a/iop/dev9/dev9/src/exports.tab
+++ b/iop/dev9/dev9/src/exports.tab
@@ -15,8 +15,6 @@ DECLARE_EXPORT_TABLE(dev9, 1, 9)
 	DECLARE_EXPORT(dev9RegisterShutdownCb)
 	DECLARE_EXPORT(dev9RegisterPreDmaCb)
 	DECLARE_EXPORT(dev9RegisterPostDmaCb)
-	DECLARE_EXPORT(dev9ControlPIO3)
-	DECLARE_EXPORT(dev9LED2Ctl)
 END_EXPORT_TABLE
 
 void _retonly() {}


### PR DESCRIPTION
Reverts ps2dev/ps2sdk#215

## Description

Reverting this PR because it causes memory issues in IOP for retail consoles.
@uyjulian will create a new PR soon.