### PR TITLE
ee/debug: introduced scr_vprintf

### DIFF
--- a/ee/debug/include/debug.h
+++ b/ee/debug/include/debug.h
@@ -26,6 +26,7 @@ extern "C" {
 
 void init_scr(void);
 void scr_printf(const char *, ...) __attribute__((format(printf,1,2)));
+void scr_vprintf(const char *format, va_list opt);
 void scr_putchar(int x, int y, u32 color, int ch);
 void ps2GetStackTrace(unsigned int* results,int max);
 void scr_setXY(int x, int y);

--- a/ee/debug/src/scr_printf.c
+++ b/ee/debug/src/scr_printf.c
@@ -254,11 +254,17 @@ static void clear_line(int Y)
 void scr_printf(const char *format, ...)
 {
     va_list opt;
+    va_start(opt, format);
+    scr_vprintf(format, opt);
+    va_end(opt);
+}
+
+void scr_vprintf(const char *format, va_list opt)
+{
     char buff[2048];
     int i, bufsz, j;
 
 
-    va_start(opt, format);
     bufsz = vsnprintf(buff, sizeof(buff), format, opt);
 
     for (i = 0; i < bufsz; i++) {
@@ -292,7 +298,6 @@ void scr_printf(const char *format, ...)
     }
     if (cursor)
         scr_putchar(X * 7, Y * 8, 0xffffff, 219);
-    va_end(opt);
 }
 
 void scr_setXY(int x, int y)


### PR DESCRIPTION
I have added a VA variant of the scr_printf function for usage from functions that already have va_list initialized.