### PR TITLE
bdm: filter for supported partition ids

### DIFF
--- a/iop/fs/bdm/include/bdm.h
+++ b/iop/fs/bdm/include/bdm.h
@@ -28,6 +28,7 @@ struct block_device {
     char* name;
     unsigned int devNr;
     unsigned int parNr;
+    unsigned char parId;
 
     unsigned int sectorSize;
     unsigned int sectorOffset;

--- a/iop/fs/bdm/src/bdm.c
+++ b/iop/fs/bdm/src/bdm.c
@@ -47,7 +47,7 @@ void bdm_connect_bd(struct block_device* bd)
 {
     int i;
 
-    M_PRINTF("connecting device %s%dp%d\n", bd->name, bd->devNr, bd->parNr);
+    M_PRINTF("connecting device %s%dp%d id=0x%x\n", bd->name, bd->devNr, bd->parNr, bd->parId);
 
     for (i = 0; i < MAX_CONNECTIONS; ++i) {
         if (g_mount[i].bd == NULL) {
@@ -63,7 +63,7 @@ void bdm_disconnect_bd(struct block_device* bd)
 {
     int i;
 
-    M_PRINTF("disconnecting device %s%dp%d\n", bd->name, bd->devNr, bd->parNr);
+    M_PRINTF("disconnecting device %s%dp%d id=0x%x\n", bd->name, bd->devNr, bd->parNr, bd->parId);
 
     for (i = 0; i < MAX_CONNECTIONS; ++i) {
         if (g_mount[i].bd == bd) {

--- a/iop/fs/bdm/src/part_driver.c
+++ b/iop/fs/bdm/src/part_driver.c
@@ -108,6 +108,7 @@ void part_create(struct block_device* bd, part_record* rec, unsigned int parNr)
             g_part_bd[i].name         = bd->name;
             g_part_bd[i].devNr        = bd->devNr;
             g_part_bd[i].parNr        = parNr + 1;
+            g_part_bd[i].parId        = rec->sid;
             g_part_bd[i].sectorSize   = bd->sectorSize;
             g_part_bd[i].sectorOffset = bd->sectorOffset + rec->start;
             g_part_bd[i].sectorCount  = rec->count;
@@ -126,6 +127,15 @@ int part_connect(struct block_device* bd)
     int rval = -1;
 
     M_DEBUG("%s\n", __func__);
+
+    // Filter for supported partition IDs:
+    // - First sector of disk can be MBR partition
+    // - 0x05 = extended MBR partition with CHS addressing
+    // - 0x0f = extended MBR partition with LBA addressing
+    if (bd->sectorOffset != 0 &&
+        bd->parId != 0x05 &&
+        bd->parId != 0x0f)
+        return rval;
 
     if ((parts = part_getPartitionTable(bd, &partTable)) <= 0)
         return rval;

--- a/iop/fs/bdmfs_vfat/src/fat_driver.c
+++ b/iop/fs/bdmfs_vfat/src/fat_driver.c
@@ -992,6 +992,12 @@ int fat_mount(struct block_device* bd)
 
     M_DEBUG("%s\n", __func__);
 
+    // Filter for supported partition IDs:
+    // - 0x0b = FAT32 with CHS addressing
+    // - 0x0c = FAT32 with LBA addressing
+    if (bd->parId != 0x0b && bd->parId != 0x0c)
+        return -1;
+
     for (i = 0; i < NUM_DRIVES && fatd == NULL; ++i) {
         if (g_fatd[i] == NULL) {
             M_DEBUG("allocate fat_driver %d!\n", sizeof(fat_driver));

--- a/iop/iLink/IEEE1394_bd/src/scsi.c
+++ b/iop/iLink/IEEE1394_bd/src/scsi.c
@@ -295,6 +295,7 @@ int scsi_init(void)
     for (i = 0; i < NUM_DEVICES; ++i) {
         g_scsi_bd[i].devNr = i;
         g_scsi_bd[i].parNr = 0;
+        g_scsi_bd[i].parId = 0x00;
 
         g_scsi_bd[i].priv  = NULL;
         g_scsi_bd[i].read  = scsi_read;

--- a/iop/sio/mx4sio_bd/src/mx4sio.c
+++ b/iop/sio/mx4sio_bd/src/mx4sio.c
@@ -787,6 +787,7 @@ static struct block_device bd = {
     "sdc",       /* name */
     0,           /* devNr */
     0,           /* parNr */
+    0x00,        /* parId */
     SECTOR_SIZE, /* sectorSize */
     0,           /* sectorOffset */
     0,           /* sectorCount */

--- a/iop/usb/usbmass_bd/src/scsi.c
+++ b/iop/usb/usbmass_bd/src/scsi.c
@@ -299,6 +299,7 @@ int scsi_init(void)
     for (i = 0; i < NUM_DEVICES; ++i) {
         g_scsi_bd[i].devNr = i;
         g_scsi_bd[i].parNr = 0;
+        g_scsi_bd[i].parId = 0x00;
 
         g_scsi_bd[i].priv  = NULL;
         g_scsi_bd[i].read  = scsi_read;


### PR DESCRIPTION
This should fix an issue where FAT32 partitions get mounted as extended MBR partition. Since the matching of partitions to file systems is now more strict, it is possible some partitions (anyone using fat12 or fat16 ?) are no longer detected.