### PR TITLE
Improve the nanosleep functionality

### DIFF
--- a/ee/kernel/include/timer_alarm.h
+++ b/ee/kernel/include/timer_alarm.h
@@ -65,12 +65,13 @@ static inline u64 Sec2TimerBusClock(u64 sec) {
 }
 
 static inline void TimerBusClock2USec (u64 ulClock, u32 *pSec, u32 *pUsec) {
-    *pSec = ulClock/kBUSCLK;
-    *pUsec = ulClock - (*pSec * kBUSCLK);
+    u64 sec = ulClock/kBUSCLK;
+    *pSec = (u32)sec;
+    *pUsec = ulClock - (sec * kBUSCLK);
 }
 
 static inline u64 TimerUSec2BusClock (u32 sec, u32 usec) {
-    return USec2TimerBusClock(sec * 1000000 + usec);
+    return Sec2TimerBusClock(sec) + USec2TimerBusClock(usec);
 }
 
 #endif

--- a/ee/kernel/include/timer_alarm.h
+++ b/ee/kernel/include/timer_alarm.h
@@ -46,22 +46,31 @@ void StopTimerAlarm(struct timer_alarm_t *alarm);
 void ThreadWaitClock(u64 clock_cycles);
 
 // Conversion functions, from time to bus cycles
-static inline u64 NSecToCycles(u64 usec) {
+static inline u64 NSec2TimerBusClock(u64 usec) {
     // Approximate, avoid 64 bit division
     return ((((kBUSCLK / 1000) * 65536ULL) / 1000000) * usec) >> 16;
 }
 
-static inline u64 USecToCycles(u64 usec) {
+static inline u64 USec2TimerBusClock(u64 usec) {
     // Approximate, avoid 64 bit division
     return ((((kBUSCLK / 1000) * 1024) / 1000) * usec) >> 10;
 }
 
-static inline u64 MSecToCycles(u64 msec) {
+static inline u64 MSec2TimerBusClock(u64 msec) {
     return (kBUSCLK / 1000) * msec;
 }
 
-static inline u64 SecToCycles(u64 sec) {
+static inline u64 Sec2TimerBusClock(u64 sec) {
     return kBUSCLK * sec;
+}
+
+static inline void TimerBusClock2USec (u64 ulClock, u32 *pSec, u32 *pUsec) {
+    *pSec = ulClock/kBUSCLK;
+    *pUsec = ulClock - (*pSec * kBUSCLK);
+}
+
+static inline u64 TimerUSec2BusClock (u32 sec, u32 usec) {
+    return USec2TimerBusClock(sec * 1000000 + usec);
 }
 
 #endif

--- a/ee/kernel/samples/systemTime/test_systemTime.c
+++ b/ee/kernel/samples/systemTime/test_systemTime.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
 {
     uint64_t current, previous;
 
-    printf("\n\nStarting ps2_clock example!\n");
+    printf("\n\nStarting GetTimerSystemTime example!\n");
     previous = GetTimerSystemTime();
     
     while (1)

--- a/ee/kernel/samples/timer_alarm/test_alarm.c
+++ b/ee/kernel/samples/timer_alarm/test_alarm.c
@@ -28,8 +28,8 @@ int main(int argc, char **argv)
     struct timer_alarm_t alarm, alarm2;
     InitializeTimerAlarm(&alarm);
     InitializeTimerAlarm(&alarm2);
-    SetTimerAlarm(&alarm, SecToCycles(2), &usercb, &flag);
-    SetTimerAlarm(&alarm2, MSecToCycles(1414), &usercb, &flag2);
+    SetTimerAlarm(&alarm, Sec2TimerBusClock(2), &usercb, &flag);
+    SetTimerAlarm(&alarm2, MSec2TimerBusClock(1414), &usercb, &flag2);
     StartTimerAlarm(&alarm);
     StartTimerAlarm(&alarm2);
 

--- a/ee/kernel/samples/timer_alarm_sleep/test_alarm_sleep.c
+++ b/ee/kernel/samples/timer_alarm_sleep/test_alarm_sleep.c
@@ -20,7 +20,7 @@ volatile int flag = 0;
 int main(int argc, char **argv)
 {
     while (1) {
-        ThreadWaitClock(MSecToCycles(350));
+        ThreadWaitClock(MSec2TimerBusClock(350));
         printf("Hello there, 350ms tick!\n");
     }
 

--- a/ee/kernel/samples/timer_alarm_stop/test_alarm_stop.c
+++ b/ee/kernel/samples/timer_alarm_stop/test_alarm_stop.c
@@ -34,8 +34,8 @@ int main(int argc, char **argv)
 {
     InitializeTimerAlarm(&alarm);
     InitializeTimerAlarm(&alarm2);
-    SetTimerAlarm(&alarm, SecToCycles(2), &usercb1, &flag);
-    SetTimerAlarm(&alarm2, SecToCycles(5), &usercb2, &flag2);
+    SetTimerAlarm(&alarm, Sec2TimerBusClock(2), &usercb1, &flag);
+    SetTimerAlarm(&alarm2, Sec2TimerBusClock(5), &usercb2, &flag2);
     StartTimerAlarm(&alarm);
     StartTimerAlarm(&alarm2);
 

--- a/ee/kernel/src/timer_alarm.c
+++ b/ee/kernel/src/timer_alarm.c
@@ -91,7 +91,7 @@ static int timOverflow(int ca) {
 
     // Check if we actually triggered an alarm
     if (event_queue) {
-        if (ps2_clock() > (event_queue->scheduled_time >> 8)) {
+        if (GetTimerSystemTime() > (event_queue->scheduled_time)) {
             // Remove the top of the queue
             struct timer_alarm_t *gone = event_queue;
             event_queue = event_queue->next;

--- a/ee/libc/include/ps2sdkapi.h
+++ b/ee/libc/include/ps2sdkapi.h
@@ -36,7 +36,7 @@ extern struct dirent * (*_ps2sdk_readdir)(DIR *dir);
 extern void (*_ps2sdk_rewinddir)(DIR *dir);
 extern int (*_ps2sdk_closedir)(DIR *dir);
 
-#define PS2_CLOCKS_PER_SEC (147456000 / 256) // 576.000
+#define PS2_CLOCKS_PER_SEC kBUSCLKBY256 // 576.000
 #define PS2_CLOCKS_PER_MSEC (PS2_CLOCKS_PER_SEC / 1000) // 576
 
 typedef uint64_t ps2_clock_t;

--- a/ee/libc/samples/nanosleep/Makefile
+++ b/ee/libc/samples/nanosleep/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = mem_test nanosleep regress
+SAMPLE_DIR = libc/nanosleep
 
 include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+include $(PS2SDKSRC)/samples/Rules.samples

--- a/ee/libc/samples/nanosleep/Makefile.sample
+++ b/ee/libc/samples/nanosleep/Makefile.sample
@@ -1,0 +1,36 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+SCREEN_DEBUG = 1
+VERBOSE = 0
+
+EE_BIN   = nanosleep_test.elf
+EE_OBJS  = main.o
+
+ifeq ($(SCREEN_DEBUG), 1)
+EE_LIBS += -ldebug
+EE_CFLAGS += -DSCREEN_DEBUG
+endif
+
+ifeq ($(VERBOSE), 1)
+EE_CFLAGS += -DVERBOSE
+endif
+
+all: $(EE_BIN)
+
+clean:
+	rm -rf $(EE_BIN) $(EE_OBJS)
+
+run: $(EE_BIN)
+	ps2client execee host:$(EE_BIN)
+
+reset:
+	ps2client reset
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/ee/libc/samples/nanosleep/main.c
+++ b/ee/libc/samples/nanosleep/main.c
@@ -1,0 +1,69 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2005, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Malloc tester
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <kernel.h>
+#include <time.h>
+
+#if defined(SCREEN_DEBUG)
+#include <unistd.h>
+#include <debug.h>
+#endif
+
+#if defined(SCREEN_DEBUG)
+#define custom_printf(args...) \
+    printf(args);              \
+    scr_printf(args);
+#else
+#define custom_printf(args...) printf(args);
+#endif
+
+int main(int argc, char *argv[])
+{
+    int second_waited = 0;
+    clock_t start, diff, diff_error, error_tolerance;
+    struct timespec tv = {0};
+    tv.tv_sec = 1;
+    tv.tv_nsec = 0;
+    error_tolerance = 5; // 5 miliseconds of error tolerance
+
+#if defined(SCREEN_DEBUG)
+    init_scr();
+    sleep(3);
+#endif
+    custom_printf("\n\nStarting NANOSLEEP TESTS...\n");
+
+    start = clock();
+    while(tv.tv_sec <= 10) {
+        custom_printf("Waiting %lli second...\n", tv.tv_sec);
+        nanosleep(&tv, NULL);
+        second_waited += tv.tv_sec;
+        tv.tv_sec++;
+    }
+    diff = (clock() - start);
+    diff_error = (second_waited * 1000) - diff;
+
+    custom_printf("Checking if we have waited %i seconds...\n", second_waited);
+    custom_printf("We have waited: %lu milliseconds\n", diff);
+
+    if (abs(diff_error)  < error_tolerance) {
+        custom_printf("nanosecond looks to works properly\n");
+    } else {
+        custom_printf("nanosecond is not accurate there is a difference of %lu milliseconds \n", diff_error);
+    }
+
+    SleepThread();
+
+    return 0;
+}

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <kernel.h>
+#include <timer.h>
 #include <malloc.h>
 #include <sio.h>
 
@@ -631,7 +632,7 @@ int _gettimeofday(struct timeval *tv, struct timezone *tz) {
 
 #ifdef F__times
 clock_t _times(struct tms *buffer) {
-	clock_t clk = ps2_clock() / (PS2_CLOCKS_PER_SEC / CLOCKS_PER_SEC);
+	clock_t clk = GetTimerSystemTime() / (kBUSCLK / CLOCKS_PER_SEC);
 
 	if (buffer != NULL) {
 		buffer->tms_utime  = clk;

--- a/ee/libc/src/ps2sdkapi.c
+++ b/ee/libc/src/ps2sdkapi.c
@@ -637,7 +637,7 @@ clock_t _times(struct tms *buffer) {
 	if (buffer != NULL) {
 		buffer->tms_utime  = clk;
 		buffer->tms_stime  = 0;
-		buffer->tms_cutime = clk;
+		buffer->tms_cutime = 0;
 		buffer->tms_cstime = 0;
 	}
 

--- a/ee/libc/src/sleep.c
+++ b/ee/libc/src/sleep.c
@@ -15,21 +15,18 @@
 
 #include <kernel.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <errno.h>
 #include <time.h>
 #include <timer_alarm.h>
 
 #ifdef F_nanosleep
-static inline u64 timespec_to_nanosecs(const struct timespec *pts) {
-    return (pts->tv_sec * 1000000000ULL) + pts->tv_nsec;
-}
 
 int nanosleep(const struct timespec *req, struct timespec *rem)
 {
-    u64 nano_secs, cycles;
+    uint64_t cycles;
 
-    nano_secs = timespec_to_nanosecs(req);
-    cycles = NSecToCycles(nano_secs);
+    cycles = TimerUSec2BusClock(req->tv_sec, req->tv_nsec * 1000);
     ThreadWaitClock(cycles);
 
     if (rem != NULL) {

--- a/ee/libc/src/sleep.c
+++ b/ee/libc/src/sleep.c
@@ -14,83 +14,23 @@
  */
 
 #include <kernel.h>
-
+#include <unistd.h>
 #include <errno.h>
 #include <time.h>
-#include <unistd.h>
-
-#include "ps2sdkapi.h"
-
-#define MIN_HSYNC_PER_SEC (240*50)
-#define MIN_HSYNC_DELAY 100
-#define MAX_PS2CLOCK_PER_HSYNC (PS2_CLOCKS_PER_SEC/MIN_HSYNC_PER_SEC)
+#include <timer_alarm.h>
 
 #ifdef F_nanosleep
-// Start with the highest possible value (so we sleep too short)
-static unsigned int iPS2ClockPerHSync = MAX_PS2CLOCK_PER_HSYNC;
-
-static void _sleep_waker(s32 alarm_id, u16 time, void *arg2)
-{
-    s32 *pSema = (s32 *)arg2;
-
-    (void)alarm_id;
-    (void)time;
-
-    iSignalSema(*pSema);
-    ExitHandler();
-}
-
-static inline u64 timespec_to_us(const struct timespec *pts) {
-    return (pts->tv_sec * 1000000ULL) + (pts->tv_nsec / 1000ULL);
-}
-
-static inline ps2_clock_t us_to_ps2_clock(u64 us) {
-    return (us * PS2_CLOCKS_PER_MSEC) / 1000;
-}
-
-static inline ps2_clock_t timespec_to_ps2_clock(const struct timespec *pts) {
-    return us_to_ps2_clock(timespec_to_us(pts));
+static inline u64 timespec_to_nanosecs(const struct timespec *pts) {
+    return (pts->tv_sec * 1000000000ULL) + pts->tv_nsec;
 }
 
 int nanosleep(const struct timespec *req, struct timespec *rem)
 {
-    ee_sema_t sema;
-    s32 sema_id;
-    ps2_clock_t clock_delay, clock_end, clock_real_end;
-    u16 hsync_delay;
+    u64 nano_secs, cycles;
 
-    clock_delay = timespec_to_ps2_clock(req);
-    clock_end   = ps2_clock() + clock_delay;
-    hsync_delay = clock_delay / iPS2ClockPerHSync;
-
-    if (hsync_delay >= MIN_HSYNC_DELAY) {
-        sema.init_count = 0;
-        sema.max_count  = 1;
-        sema.option     = 0;
-        sema_id = CreateSema(&sema);
-
-        SetAlarm(hsync_delay, _sleep_waker, &sema_id);
-        WaitSema(sema_id);
-        DeleteSema(sema_id);
-
-        // Correct the HSync delay
-        // NOTE: We're always trying to end btween 0 and 1 HSyncs too short
-        clock_real_end = ps2_clock();
-        if (clock_real_end < (clock_end - iPS2ClockPerHSync)) {
-            // We sleeped too short, so HSyncs must be faster
-            // Correct the HSyncs for next time
-            iPS2ClockPerHSync -= (clock_end - iPS2ClockPerHSync - clock_real_end) / hsync_delay;
-        }
-        else if (clock_real_end > clock_end) {
-            // We sleeped too long, so HSyncs must be slower
-            // Correct the HSyncs for next time
-            iPS2ClockPerHSync += (clock_real_end - clock_end) / (hsync_delay-1);
-        }
-    }
-
-    // Delay whatever time is left
-    while(clock_end > ps2_clock())
-        ;
+    nano_secs = timespec_to_nanosecs(req);
+    cycles = NSecToCycles(nano_secs);
+    ThreadWaitClock(cycles);
 
     if (rem != NULL) {
         rem->tv_sec = 0;
@@ -99,4 +39,5 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
 
 	return 0;
 }
+
 #endif

--- a/samples/Makefile_sample
+++ b/samples/Makefile_sample
@@ -26,6 +26,7 @@ SUBDIRS += kernel/noPatchedHelloWorld
 SUBDIRS += kernel/nanoHelloWorld
 SUBDIRS += libc/regress
 SUBDIRS += libc/mem_test
+SUBDIRS += libc/nanosleep
 SUBDIRS += libgs/doublebuffer
 SUBDIRS += libgs/draw
 #SUBDIRS += mpeg                #TODO: not modified for updated newlib


### PR DESCRIPTION
Now that we have real timers in the `kernel` and we can do `ThreadWaitClock` let's update our tricky `nanosleep` implementation.