### PR TITLE
libsd: use macros for read/write registers

### DIFF
--- a/iop/sound/libsd/include/spu2regs.h
+++ b/iop/sound/libsd/include/spu2regs.h
@@ -12,6 +12,15 @@
 #define U16_REGISTER(x)					((volatile u16 *) (0xBF900000 | (x)))
 #define U32_REGISTER(x)					((volatile u32 *) (0xBF800000 | (x)))
 
+#define U16_REGISTER_READ(x)			(*((volatile u16 *) (x)))
+#define U32_REGISTER_READ(x)			(*((volatile u32 *) (x)))
+#define U16_REGISTER_WRITE(x, y)		(*((volatile u16 *) (x)) = y)
+#define U32_REGISTER_WRITE(x, y)		(*((volatile u32 *) (x)) = y)
+#define U16_REGISTER_WRITEOR(x, y)		(*((volatile u16 *) (x)) |= y)
+#define U32_REGISTER_WRITEOR(x, y)		(*((volatile u32 *) (x)) |= y)
+#define U16_REGISTER_WRITEAND(x, y)		(*((volatile u16 *) (x)) &= y)
+#define U32_REGISTER_WRITEAND(x, y)		(*((volatile u32 *) (x)) &= y)
+
 #define SD_BASE_REG(reg)				((volatile u16 *)(0xBF900000 + reg))
 
 #define SD_VP_REG(core, voice, reg)		SD_BASE_REG(((core) << 10) + ((voice) << 4) + (reg))

--- a/iop/sound/libsd/src/block.c
+++ b/iop/sound/libsd/src/block.c
@@ -56,22 +56,22 @@ s32 BlockTransWriteFrom(u8 *iopaddr, u32 size, s32 chan, u16 mode, u8 *startaddr
 
 	iopaddr += (BlockTransSize[core] * BlockTransBuff[core]) + offset;
 
-	if(*SD_CORE_ATTR(core) & SD_DMA_IN_PROCESS) return -1;
-	if(*SD_DMA_CHCR(core) & SD_DMA_START) return -1;
+	if(U16_REGISTER_READ(SD_CORE_ATTR(core)) & SD_DMA_IN_PROCESS) return -1;
+	if(U32_REGISTER_READ(SD_DMA_CHCR(core)) & SD_DMA_START) return -1;
 
-	*SD_CORE_ATTR(core) &= 0xFFCF;
+	U16_REGISTER_WRITEAND(SD_CORE_ATTR(core), 0xFFCF);
 
-	*SD_A_TSA_HI(core) = 0;
-	*SD_A_TSA_LO(core) = 0;
+	U16_REGISTER_WRITE(SD_A_TSA_HI(core), 0);
+	U16_REGISTER_WRITE(SD_A_TSA_LO(core), 0);
 
-	*U16_REGISTER(0x1B0+(core*1024)) = 1 << core;
+	U16_REGISTER_WRITE(U16_REGISTER(0x1B0+(core*1024)), 1 << core);
 
 	SetDmaWrite(core);
 
-	*SD_DMA_ADDR(core) = (u32)iopaddr;
-	*SD_DMA_MODE(core) = 0x10;
-	*SD_DMA_SIZE(core) = (size/64)+((size&63)>0);
-	*SD_DMA_CHCR(core) = SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_IOP2SPU;
+	U32_REGISTER_WRITE(SD_DMA_ADDR(core), (u32)iopaddr);
+	U16_REGISTER_WRITE(SD_DMA_MODE(core), 0x10);
+	U16_REGISTER_WRITE(SD_DMA_SIZE(core), (size/64)+((size&63)>0));
+	U32_REGISTER_WRITE(SD_DMA_CHCR(core), SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_IOP2SPU);
 
 	return 0;
 }
@@ -84,22 +84,22 @@ s32 BlockTransWrite(u8 *iopaddr, u32 size, s32 chan)
 	BlockTransSize[core] = size;
 	BlockTransAddr[core] = (u32)iopaddr;
 
-	if(*SD_CORE_ATTR(core) & SD_DMA_IN_PROCESS) return -1;
-	if(*SD_DMA_CHCR(core) & SD_DMA_START) return -1;
+	if(U16_REGISTER_READ(SD_CORE_ATTR(core)) & SD_DMA_IN_PROCESS) return -1;
+	if(U32_REGISTER_READ(SD_DMA_CHCR(core)) & SD_DMA_START) return -1;
 
-	*SD_CORE_ATTR(core) &= 0xFFCF;
+	U16_REGISTER_WRITEAND(SD_CORE_ATTR(core), 0xFFCF);
 
-	*SD_A_TSA_HI(core) = 0;
-	*SD_A_TSA_LO(core) = 0;
+	U16_REGISTER_WRITE(SD_A_TSA_HI(core), 0);
+	U16_REGISTER_WRITE(SD_A_TSA_LO(core), 0);
 
-	*U16_REGISTER(0x1B0+(core*1024)) = 1 << core;
+	U16_REGISTER_WRITE(U16_REGISTER(0x1B0+(core*1024)), 1 << core);
 
 	SetDmaWrite(core);
 
-	*SD_DMA_ADDR(core) = (u32)iopaddr;
-	*SD_DMA_MODE(core) = 0x10;
-	*SD_DMA_SIZE(core) = (size/64)+((size&63)>0);
-	*SD_DMA_CHCR(core) = SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_IOP2SPU;
+	U32_REGISTER_WRITE(SD_DMA_ADDR(core), (u32)iopaddr);
+	U16_REGISTER_WRITE(SD_DMA_MODE(core), 0x10);
+	U16_REGISTER_WRITE(SD_DMA_SIZE(core), (size/64)+((size&63)>0));
+	U32_REGISTER_WRITE(SD_DMA_CHCR(core), SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_IOP2SPU);
 
 	return 0;
 }
@@ -115,28 +115,28 @@ s32 BlockTransRead(u8 *iopaddr, u32 size, s32 chan, s16 mode)
 	BlockTransSize[core] = size;
 	BlockTransAddr[core] = (u32)iopaddr;
 
-	if(*SD_CORE_ATTR(core) & SD_DMA_IN_PROCESS) return -1;
-	if(*SD_DMA_CHCR(core) & SD_DMA_START) return -1;
+	if(U16_REGISTER_READ(SD_CORE_ATTR(core)) & SD_DMA_IN_PROCESS) return -1;
+	if(U32_REGISTER_READ(SD_DMA_CHCR(core)) & SD_DMA_START) return -1;
 
-	*SD_CORE_ATTR(core) &= 0xFFCF;
+	U16_REGISTER_WRITEAND(SD_CORE_ATTR(core), 0xFFCF);
 
-	*SD_A_TSA_HI(core) = 0;
-	*SD_A_TSA_LO(core) = ((mode & 0xF00) << 1) + 0x400;
+	U16_REGISTER_WRITE(SD_A_TSA_HI(core), 0);
+	U16_REGISTER_WRITE(SD_A_TSA_LO(core), ((mode & 0xF00) << 1) + 0x400);
 
-	*U16_REGISTER(0x1AE + (core*1024)) = (mode & 0xF000) >> 11;
+	U16_REGISTER_WRITE(U16_REGISTER(0x1AE + (core*1024)), (mode & 0xF000) >> 11);
 
 	i = 0x4937;
 
 	while(i--);
 
-	*U16_REGISTER(0x1B0+(core*1024)) = 4;
+	U16_REGISTER_WRITE(U16_REGISTER(0x1B0+(core*1024)), 4);
 
 	SetDmaRead(core);
 
-	*SD_DMA_ADDR(core) = (u32)iopaddr;
-	*SD_DMA_MODE(core) = 0x10;
-	*SD_DMA_SIZE(core) = (size/64)+((size&63)>0);
-	*SD_DMA_CHCR(core) = SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_SPU2IOP;
+	U32_REGISTER_WRITE(SD_DMA_ADDR(core), (u32)iopaddr);
+	U16_REGISTER_WRITE(SD_DMA_MODE(core), 0x10);
+	U16_REGISTER_WRITE(SD_DMA_SIZE(core), (size/64)+((size&63)>0));
+	U32_REGISTER_WRITE(SD_DMA_CHCR(core), SD_DMA_CS | SD_DMA_START | SD_DMA_DIR_SPU2IOP);
 
 
 	return 0;
@@ -219,10 +219,10 @@ u32 sceSdBlockTransStatus(s16 chan, s16 flag)
 
 	chan &= 1;
 
-	if(*U16_REGISTER(0x1B0 + (chan * 1024)) == 0)
+	if(U16_REGISTER_READ(U16_REGISTER(0x1B0 + (chan * 1024))) == 0)
 		retval = 0;
 	else
-		retval = *SD_DMA_ADDR(chan);
+		retval = U32_REGISTER_READ(SD_DMA_ADDR(chan));
 
 	retval = (BlockTransBuff[chan] << 24) | (retval & 0xFFFFFF);
 

--- a/iop/sound/libsd/src/effect.c
+++ b/iop/sound/libsd/src/effect.c
@@ -71,22 +71,22 @@ const u32 ClearEffectData[256] __attribute__((aligned(16))) =
 
 u32 GetEEA(s32 core)
 {
-	return (*SD_A_EEA_HI(core) << 17) | 0x1FFFF;
+	return (U16_REGISTER_READ(SD_A_EEA_HI(core)) << 17) | 0x1FFFF;
 }
 
 void SetESA(s32 core, u32 value)
 {
 	volatile u16 *reg = SD_A_ESA_HI(core);
 
-	reg[0] = value >> 17;
-	reg[1] = value >> 1;
+	U16_REGISTER_WRITE(reg + 0, value >> 17);
+	U16_REGISTER_WRITE(reg + 1, value >> 1);
 
 }
 
 void SetEffectRegister(volatile u16* reg, u32 val)
 {
-	reg[0] = (u16)(val >> 14);
-	reg[1] = (u16)(val << 2);
+	U16_REGISTER_WRITE(reg + 0, (u16)(val >> 14));
+	U16_REGISTER_WRITE(reg + 1, (u16)(val << 2));
 }
 
 void SetEffectData(u16 *mode_data, u32 core)
@@ -97,13 +97,13 @@ void SetEffectData(u16 *mode_data, u32 core)
 	SetEffectRegister(SD_R_FB_SRC_B(core), mode_data[1]);
 
 	for(i=0; i < 8; i++)
-		*(SD_R_IIR_ALPHA(core)+i) = mode_data[2+i];
+		U16_REGISTER_WRITE(SD_R_IIR_ALPHA(core)+i, mode_data[2+i]);
 
 	for(i=0; i < 20; i++)
 		SetEffectRegister(SD_R_IIR_DEST_A0(core)+(i*2), mode_data[10+i]);
 
-	*SD_R_IN_COEF_L(core) = mode_data[30];
-	*SD_R_IN_COEF_R(core) = mode_data[31];
+	U16_REGISTER_WRITE(SD_R_IN_COEF_L(core), mode_data[30]);
+	U16_REGISTER_WRITE(SD_R_IN_COEF_R(core), mode_data[31]);
 }
 
 int sceSdSetEffectAttr(int core, sceSdEffectAttr *attr)
@@ -165,10 +165,10 @@ int sceSdSetEffectAttr(int core, sceSdEffectAttr *attr)
 	}
 
 	// Disable effects
-	if(*SD_CORE_ATTR(core) & SD_ENABLE_EFFECTS)
+	if(U16_REGISTER_READ(SD_CORE_ATTR(core)) & SD_ENABLE_EFFECTS)
 	{
 		effects_disabled = 1;
-		*SD_CORE_ATTR(core) &= ~SD_ENABLE_EFFECTS;
+		U16_REGISTER_WRITEAND(SD_CORE_ATTR(core), ~SD_ENABLE_EFFECTS);
 	}
 
 	// Clean up after last mode
@@ -190,7 +190,7 @@ int sceSdSetEffectAttr(int core, sceSdEffectAttr *attr)
 
 	// Enable effects
 	if(effects_disabled)
-		*SD_CORE_ATTR(core) |= SD_ENABLE_EFFECTS;
+		U16_REGISTER_WRITEOR(SD_CORE_ATTR(core), SD_ENABLE_EFFECTS);
 
 	return 0;
 }


### PR DESCRIPTION
This will make it easier to replace it for another backend e.g. spu2 emulator