### PR TITLE
usbd: add MINI_DRIVER version that uses 40+ KB less IOP RAM

### DIFF
--- a/iop/usb/usbd/src/driver.c
+++ b/iop/usb/usbd/src/driver.c
@@ -270,7 +270,11 @@ int initCallbackThread(void)
     thread.attr      = TH_C;
     thread.option    = 0;
     thread.thread    = callbackThreadFunc;
-    thread.stacksize = 0x4000;
+#ifndef MINI_DRIVER
+    thread.stacksize = 0x4000; // 16KiB
+#else
+    thread.stacksize = 0x0800; //  2KiB
+#endif
     thread.priority  = usbConfig.cbThreadPrio;
     callbackTid      = CreateThread(&thread);
     StartThread(callbackTid, NULL);

--- a/iop/usb/usbd/src/hcd.c
+++ b/iop/usb/usbd/src/hcd.c
@@ -519,7 +519,11 @@ int hcdInit(void)
     thread.attr      = TH_C;
     thread.option    = 0;
     thread.thread    = hcdIrqThread;
-    thread.stacksize = 0x4000;
+#ifndef MINI_DRIVER
+    thread.stacksize = 0x4000; // 16KiB
+#else
+    thread.stacksize = 0x0800; //  2KiB
+#endif
     thread.priority  = usbConfig.hcdThreadPrio;
     hcdTid           = CreateThread(&thread);
     StartThread(hcdTid, (void *)hcdIrqEvent);

--- a/iop/usb/usbd/src/usbd.c
+++ b/iop/usb/usbd/src/usbd.c
@@ -31,6 +31,7 @@ IRX_ID("usbd", 1, 1);
 // While the header of the export table is small, the large size of the export table (as a whole) places it in data instead of sdata.
 extern struct irx_export_table _exp_usbd __attribute__((section("data")));
 
+#ifndef MINI_DRIVER
 UsbdConfig usbConfig = {
     0x20,  // maxDevices
     0x40,  // maxEndpoints
@@ -44,6 +45,21 @@ UsbdConfig usbConfig = {
     0x1E, // hcdThreadPrio
     0x24  // cbThreadPrio
 };
+#else
+UsbdConfig usbConfig = {
+    0x10,  // maxDevices
+    0x20,  // maxEndpoints
+    0x40,  // maxTransDesc
+    0x40,  // maxIsoTransfDesc
+    0x100, // maxIoReqs
+    0x200, // maxStaticDescSize
+    4,     // maxHubDevices
+    4,     // maxPortsPerHub
+
+    0x1E, // hcdThreadPrio
+    0x24  // cbThreadPrio
+};
+#endif
 
 int usbdSema;
 

--- a/iop/usb/usbd_mini/Makefile
+++ b/iop/usb/usbd_mini/Makefile
@@ -6,7 +6,9 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = usbd usbd_mini keyboard camera mouse usbhdfsd usbmass_bd usbmass_bd_mini
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/usb/usbd/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_CFLAGS += -DMINI_DRIVER
+IOP_CFLAGS += -I$(PS2SDKSRC)/iop/usb/usbd/include/
+
+include $(PS2SDKSRC)/iop/usb/usbd/Makefile


### PR DESCRIPTION
For OPL's ingame it is important to use as little RAM as possible to preserve game compatibility. This PR adds the creation of a usbd_mini.irx (from the same sources, no copies), that uses over 40KiB less RAM.

Inspired by the ingame usbd module from @sp193 's ps2esdl.