### PR TITLE
Merge smap from ps2eth

### DIFF
--- a/iop/network/smap-ps2ip/Makefile
+++ b/iop/network/smap-ps2ip/Makefile
@@ -6,12 +6,12 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	netman \
-	smap \
-	smap-ps2ip \
-	smbman \
-	udptty
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/network/smap/src/
+IOP_INC_DIR = $(PS2SDKSRC)/iop/network/smap/include/
+
+SMAP_NETMAN ?= 0
+SMAP_PS2IP ?= 1
+
+include $(PS2SDKSRC)/iop/network/smap/Makefile

--- a/iop/network/smap/Makefile
+++ b/iop/network/smap/Makefile
@@ -7,16 +7,31 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 # Build for use with a DHCP-enabled LWIP stack.
-LWIP_DHCP = 1
+LWIP_DHCP ?= 1
+
+# Build against the netman library.
+SMAP_NETMAN ?= 1
+
+# Build against the ps2ip library.
+SMAP_PS2IP ?= 0
 
 IOP_PREFER_GPOPT = 16384
 IOP_CFLAGS += -mno-check-zero-division
 
-ifdef LWIP_DHCP
+ifneq (x$(LWIP_DHCP),x0)
 IOP_CFLAGS += -DLWIP_DHCP=1
 endif
 
-IOP_INCS = -I$(PS2SDKSRC)/iop/dev9/dev9/include
+ifneq (x$(SMAP_NETMAN),x0)
+IOP_CFLAGS += -DBUILDING_SMAP_NETMAN=1
+endif
+
+ifneq (x$(SMAP_PS2IP),x0)
+IOP_CFLAGS += -DBUILDING_SMAP_PS2IP=1
+IOP_INCS += -I$(PS2SDKSRC)/iop/tcpip/tcpip/include
+endif
+
+IOP_INCS += -I$(PS2SDKSRC)/iop/dev9/dev9/include
 
 IOP_OBJS = main.o smap.o xfer.o imports.o exports.o
 

--- a/iop/network/smap/src/exports.tab
+++ b/iop/network/smap/src/exports.tab
@@ -1,3 +1,4 @@
+#ifdef BUILDING_SMAP_NETMAN
 void _retonly(){};
 
 DECLARE_EXPORT_TABLE(smap, 1, 1)
@@ -6,3 +7,4 @@ DECLARE_EXPORT_TABLE(smap, 1, 1)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 END_EXPORT_TABLE
+#endif

--- a/iop/network/smap/src/imports.lst
+++ b/iop/network/smap/src/imports.lst
@@ -32,6 +32,7 @@ I_RegisterLibraryEntries
 I_ReleaseLibraryEntries
 loadcore_IMPORTS_end
 
+#ifdef BUILDING_SMAP_NETMAN
 netman_IMPORTS_start
 I_NetManNetProtStackAllocPacket
 I_NetManNetProtStackFreePacket
@@ -42,6 +43,26 @@ I_NetManToggleNetIFLinkState
 I_NetManTxPacketNext
 I_NetManTxPacketDeQ
 netman_IMPORTS_end
+#endif
+
+#ifdef BUILDING_SMAP_PS2IP
+ps2ip_IMPORTS_start
+I_pbuf_alloc
+I_pbuf_free
+I_pbuf_coalesce
+I_pbuf_ref
+I_netif_add
+I_netif_set_default
+I_netif_set_up
+I_ps2ip_input
+I_etharp_output
+I_inet_addr
+I_tcpip_input
+I_netif_set_link_up
+I_netif_set_link_down
+I_tcpip_callback_with_block
+ps2ip_IMPORTS_end
+#endif
 
 thevent_IMPORTS_start
 I_CreateEventFlag

--- a/iop/network/smap/src/include/irx_imports.h
+++ b/iop/network/smap/src/include/irx_imports.h
@@ -7,7 +7,12 @@
 #include <dev9.h>
 #include <intrman.h>
 #include <loadcore.h>
+#ifdef BUILDING_SMAP_NETMAN
 #include <netman.h>
+#endif
+#ifdef BUILDING_SMAP_PS2IP
+#include <ps2ip.h>
+#endif
 #include <stdio.h>
 #include <sysclib.h>
 #include <thbase.h>

--- a/iop/network/smap/src/include/main.h
+++ b/iop/network/smap/src/include/main.h
@@ -1,6 +1,25 @@
 // In the SONY original, all the calls to DEBUG_PRINTF() were to sceInetPrintf().
 #define DEBUG_PRINTF(args...) printf(args)
 
+#ifdef BUILDING_SMAP_PS2IP
+struct RuntimeStats
+{
+    u32 RxDroppedFrameCount;
+    u32 RxErrorCount;
+    u16 RxFrameOverrunCount;
+    u16 RxFrameBadLengthCount;
+    u16 RxFrameBadFCSCount;
+    u16 RxFrameBadAlignmentCount;
+    u32 TxDroppedFrameCount;
+    u32 TxErrorCount;
+    u16 TxFrameLOSSCRCount;
+    u16 TxFrameEDEFERCount;
+    u16 TxFrameCollisionCount;
+    u16 TxFrameUnderrunCount;
+    u16 RxAllocFail;
+};
+#endif
+
 struct SmapDriverData
 {
     volatile u8 *smap_regbase;
@@ -20,8 +39,13 @@ struct SmapDriverData
     unsigned char LinkStatus; // Ethernet link is initialized (hardware)
     unsigned char LinkMode;
     iop_sys_clock_t LinkCheckTimer;
+#ifdef BUILDING_SMAP_NETMAN
     struct NetManEthRuntimeStats RuntimeStats;
     int NetIFID;
+#endif
+#ifdef BUILDING_SMAP_PS2IP
+    struct RuntimeStats RuntimeStats;
+#endif
 };
 
 /* Event flag bits */
@@ -34,9 +58,20 @@ struct SmapDriverData
 /* Function prototypes */
 int DisplayBanner(void);
 int smap_init(int argc, char *argv[]);
+#ifdef BUILDING_SMAP_PS2IP
+int SMAPInitStart(void);
+#endif
 int SMAPStart(void);
 void SMAPStop(void);
 void SMAPXmit(void);
 int SMAPGetMACAddress(u8 *buffer);
+#ifdef BUILDING_SMAP_PS2IP
+void PS2IPLinkStateUp(void);
+void PS2IPLinkStateDown(void);
+
+void SMapLowLevelInput(struct pbuf *pBuf);
+int SMapTxPacketNext(void **payload);
+void SMapTxPacketDeQ(void);
+#endif
 
 #include "xfer.h"

--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -1,28 +1,295 @@
+#ifdef BUILDING_SMAP_NETMAN
 #include <errno.h>
+#endif
 #include <stdio.h>
+#ifdef BUILDING_SMAP_PS2IP
+#include <sysclib.h>
+#endif
 #include <loadcore.h>
 #include <thbase.h>
+#ifdef BUILDING_SMAP_PS2IP
+#include <thevent.h>
+#include <thsemap.h>
+#include <intrman.h>
+#endif
+#ifdef BUILDING_SMAP_PS2IP
+#include <ps2ip.h>
+#endif
+#ifdef BUILDING_SMAP_NETMAN
 #include <irx.h>
 #include <netman.h>
+#endif
 
 #include "main.h"
+#ifdef BUILDING_SMAP_NETMAN
 #include "xfer.h"
+#endif
 
 // Last SDK 3.1.0 has INET family version "2.26.0"
 // SMAP module is the same as "2.25.0"
 IRX_ID("SMAP_driver", 0x2, 0x1A);
 
+#ifdef BUILDING_SMAP_PS2IP
+
+#define IFNAME0 's'
+#define IFNAME1 'm'
+
+typedef struct ip4_addr IPAddr;
+typedef struct netif NetIF;
+typedef struct SMapIF SMapIF;
+typedef struct pbuf PBuf;
+
+static struct pbuf *TxHead, *TxTail;
+static void EnQTxPacket(struct pbuf *tx);
+
+static NetIF NIF;
+
+// From lwip/err.h and lwip/tcpip.h
+
+#define ERR_OK   0   // No error, everything OK
+#define ERR_MEM  -1  // Out of memory error.
+#define ERR_CONN -6  // Not connected
+#define ERR_IF   -11 // Low-level netif error
+
+// SMapLowLevelOutput():
+
+// This function is called by the TCP/IP stack when a low-level packet should be sent. It'll be invoked in the context of the
+// tcpip-thread.
+
+static err_t
+SMapLowLevelOutput(NetIF *pNetIF, PBuf *pOutput)
+{
+    err_t result;
+    struct pbuf *pbuf;
+
+#if USE_GP_REGISTER
+    void *OldGP;
+
+    OldGP = SetModuleGP();
+#endif
+
+    result = ERR_OK;
+    if (pOutput->tot_len > pOutput->len) {
+        pbuf_ref(pOutput);                                          // Increment reference count because LWIP must free the PBUF, not the driver!
+        if ((pbuf = pbuf_coalesce(pOutput, PBUF_RAW)) != pOutput) { // No need to increase reference count because pbuf_coalesce() does it.
+            EnQTxPacket(pbuf);
+            SMAPXmit();
+        } else
+            result = ERR_MEM;
+    } else {
+        pbuf_ref(pOutput); // This will be freed later.
+        EnQTxPacket(pOutput);
+        SMAPXmit();
+    }
+
+#if USE_GP_REGISTER
+    SetGP(OldGP);
+#endif
+
+    return result;
+}
+
+// SMapOutput():
+
+// This function is called by the TCP/IP stack when an IP packet should be sent. It'll be invoked in the context of the
+// tcpip-thread, hence no synchronization is required.
+//  For LWIP versions before v1.3.0.
+#ifdef PRE_LWIP_130_COMPAT
+static err_t
+SMapOutput(NetIF *pNetIF, PBuf *pOutput, IPAddr *pIPAddr)
+{
+    err_t result;
+    PBuf *pBuf;
+
+#if USE_GP_REGISTER
+    void *OldGP;
+
+    OldGP = SetModuleGP();
+#endif
+
+    pBuf = etharp_output(pNetIF, pIPAddr, pOutput);
+
+    result = pBuf != NULL ? SMapLowLevelOutput(pNetIF, pBuf) : ERR_OK;
+
+#if USE_GP_REGISTER
+    SetGP(OldGP);
+#endif
+
+    return result;
+}
+#endif
+
+// SMapIFInit():
+
+// Should be called at the beginning of the program to set up the network interface.
+
+static err_t
+SMapIFInit(NetIF *pNetIF)
+{
+#if USE_GP_REGISTER
+    void *OldGP;
+
+    OldGP = SetModuleGP();
+#endif
+
+    TxHead = NULL;
+    TxTail = NULL;
+
+    pNetIF->name[0] = IFNAME0;
+    pNetIF->name[1] = IFNAME1;
+#ifdef PRE_LWIP_130_COMPAT
+    pNetIF->output = &SMapOutput; // For LWIP versions before v1.3.0.
+#else
+    pNetIF->output = &etharp_output;                             // For LWIP 1.3.0 and later.
+#endif
+    pNetIF->linkoutput = &SMapLowLevelOutput;
+    pNetIF->hwaddr_len = NETIF_MAX_HWADDR_LEN;
+#ifdef PRE_LWIP_130_COMPAT
+    pNetIF->flags |= (NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST); // For LWIP versions before v1.3.0.
+#else
+    pNetIF->flags |= (NETIF_FLAG_ETHARP | NETIF_FLAG_BROADCAST); // For LWIP v1.3.0 and later.
+#endif
+    pNetIF->mtu = 1500;
+
+    // Get MAC address.
+    SMAPGetMACAddress(pNetIF->hwaddr);
+    DEBUG_PRINTF("MAC address : %02x:%02x:%02x:%02x:%02x:%02x\n", pNetIF->hwaddr[0], pNetIF->hwaddr[1], pNetIF->hwaddr[2],
+              pNetIF->hwaddr[3], pNetIF->hwaddr[4], pNetIF->hwaddr[5]);
+
+    // Enable sending and receiving of data.
+    SMAPInitStart();
+
+#if USE_GP_REGISTER
+    SetGP(OldGP);
+#endif
+
+    return ERR_OK;
+}
+
+void SMapLowLevelInput(PBuf *pBuf)
+{
+    // When we receive data, the interrupt-handler will invoke this function, which means we are in an interrupt-context. Pass on
+    // the received data to ps2ip.
+
+    ps2ip_input(pBuf, &NIF);
+}
+
+static void EnQTxPacket(struct pbuf *tx)
+{
+    int OldState;
+
+    CpuSuspendIntr(&OldState);
+
+    if (TxHead != NULL)
+        TxHead->next = tx;
+
+    TxHead   = tx;
+    tx->next = NULL;
+
+    if (TxTail == NULL) // Queue empty
+        TxTail = TxHead;
+
+    CpuResumeIntr(OldState);
+}
+
+int SMapTxPacketNext(void **payload)
+{
+    int len;
+
+    if (TxTail != NULL) {
+        *payload = TxTail->payload;
+        len      = TxTail->len;
+    } else
+        len = 0;
+
+    return len;
+}
+
+void SMapTxPacketDeQ(void)
+{
+    struct pbuf *toFree;
+    int OldState;
+
+    toFree = NULL;
+
+    CpuSuspendIntr(&OldState);
+    if (TxTail != NULL) {
+        toFree = TxTail;
+
+        if (TxTail == TxHead) {
+            // Last in queue.
+            TxTail = NULL;
+            TxHead = NULL;
+        } else {
+            TxTail = TxTail->next;
+        }
+    }
+    CpuResumeIntr(OldState);
+
+    if (toFree != NULL) {
+        toFree->next = NULL;
+        pbuf_free(toFree);
+    }
+}
+
+static inline int SMapInit(IPAddr *IP, IPAddr *NM, IPAddr *GW, int argc, char *argv[])
+{
+    if (smap_init(argc, argv) != 0) {
+        return 0;
+    }
+    DEBUG_PRINTF("SMapInit: SMap initialized\n");
+
+    netif_add(&NIF, IP, NM, GW, &NIF, &SMapIFInit, tcpip_input);
+    netif_set_default(&NIF);
+    netif_set_up(&NIF);
+    DEBUG_PRINTF("SMapInit: NetIF added to ps2ip\n");
+
+    // Return 1 (true) to indicate success.
+
+    return 1;
+}
+
+static void
+PrintIP(struct ip4_addr const *pAddr)
+{
+    printf("%d.%d.%d.%d", (u8)pAddr->addr, (u8)(pAddr->addr >> 8), (u8)(pAddr->addr >> 16), (u8)(pAddr->addr >> 24));
+}
+
+void PS2IPLinkStateUp(void)
+{
+    tcpip_callback((void *)&netif_set_link_up, &NIF);
+}
+
+void PS2IPLinkStateDown(void)
+{
+    tcpip_callback((void *)&netif_set_link_down, &NIF);
+}
+#endif
+
+#ifdef BUILDING_SMAP_NETMAN
 // While the header of the export table is small, the large size of the export table (as a whole) places it in data instead of sdata.
 extern struct irx_export_table _exp_smap __attribute__((section("data")));
+#endif
 
 int _start(int argc, char *argv[])
 {
+#ifdef BUILDING_SMAP_PS2IP
+    IPAddr IP;
+    IPAddr NM;
+    IPAddr GW;
+    int numArgs;
+    char **pArgv;
+#endif
+#ifdef BUILDING_SMAP_NETMAN
     int result;
+#endif
 
+#ifdef BUILDING_SMAP_NETMAN
     if (RegisterLibraryEntries(&_exp_smap) != 0) {
         DEBUG_PRINTF("smap: module already loaded\n");
         return MODULE_NO_RESIDENT_END;
     }
+#endif
 
     DisplayBanner();
 
@@ -43,12 +310,55 @@ int _start(int argc, char *argv[])
         return MODULE_NO_RESIDENT_END;
     } */
 
+#ifdef BUILDING_SMAP_PS2IP
+    // Parse IP args.
+    DEBUG_PRINTF("SMAP: argc %d\n", argc);
 
+    if (argc >= 4) {
+        DEBUG_PRINTF("SMAP: %s %s %s\n", argv[1], argv[2], argv[3]);
+        IP.addr = inet_addr(argv[1]);
+        NM.addr = inet_addr(argv[2]);
+        GW.addr = inet_addr(argv[3]);
+
+        numArgs = argc - 4;
+        pArgv   = &argv[4];
+    } else {
+        // Set some defaults.
+
+        IP4_ADDR(&IP, 192, 168, 0, 80);
+        IP4_ADDR(&NM, 255, 255, 255, 0);
+        IP4_ADDR(&GW, 192, 168, 0, 1);
+
+        numArgs = argc - 1;
+        pArgv   = &argv[1];
+    }
+#endif
+
+#ifdef BUILDING_SMAP_NETMAN
     if ((result = smap_init(argc, argv)) < 0) {
         DEBUG_PRINTF("smap: smap_init -> %d\n", result);
         ReleaseLibraryEntries(&_exp_smap);
         return MODULE_NO_RESIDENT_END;
     }
+#endif
+
+#ifdef BUILDING_SMAP_PS2IP
+    if (!SMapInit(&IP, &NM, &GW, numArgs, pArgv)) {
+
+        // Something went wrong, return 1 to indicate failure.
+        return MODULE_NO_RESIDENT_END;
+    }
+
+    printf("SMap: Initialized OK, IP: ");
+    PrintIP(&IP);
+    printf(", NM: ");
+    PrintIP(&NM);
+    printf(", GW: ");
+    PrintIP(&GW);
+    printf("\n");
+
+    // Initialized ok.
+#endif
 
     return MODULE_RESIDENT_END;
 }


### PR DESCRIPTION
Merge the `smap` sources from the `ps2eth` repository to reduce code duplication.  

Mainly for backwards compatibility.  