### PR TITLE
don't use fio functions in TerminateLibrary

### DIFF
--- a/ee/kernel/src/initsys.c
+++ b/ee/kernel/src/initsys.c
@@ -32,7 +32,7 @@ void _InitSys(void)
 void TerminateLibrary(void)
 {
 #ifndef KERNEL_NO_PATCHES
-	InitTLB();
+	_InitTLB();
 #endif
 }
 #endif


### PR DESCRIPTION
When TerminateLibrary is called there is a good chance all IO services will already be shutdown so only check for DESR at init