### PR TITLE
Move system clock to TIM2

### DIFF
--- a/ee/kernel/include/timer.h
+++ b/ee/kernel/include/timer.h
@@ -39,6 +39,11 @@
 #define T3_MODE  ((volatile unsigned int *)0x10001810)
 #define T3_COMP  ((volatile unsigned int *)0x10001820)
 
+// Pointers to the kernel segment (uncached)
+#define K_T2_COUNT  ((volatile unsigned int *)0xB0001000)
+#define K_T2_MODE   ((volatile unsigned int *)0xB0001010)
+#define K_T2_COMP   ((volatile unsigned int *)0xB0001020)
+
 #define Tn_MODE(CLKS, GATE, GATS, GATM, ZRET, CUE, CMPE, OVFE, EQUF, OVFF) \
     (u32)((u32)(CLKS) | ((u32)(GATE) << 2) |                               \
           ((u32)(GATS) << 3) | ((u32)(GATM) << 4) |                        \


### PR DESCRIPTION
TIM2 is not used and, in theory, reserved for the kernel (but it never uses it). Since we only use it to measure the time, it's easy to configure it (using kmode enter/exit to get around permissions) and use it without much overhead (reads are allowed), while at the same time protecting it from the users.

This will free timer 0 and 1 to be used by homebrew users, and potentially by the timer library in PR #266