### PR TITLE
Packet2: Fixed wrong cmd in flusha

### DIFF
--- a/ee/packet2/include/packet2_types.h
+++ b/ee/packet2/include/packet2_types.h
@@ -214,7 +214,7 @@ enum VIFOpcode
      * FLUSHA waits for the state in which there is no transfer request from PATH3 after the end of micro 
      * program in VU1 and end of transfer to the GIF from PATH1 and PATH2. 
      */
-    P2_VIF_FLUSHA = 18,
+    P2_VIF_FLUSHA = 19,
     /** 
      * Activates the microprogram. 
      * MSCAL waits for the end of the microprogram under execution and activates the micro program with the 


### PR DESCRIPTION
Typo fix. There is no `18` VIFCode

![image](https://user-images.githubusercontent.com/32263891/174450577-6718f9f6-f395-4edd-8a2f-bfe94109e0a0.png)
