### PR TITLE
Add (de)fragmentation support to fat32/exFat

### DIFF
--- a/common/include/usbhdfsd-common.h
+++ b/common/include/usbhdfsd-common.h
@@ -15,6 +15,20 @@
 #ifndef __USBHDFSD_COMMON_H__
 #define __USBHDFSD_COMMON_H__
 
+#include <tamtypes.h>
+
+#define BD_MAX_FRAGMENTS 10
+
+typedef struct bd_fragment {
+    u32 sector; /// start sector of fragmented bd/file
+    u32 count;  /// number of sector in this fragment
+} __attribute__((packed)) bd_fragment_t;
+
+typedef struct bd_fraglist {
+    u32 count;                            /// number of fragments
+    bd_fragment_t list[BD_MAX_FRAGMENTS]; /// pointer to fragment list
+} __attribute__((packed)) bd_fraglist_t;
+
 // IOCTL function codes
 /** Rename opened file. Data input to ioctl() -> new, full filename of file. */
 #define USBMASS_IOCTL_RENAME         0x0000
@@ -25,7 +39,9 @@
 /** Returns the block device driver name */
 #define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
 /** Check if fragments exist */
-#define USBMASS_IOCTL_CHECK_CHAIN	 0x0004
+#define USBMASS_IOCTL_CHECK_CHAIN    0x0004
+/** Return fragment table **/
+#define USBMASS_IOCTL_GET_FRAGLIST   0x0005
 
 // DEVCTL function codes
 /** Issues the SCSI STOP UNIT command to the specified device. Use this to shut down devices properly. */

--- a/iop/fs/bdmfs_fatfs/src/diskio.c
+++ b/iop/fs/bdmfs_fatfs/src/diskio.c
@@ -23,7 +23,6 @@ DSTATUS disk_status(
     BYTE pdrv /* Physical drive number to identify the drive */
 )
 {
-    DSTATUS stat;
     int result;
 
     result = (mounted_bd == NULL) ? STA_NODISK : FR_OK;
@@ -41,7 +40,6 @@ DSTATUS disk_initialize(
     BYTE pdrv /* Physical drive nmuber to identify the drive */
 )
 {
-    DSTATUS stat;
     int result;
 
     result = (mounted_bd == NULL) ? STA_NODISK : FR_OK;

--- a/iop/fs/bdmfs_fatfs/src/ff.c
+++ b/iop/fs/bdmfs_fatfs/src/ff.c
@@ -1111,7 +1111,7 @@ static FRESULT sync_fs (	/* Returns FR_OK or FR_DISK_ERR */
 /* Get physical sector number from cluster number                        */
 /*-----------------------------------------------------------------------*/
 
-static LBA_t clst2sect (	/* !=0:Sector number, 0:Failed (invalid cluster#) */
+LBA_t clst2sect (	/* !=0:Sector number, 0:Failed (invalid cluster#) */
 	FATFS* fs,		/* Filesystem object */
 	DWORD clst		/* Cluster# to be converted */
 )

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -31,6 +31,9 @@
 FATFS fatfs;
 struct block_device *mounted_bd;
 
+void *malloc(int size);
+void free(void *ptr);
+
 // TODO: if all drives have the same mount point, it will only allow for one mounted block device
 int connect_bd(struct block_device *bd)
 {
@@ -47,7 +50,6 @@ void disconnect_bd(struct block_device *bd)
 {
     f_unmount("");
     mounted_bd = NULL;
-    return 0;
 }
 
 //---------------------------------------------------------------------------
@@ -90,8 +92,6 @@ static void _fs_unlock(void)
 //---------------------------------------------------------------------------
 static void fs_reset(void)
 {
-    int i;
-
     M_DEBUG("%s\n", __func__);
 
     if (_lock_sema_id >= 0)
@@ -336,7 +336,7 @@ static int fs_dclose(iop_file_t *fd)
 
 //--------------------------------------------------------------------------
 
-static int fileInfoToStat(FILINFO *fno, iox_stat_t *stat)
+static void fileInfoToStat(FILINFO *fno, iox_stat_t *stat)
 {
     unsigned char *cdate = (unsigned char *)&(fno->fdate);
     unsigned char *ctime = (unsigned char *)&(fno->ftime);
@@ -424,10 +424,41 @@ static int fs_getstat(iop_file_t *fd, const char *name, iox_stat_t *stat)
     return ret;
 }
 
-//---------------------------------------------------------------------------
-int fs_ioctl(iop_file_t *fd, int cmd, void *data)
+static int get_frag_list(FIL *file, void *rdata, unsigned int rdatalen)
 {
-    M_DEBUG("%s\n", __func__);
+    bd_fraglist_t *l = (bd_fraglist_t*)rdata;
+    DWORD iClusterStart = file->obj.sclust;
+    DWORD iClusterCurrent = iClusterStart;
+
+    if (rdatalen < sizeof(bd_fraglist_t)) {
+        M_DEBUG("ERROR: rdatalen=%d\n", rdatalen);
+        return -1;
+    }
+
+    l->count = 0;
+    do {
+        DWORD iClusterNext = get_fat(&file->obj, iClusterCurrent);
+        if (iClusterNext != (iClusterCurrent + 1)) {
+            // Fragment or file end
+            M_DEBUG("fragment: %uc - %uc + 1\n", iClusterStart, iClusterCurrent + 1);
+            if (l->count < 10) {
+                l->list[l->count].sector = clst2sect(file->obj.fs, iClusterStart);
+                l->list[l->count].count  = clst2sect(file->obj.fs, iClusterCurrent) - clst2sect(file->obj.fs, iClusterStart) + file->obj.fs->csize;
+                M_DEBUG(" - sectors: %us count %us\n", l->list[l->count].sector, l->list[l->count].count);
+            }
+            l->count++;
+            iClusterStart = iClusterNext;
+        }
+        iClusterCurrent = iClusterNext;
+    } while(iClusterCurrent < file->obj.fs->n_fatent);
+
+    return l->count;
+}
+
+//---------------------------------------------------------------------------
+int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, void *rdata, unsigned int rdatalen)
+{
+    M_DEBUG("%s cmd=%d\n", __func__, cmd);
 
     int ret   = 0;
     FIL *file = ((FIL *)(fd->privdata));
@@ -448,7 +479,7 @@ int fs_ioctl(iop_file_t *fd, int cmd, void *data)
             ret = file->obj.sclust;
             break;
         case USBMASS_IOCTL_GET_LBA:
-            ret = file->obj.fs->database + (file->obj.fs->csize * (file->obj.sclust - 2));
+            ret = clst2sect(file->obj.fs, file->obj.sclust);
             break;
         case USBMASS_IOCTL_GET_DRIVERNAME:
             ret = *(int *)(mounted_bd->name);
@@ -456,12 +487,21 @@ int fs_ioctl(iop_file_t *fd, int cmd, void *data)
         case USBMASS_IOCTL_CHECK_CHAIN:
             ret = (file->obj.n_frag < 2);
             break;
+        case USBMASS_IOCTL_GET_FRAGLIST:
+            ret = get_frag_list(file, rdata, rdatalen);
+            break;
         default:
             break;
     }
 
     _fs_unlock();
     return ret;
+}
+
+//---------------------------------------------------------------------------
+int fs_ioctl(iop_file_t *fd, int cmd, void *data)
+{
+    return fs_ioctl2(fd, cmd, data, 1024, NULL, 0);
 }
 
 int fs_rename(iop_file_t *fd, const char *path, const char *newpath)
@@ -537,7 +577,7 @@ static iop_device_ops_t fs_functarray = {
     &fs_devctl,
     (void *)&fs_dummy,
     (void *)&fs_dummy,
-    (void *)&fs_dummy,
+    &fs_ioctl2,
 };
 static iop_device_t fs_driver = {
     "mass",

--- a/iop/fs/bdmfs_fatfs/src/include/ff.h
+++ b/iop/fs/bdmfs_fatfs/src/include/ff.h
@@ -345,6 +345,11 @@ TCHAR* f_gets (TCHAR* buff, int len, FIL* fp);						/* Get a string from the fil
 #define f_rmdir(path) f_unlink(path)
 #define f_unmount(path) f_mount(0, path, 0)
 
+LBA_t clst2sect (	/* !=0:Sector number, 0:Failed (invalid cluster#) */
+	FATFS* fs,		/* Filesystem object */
+	DWORD clst		/* Cluster# to be converted */
+);
+
 DWORD get_fat (		/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFFF:Cluster status */
 	FFOBJID* obj,	/* Corresponding object */
 	DWORD clst		/* Cluster number to get the value */

--- a/iop/fs/libbdm/Makefile
+++ b/iop/fs/libbdm/Makefile
@@ -6,7 +6,14 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = bdm libbdm bdmfs_vfat bdmfs_fatfs devfs fakehost filexio http netfs
+# IOP_CFLAGS += -DDEBUG
+
+IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
+
+IOP_OBJS = bd_defrag.o
+IOP_LIB = libbdm.a
 
 include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+include $(PS2SDKSRC)/iop/Rules.lib.make
+include $(PS2SDKSRC)/iop/Rules.make
+include $(PS2SDKSRC)/iop/Rules.release

--- a/iop/fs/libbdm/include/bd_defrag.h
+++ b/iop/fs/libbdm/include/bd_defrag.h
@@ -1,12 +1,28 @@
+/*
 # _____     ___ ____     ___ ____
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
+*/
 
-SUBDIRS = bdm libbdm bdmfs_vfat bdmfs_fatfs devfs fakehost filexio http netfs
+/**
+ * @file
+ * Fragmented Block Device to Block Device
+ */
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+#ifndef __BDM_DEFRAG_H__
+#define __BDM_DEFRAG_H__
+
+
+#include <tamtypes.h>
+#include <bdm.h>
+#include <usbhdfsd-common.h>
+
+
+int bd_defrag(struct block_device* bd, struct bd_fraglist* fl, u32 sector, void* buffer, u16 count);
+
+
+
+#endif

--- a/iop/fs/libbdm/src/bd_defrag.c
+++ b/iop/fs/libbdm/src/bd_defrag.c
@@ -1,0 +1,53 @@
+#include <bd_defrag.h>
+
+//#define DEBUG  //comment out this line when not debugging
+#include "module_debug.h"
+
+
+int bd_defrag(struct block_device* bd, struct bd_fraglist* fl, u32 sector, void* buffer, u16 count)
+{
+    u32 sector_start = sector;
+    u16 count_left = count;
+
+    while (count_left > 0) {
+        u16 count_read;
+        u32 offset = 0; // offset of fragment in bd/file
+        struct bd_fragment *f = NULL;
+        int i;
+
+        // Locate fragment containing start sector
+        for (i=0; i<fl->count; i++) {
+            f = &fl->list[i];
+            if (offset <= sector_start && (offset + f->count) > sector_start) {
+                // Fragment found
+                break;
+            }
+            offset += f->count;
+        }
+
+        if (i == fl->count) {
+            M_PRINTF("%s: ERROR: fragment not found!\n", __FUNCTION__);
+            return -1;
+        }
+
+        // Clip to fragment size
+        count_read = count_left;
+        if ((sector_start + count_read) > (offset + f->count)) {
+            count_read = (offset + f->count) - sector_start;
+            M_DEBUG("%s: clipping sectors %d -> %d\n", __FUNCTION__, count_left, count_read);
+        }
+
+        // Do the read
+        if (bd->read(bd, f->sector + (sector_start - offset), buffer, count_read) != count_read) {
+            M_PRINTF("%s: ERROR: read failed!\n", __FUNCTION__);
+            return -1;
+        }
+
+        // Advance to next fragment
+        sector_start += count_read;
+        count_left -= count_read;
+        buffer = (u8*)buffer + (count_read * bd->sectorSize);
+    }
+
+    return count;
+}

--- a/iop/fs/libbdm/src/include/module_debug.h
+++ b/iop/fs/libbdm/src/include/module_debug.h
@@ -1,0 +1,19 @@
+#ifndef _MODULE_DEBUG_H
+#define _MODULE_DEBUG_H
+
+//#define MINI_DRIVER
+
+#ifndef MINI_DRIVER
+#include <stdio.h>
+#define M_PRINTF(format, args...) printf("BDM: " format, ##args)
+#else
+#define M_PRINTF(format, args...) do { } while(0)
+#endif
+
+#ifdef DEBUG
+#define M_DEBUG M_PRINTF
+#else
+#define M_DEBUG(format, args...) do { } while(0)
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds a new ioctl2 command: `USBMASS_IOCTL_GET_FRAGLIST`. This lets you request the number of fragments, and a list of the location and sizes of up to 10 fragments.

With this fragment list, the file system driver is no longer needed to read a file with up to 10 fragments.
To process this fragment list, a new library `libbdm` has been added.

Also in this PR all compile warnings of `bdmfs_fatfs` have been fixed.