### PR TITLE
Add simple BDM sector cache

### DIFF
--- a/iop/fs/Makefile
+++ b/iop/fs/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = bdm libbdm bdmfs_vfat bdmfs_fatfs devfs fakehost filexio http netfs
+SUBDIRS = libbdm bdm bdmfs_vfat bdmfs_fatfs devfs fakehost filexio http netfs
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/Rules.make

--- a/iop/fs/bdm/Makefile
+++ b/iop/fs/bdm/Makefile
@@ -9,6 +9,9 @@
 # IOP_CFLAGS += -DDEBUG
 
 IOP_OBJS = main.o bdm.o part_driver.o imports.o exports.o
+IOP_LIBS = -lbdm
+IOP_CFLAGS = -I$(PS2SDKSRC)/iop/fs/libbdm/include/
+IOP_LDFLAGS = -L$(PS2SDKSRC)/iop/fs/libbdm/lib/
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make

--- a/iop/fs/bdm/src/imports.lst
+++ b/iop/fs/bdm/src/imports.lst
@@ -6,6 +6,15 @@ stdio_IMPORTS_start
 I_printf
 stdio_IMPORTS_end
 
+sysclib_IMPORTS_start
+I_memcpy
+sysclib_IMPORTS_end
+
+sysmem_IMPORTS_start
+I_AllocSysMemory
+I_FreeSysMemory
+sysmem_IMPORTS_end
+
 thbase_IMPORTS_start
 I_CreateThread
 I_StartThread

--- a/iop/fs/bdm/src/irx_imports.h
+++ b/iop/fs/bdm/src/irx_imports.h
@@ -19,6 +19,8 @@
 #include <bdm.h>
 #include <loadcore.h>
 #include <stdio.h>
+#include <sysclib.h>
+#include <sysmem.h>
 #include <thbase.h>
 #include <thevent.h>
 

--- a/iop/fs/libbdm/Makefile
+++ b/iop/fs/libbdm/Makefile
@@ -10,7 +10,7 @@
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
 
-IOP_OBJS = bd_defrag.o
+IOP_OBJS = bd_defrag.o bd_cache.o
 IOP_LIB = libbdm.a
 
 include $(PS2SDKSRC)/Defs.make

--- a/iop/fs/libbdm/include/bd_cache.h
+++ b/iop/fs/libbdm/include/bd_cache.h
@@ -1,0 +1,30 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * Simple cache for Block Devices
+ */
+
+#ifndef __BDM_CACHE_H__
+#define __BDM_CACHE_H__
+
+
+#include <tamtypes.h>
+#include <bdm.h>
+
+
+/* Create a new cached block device */
+struct block_device *bd_cache_create(struct block_device *bd);
+
+/* Destroy a cached block device */
+void bd_cache_destroy(struct block_device *cbd);
+
+
+#endif

--- a/iop/fs/libbdm/src/bd_cache.c
+++ b/iop/fs/libbdm/src/bd_cache.c
@@ -1,0 +1,188 @@
+#include <bd_cache.h>
+#include <string.h>
+#include <sysmem.h>
+
+//#define DEBUG  //comment out this line when not debugging
+#include "module_debug.h"
+
+
+#define SECTORS_PER_BLOCK 8 // 8 * 512b =  4KiB
+#define BLOCK_COUNT       8 // 8 * 4KiB = 32KiB
+
+
+struct bd_cache
+{
+    struct block_device *bd;
+    u32 lru_current;
+    u32 lru[BLOCK_COUNT];
+    u32 sector[BLOCK_COUNT];
+    u8 cache[BLOCK_COUNT][SECTORS_PER_BLOCK*512];
+#ifdef DEBUG
+    u32 sectors_read;
+    u32 sectors_cache;
+#endif
+};
+
+/* cache overlaps with requested area ? */
+static int _overlaps(u32 csector, u32 sector, u16 count)
+{
+    if ((sector < (csector + SECTORS_PER_BLOCK)) && ((sector + count) > csector))
+        return 1;
+    else
+        return 0;
+}
+
+/* cache contains requested area ? */
+static int _contains(u32 csector, u32 sector, u16 count)
+{
+    if ((sector >= csector) && ((sector + count) <= (csector + SECTORS_PER_BLOCK)))
+        return 1;
+    else
+        return 0;
+}
+
+static void _invalidate(struct bd_cache *c, u32 sector, u16 count)
+{
+    int blkidx;
+
+    for (blkidx = 0; blkidx < BLOCK_COUNT; blkidx++) {
+        if (_overlaps(c->sector[blkidx], sector, count)) {
+            // Invalidate cache entry
+            c->sector[blkidx] = 0xffffffff;
+        }
+    }
+}
+
+static int _read(struct block_device *bd, u32 sector, void *buffer, u16 count)
+{
+    struct bd_cache *c = bd->priv;
+
+    M_DEBUG("%s(%d, %d)\n", __FUNCTION__, sector, count);
+
+    if (count >= SECTORS_PER_BLOCK) {
+        // Do a direct read
+        return c->bd->read(c->bd, sector, buffer, count);
+    }
+    else {
+        // Do a cached read
+        int blkidx;
+        for (blkidx = 0; blkidx < BLOCK_COUNT; blkidx++) {
+            if (_contains(c->sector[blkidx], sector, count)) {
+#ifdef DEBUG
+                c->sectors_cache += 1;
+                M_DEBUG("- CACHE HIT [block %d] [stats: read %ds, cache %ds]\n", blkidx, c->sectors_read, c->sectors_cache);
+#endif
+                // Read from cache
+                u32 offset = (sector - c->sector[blkidx]) * 512;
+                c->lru[blkidx] = c->lru_current++;
+                memcpy(buffer, &c->cache[blkidx][offset], count * 512);
+                return count;
+            }
+        }
+
+        // Find the LRU block
+        u32 blkidx_best_lru = 0xffffffff;
+        int blkidx_best = 0;
+        for (blkidx = 0; blkidx < BLOCK_COUNT; blkidx++) {
+            if (c->lru[blkidx] < blkidx_best_lru) {
+                // Better block found
+                blkidx_best_lru = c->lru[blkidx];
+                blkidx_best = blkidx;
+            }
+        }
+
+#ifdef DEBUG
+        c->sectors_read  += 1; // number of reads from device
+        c->sectors_cache += 1; // number of reads from cache
+        M_DEBUG("- CACHE READ -> [block %d] [stats: read %d, cache %d]\n", blkidx_best, c->sectors_read, c->sectors_cache);
+#endif
+
+        // Fill the block
+        c->bd->read(c->bd, sector, c->cache[blkidx_best], SECTORS_PER_BLOCK);
+        c->sector[blkidx_best] = sector;
+
+        // Read from cache
+        u32 offset = (sector - c->sector[blkidx_best]) * 512;
+        c->lru[blkidx_best] = c->lru_current++;
+        memcpy(buffer, &c->cache[blkidx_best][offset], count * 512);
+        return count;
+    }
+}
+
+static int _write(struct block_device *bd, u32 sector, const void *buffer, u16 count)
+{
+    struct bd_cache *c = bd->priv;
+
+    M_DEBUG("%s(%d, %d)\n", __FUNCTION__, sector, count);
+
+    _invalidate(c, sector, count);
+
+    return c->bd->write(c->bd, sector, buffer, count);
+}
+
+static void _flush(struct block_device *bd)
+{
+    struct bd_cache *c = bd->priv;
+
+    M_DEBUG("%s\n", __FUNCTION__);
+
+    return c->bd->flush(c->bd);
+}
+
+static int _stop(struct block_device *bd)
+{
+    struct bd_cache *c = bd->priv;
+
+    M_DEBUG("%s\n", __FUNCTION__);
+
+    return c->bd->stop(c->bd);
+}
+
+struct block_device *bd_cache_create(struct block_device *bd)
+{
+    int blkidx;
+
+    // Create new block device
+    struct block_device *cbd = AllocSysMemory(ALLOC_FIRST, sizeof(struct block_device), NULL);
+    // Create new private data
+    struct bd_cache *c = AllocSysMemory(ALLOC_FIRST, sizeof(struct bd_cache), NULL);
+
+    M_DEBUG("%s\n", __FUNCTION__);
+
+    c->bd = bd;
+    c->lru_current = 1;
+    for (blkidx = 0; blkidx < BLOCK_COUNT; blkidx++) {
+        c->lru[blkidx] = 0;
+        c->sector[blkidx] = 0xffffffff;
+    }
+#ifdef DEBUG
+    c->sectors_read = 0;
+    c->sectors_cache = 0;
+#endif
+
+    // copy all parameters becouse we are the same blocks device
+    // only difference is we are cached.
+    cbd->priv         = c;
+    cbd->name         = bd->name;
+    cbd->devNr        = bd->devNr;
+    cbd->parNr        = bd->parNr;
+    cbd->parId        = bd->parId;
+    cbd->sectorSize   = bd->sectorSize;
+    cbd->sectorOffset = bd->sectorOffset;
+    cbd->sectorCount  = bd->sectorCount;
+
+    cbd->read = _read;
+    cbd->write = _write;
+    cbd->flush = _flush;
+    cbd->stop = _stop;
+
+    return cbd;
+}
+
+void bd_cache_destroy(struct block_device *cbd)
+{
+    M_DEBUG("%s\n", __FUNCTION__);
+
+    FreeSysMemory(cbd->priv);
+    FreeSysMemory(cbd);
+}


### PR DESCRIPTION
This PR adds a simple 32KiB sector cache to all BDM devices.

Algorithm:
- All reads smaller than 4K will go through the cache (so 512b, 1K, 2k)
- All reads of 4K and larger will **not** use the cache, they are already fast, and only waste cache space.
- Cache will always read in 4K blocks from device (so always more than the requested 512b, 1K, 2k) becouse it is faster
- Cache reads start at the requested sector (so not aligned to 4K)
- Cache has 8 blocks of 4K = 32K
- LRU algorithm
- Read only cache (writes will invalidate the written sectors)

Possible improvements:
- Dynamic cache size (adding an extra parameter to bd_cache_create)
- Better algorithm

Note for OPL:
- This improves GUI loading speeds for all BDM devices
- This **does not** improve ingame speed
- This cache can potentially be used ingame, but that would require a dynamic cache size (see improvements)

Comparison to vfat cache (ccache):
- Has the same 4KiB block size
- Has 32 blocks, instead of 8 (also uses 128KiB instead of 32KiB)
- Has better write support