### PR TITLE
Add missing stdarg.h include to debug.h

### DIFF
--- a/ee/debug/include/debug.h
+++ b/ee/debug/include/debug.h
@@ -17,6 +17,7 @@
 #define __DEBUG_H__
 
 #include <tamtypes.h>
+#include <stdarg.h>
 
 #define DEBUG_BGCOLOR(col) *((u64 *) 0x120000e0) = (u64) (col)
 


### PR DESCRIPTION
Fixes include of `debug.h` when `stdarg.h` isn't included caused by 222e4a19d604cf7876609d45fca43c359c62e82a