### PR TITLE
cdfs: invalidate caches if disc has changed

### DIFF
--- a/iop/cdvd/cdfs/src/cdfs_iop.h
+++ b/iop/cdvd/cdfs/src/cdfs_iop.h
@@ -23,11 +23,18 @@ enum CDFS_getMode {
     CDFS_GET_FILES_AND_DIRS = 3
 };
 
+enum Cdvd_Changed_Index {
+    CHANGED_TOC = 0,
+    CHANGED_FIO = 1,
+    CHANGED_MAX
+};
+
 int cdfs_prepare(void);
 int cdfs_start(void);
 int cdfs_finish(void);
 int cdfs_findfile(const char *fname, struct TocEntry *tocEntry);
 int cdfs_readSect(u32 lsn, u32 sectors, u8 *buf);
 int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode getMode, struct TocEntry tocEntry[], unsigned int req_entries);
+int cdfs_checkDiskChanged(enum Cdvd_Changed_Index index);
 
 #endif  // _CDFS_H

--- a/iop/cdvd/cdfs/src/imports.lst
+++ b/iop/cdvd/cdfs/src/imports.lst
@@ -7,6 +7,7 @@ I_sceCdStop
 I_sceCdSync
 I_sceCdDiskReady
 I_sceCdGetDiskType
+I_sceCdTrayReq
 cdvdman_IMPORTS_end
 
 ioman_IMPORTS_start

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -39,7 +39,7 @@ static struct fodtable fod_table[MAX_FOLDERS_OPENED];
 static int fod_used[MAX_FOLDERS_OPENED];
 
 // global variables
-static int lastsector;
+static int lastsector = -1;
 static int last_bk = 0;
 
 /***********************************************
@@ -76,6 +76,12 @@ static int fio_open(iop_file_t *f, const char *name, int mode)
     DPRINTF("      kernel_fd.. %p\n", f);
     DPRINTF("      name....... %s %x\n", name, (int)name);
     DPRINTF("      mode....... %d\n\n", mode);
+
+    // Invalidate last sector cache if disk changed
+    if (cdfs_checkDiskChanged(CHANGED_FIO)) {
+        lastsector = -1;
+        last_bk = 0;
+    }
 
     // check if the file exists
     if (!cdfs_findfile(name, &tocEntry)) {


### PR DESCRIPTION
Since `SYSTEM.CNF` is basically often located in the same area of the disc, this may result in stale data being read when the disc has changed. In this case, check if the disc has changed before invalidating cache.  

We rely on `sceCdTrayReq` with `SCECdTrayCheck` as argument in order to check this.  
