### PR TITLE
Fixed small variable typo (packet2)

### DIFF
--- a/ee/packet2/include/packet2.h
+++ b/ee/packet2/include/packet2.h
@@ -153,7 +153,7 @@ extern "C"
 
     static inline void packet2_add_data(packet2_t *packet2, void *t_data, u32 t_size)
     {
-        int i;
+        u32 i;
         for (i = 0; i < t_size; i++)
             packet2_add_u128(packet2, ((u128 *)t_data)[i]);
     }


### PR DESCRIPTION
Small change.
It is frustrating me to look at this warning in every compilation.  

![image](https://user-images.githubusercontent.com/32263891/173187330-71d45df2-c7c4-401c-83b7-8ec9209ef074.png)
