### PR TITLE
Rename _Exit to KExit to avoid conflicts with _Exit from POSIX

### DIFF
--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -20,7 +20,7 @@ ifeq ($(KERNEL_NO_PATCHES),1)
 	ISUSPEND_THREAD_SYSCALL = iSuspendThread.o
 	TLB_SYSCALLS =
 else
-	EXEC_SYSCALLS = _Exit.o _LoadExecPS2.o _ExecPS2.o
+	EXEC_SYSCALLS = KExit.o _LoadExecPS2.o _ExecPS2.o
 	EXECOSD_SYSCALL = _ExecOSD.o
 	ALARM_SYSCALLS = _SetAlarm.o SetAlarm.o _ReleaseAlarm.o ReleaseAlarm.o
 	ALARM_INTR_SYSCALLS = _iSetAlarm.o iSetAlarm.o _iReleaseAlarm.o iReleaseAlarm.o

--- a/ee/kernel/include/kernel.h
+++ b/ee/kernel/include/kernel.h
@@ -340,7 +340,7 @@ void iInvalidDCache(void *start, void *end);
 /* System call prototypes */
 void ResetEE(u32 init_bitfield);
 void SetGsCrt(s16 interlace, s16 pal_ntsc, s16 field);
-void _Exit(s32 exit_code) __attribute__((noreturn));
+void KExit(s32 exit_code) __attribute__((noreturn));
 void _LoadExecPS2(const char *filename, s32 num_args, char *args[]) __attribute__((noreturn));
 s32 _ExecPS2(void *entry, void *gp, int num_args, char *args[]);
 void RFU009(u32 arg0, u32 arg1);

--- a/ee/kernel/include/syscallnr.h
+++ b/ee/kernel/include/syscallnr.h
@@ -8,7 +8,7 @@
 
 #define __NR_ResetEE                  1
 #define __NR_SetGsCrt                 2
-#define __NR__Exit                    4
+#define __NR_KExit                    4
 #define __NR_ResumeIntrDispatch       5 // Arbitrarily named
 #define __NR__LoadExecPS2             6
 #define __NR__ExecPS2                 7

--- a/ee/kernel/src/exit.c
+++ b/ee/kernel/src/exit.c
@@ -65,7 +65,7 @@ const char *SetArg(const char *filename, int argc, char *argv[])
 void Exit(s32 exit_code)
 {
     TerminateLibrary();
-    _Exit(exit_code);
+    KExit(exit_code);
 }
 #endif
 

--- a/ee/kernel/src/kernel.S
+++ b/ee/kernel/src/kernel.S
@@ -100,7 +100,7 @@ SYSCALL(SetGsCrt)
 #ifdef KERNEL_NO_PATCHES
 
 #ifdef F_Exit
-SYSCALL_SPECIAL(Exit, _Exit)
+SYSCALL_SPECIAL(Exit, KExit)
 #endif
 
 #ifdef F_LoadExecPS2
@@ -113,8 +113,8 @@ SYSCALL_SPECIAL(ExecPS2, _ExecPS2)
 
 #else	/* KERNEL_NO_PATCHES */
 
-#ifdef F__Exit
-SYSCALL(_Exit)
+#ifdef F_KExit
+SYSCALL(KExit)
 #endif
 
 #ifdef F__LoadExecPS2


### PR DESCRIPTION
## Description
We should have a different name for the function [`_Exit`](https://github.com/ps2dev/ps2sdk/blob/master/ee/kernel/include/kernel.h#L343)

We probably put in the past that name because we are wrapping the syscall function by patching some kernel functions.

Then our custom `Exit` function, after doing our things, calls [`_Exit`](https://github.com/ps2dev/ps2sdk/blob/master/ee/kernel/src/exit.c#L64-L70)

However, `_Exit` (together with `_exit` and others) is a "defined [POSIX](https://man7.org/linux/man-pages/man2/exit.2.html) function" 

So, what's the problem then?
Some libraries/apps/developers could call directly to `_Exit` thinking that it is going to be safe, but it isn't, because we expect `Exit` to called instead of `_Exit`.

This is precisely an example is what I have been suffering when porting `SDL2`.
https://github.com/libsdl-org/SDL/blob/main/src/SDL.c#L107

So in order to avoid this issue, I have renamed the `_Exit` function to `KExit`

Thanks