### PR TITLE
Time and timezone related improvements

### DIFF
--- a/ee/kernel/src/osd_config.c
+++ b/ee/kernel/src/osd_config.c
@@ -129,7 +129,7 @@ int configGetDateFormat(void)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return 0;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
     return config2.dateFormat;
 }
 #endif
@@ -150,9 +150,9 @@ void configSetDateFormat(int dateFormat)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
     config2.dateFormat = dateFormat;
-    SetOsdConfigParam2(&config2, 1, 1);
+    SetOsdConfigParam2(&config2, sizeof(config2), 0);
 }
 #endif
 
@@ -168,7 +168,7 @@ int configGetTimeFormat(void)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return 0;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
     return config2.timeFormat;
 }
 #endif
@@ -189,9 +189,9 @@ void configSetTimeFormat(int timeFormat)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
     config2.timeFormat = timeFormat;
-    SetOsdConfigParam2(&config2, 1, 1);
+    SetOsdConfigParam2(&config2, sizeof(config2), 0);
 }
 #endif
 
@@ -309,7 +309,7 @@ int configIsDaylightSavingEnabled(void)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return 0;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
 
     return config2.daylightSaving;
 }
@@ -327,9 +327,9 @@ void configSetDaylightSavingEnabled(int daylightSaving)
     GetOsdConfigParam(&config);
     if (IsEarlyJap(config))
         return;
-    GetOsdConfigParam2(&config2, 1, 1);
+    GetOsdConfigParam2(&config2, sizeof(config2), 0);
     config2.daylightSaving = daylightSaving;
-    SetOsdConfigParam2(&config2, 1, 1);
+    SetOsdConfigParam2(&config2, sizeof(config2), 0);
     _libcglue_timezone_update();
 }
 #endif

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -617,12 +617,7 @@ int _gettimeofday(struct timeval *tv, struct timezone *tz) {
   	tv->tv_sec = (time_t) ps2time((time_t *) NULL);
   	tv->tv_usec = 0L;
   	if (tz != NULL) {
-		/* TODO: impplement something similar at:
-		https://code.woboq.org/userspace/glibc/sysdeps/posix/gettimeofday.c.html
-		*/
-
-		/* Timezone not supported for gettimeofday */
-		tz->tz_minuteswest = 0;
+		tz->tz_minuteswest = _timezone / 60;
 		tz->tz_dsttime = 0;
     }
 

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -33,7 +33,8 @@ void _libcglue_timezone_update()
 
 	// _timezone is in seconds, while the return value of configGetTimezone is in minutes
 	// Add one hour if configIsDaylightSavingEnabled is 1
-	_timezone = (configGetTimezone() + (configIsDaylightSavingEnabled() * 60)) * 60;
+	// _timezone is offset from local time to UTC (not UTC to local time), so flip the sign
+	_timezone = -((configGetTimezone() + (configIsDaylightSavingEnabled() * 60)) * 60);
 	tz->__tzrule[0].offset = _timezone;
 	snprintf(_ps2sdk_tzname, sizeof(_ps2sdk_tzname), "Etc/GMT%+ld", _timezone / 3600);
 	_tzname[0] = _ps2sdk_tzname;

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -26,8 +26,13 @@ __attribute__((weak))
 void _libcglue_timezone_update()
 {
 	// Set TZ and call tzset to ensure that timezone information won't get overwritten when tszet is called multiple times
+	// The TZ environment variable parsing in newlib is broken in various ways:
+	// * It doesn't support arbritary characters in the timezone name using angle brackets
+	// * The timezone offset sign is inverted
 	setenv("TZ", "", 0);
 	tzset();
+
+	// Set tzinfo manually instead.
 
 	__tzinfo_type *tz = __gettzinfo();
 


### PR DESCRIPTION
`configGetTimezone` and `configSetTimezone` now handle negative timezone offsets.  
`configIsDaylightSavingEnabled` and `configSetDaylightSavingEnabled` now work properly.  
`_timezone` now has the correct sign, so timezone offsets are applied correctly.  
