### PR TITLE
Make Makefile.pref_sample contents the same as Defs.make

### DIFF
--- a/samples/Makefile.pref_sample
+++ b/samples/Makefile.pref_sample
@@ -10,23 +10,62 @@
 # Change the settings, so they match yours         #
 ####################################################
 
-EE_PREFIX ?= mips64r5900el-ps2-elf-
-EE_CC = $(EE_PREFIX)gcc
-EE_CXX= $(EE_PREFIX)g++
-EE_AS = $(EE_PREFIX)as
-EE_LD = $(EE_PREFIX)ld
-EE_AR = $(EE_PREFIX)ar
-EE_OBJCOPY = $(EE_PREFIX)objcopy
-EE_STRIP = $(EE_PREFIX)strip
-EE_ADDR2LINE = $(EE_PREFIX)addr2line
-EE_RANLIB = $(EE_PREFIX)ranlib
+#
+# Definitions for the EE toolchain.
+#
 
-IOP_PREFIX ?= mipsel-ps2-irx-
-IOP_CC = $(IOP_PREFIX)gcc
-IOP_AS = $(IOP_PREFIX)as
-IOP_LD = $(IOP_PREFIX)ld
-IOP_AR = $(IOP_PREFIX)ar
-IOP_OBJCOPY = $(IOP_PREFIX)objcopy
-IOP_STRIP = $(IOP_PREFIX)strip
-IOP_ADDR2LINE = $(IOP_PREFIX)addr2line
-IOP_RANLIB = $(IOP_PREFIX)ranlib
+EE_TOOL_PREFIX ?= mips64r5900el-ps2-elf-
+EE_CC = $(EE_TOOL_PREFIX)gcc
+EE_CXX= $(EE_TOOL_PREFIX)g++
+EE_AS = $(EE_TOOL_PREFIX)as
+EE_LD = $(EE_TOOL_PREFIX)ld
+EE_AR = $(EE_TOOL_PREFIX)ar
+EE_OBJCOPY = $(EE_TOOL_PREFIX)objcopy
+EE_STRIP = $(EE_TOOL_PREFIX)strip
+EE_ADDR2LINE = $(EE_TOOL_PREFIX)addr2line
+EE_RANLIB = $(EE_TOOL_PREFIX)ranlib
+
+#
+# Defintions for the IOP toolchain.
+#
+
+IOP_TOOL_PREFIX ?= mipsel-ps2-irx-
+IOP_CC = $(IOP_TOOL_PREFIX)gcc
+IOP_AS = $(IOP_TOOL_PREFIX)as
+IOP_LD = $(IOP_TOOL_PREFIX)ld
+IOP_AR = $(IOP_TOOL_PREFIX)ar
+IOP_OBJCOPY = $(IOP_TOOL_PREFIX)objcopy
+IOP_STRIP = $(IOP_TOOL_PREFIX)strip
+IOP_ADDR2LINE = $(IOP_TOOL_PREFIX)addr2line
+IOP_RANLIB = $(IOP_TOOL_PREFIX)ranlib
+
+#
+# Definitions for the local toolchain
+#
+
+CC = cc
+AS = as
+LD = ld
+AR = ar
+OBJCOPY = objcopy
+STRIP = strip
+
+#
+# Definitions for local shell operations
+#
+
+MKDIR = mkdir
+RMDIR = rmdir
+ECHO  = echo
+
+SYSTEM = $(shell uname)
+
+ifeq ($(findstring Windows, $(SYSTEM)), Windows)
+  # these versions are used for the cygwin toolchain in a dos environment
+  # since they need to overwrite the standard dos versions of each command
+  MKDIR = cyg-mkdir
+  RMDIR = cyg-rmdir
+  ECHO  = cyg-echo
+endif
+
+MAKEREC = $(MAKE) -C


### PR DESCRIPTION
Fixes the following issue:  

```
make: p: No such file or directory
```