### PR TITLE
Write also to `sio_write` meanwhile issue with fileXio is fixed

### DIFF
--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -312,8 +312,9 @@ int (*_ps2sdk_write)(int, const void*, int) = fioWrite;
 
 int _write(int fd, const void *buf, size_t nbytes) {
 	// HACK: stdout and strerr to serial
-	//if ((fd==1) || (fd==2))
-	//	return sio_write((void *)buf, nbytes);
+	// meanwhile https://github.com/ps2dev/ps2sdk/issues/332 is fixed
+	if (((fd==1) || (fd==2)) && (_ps2sdk_write != fioWrite))
+		sio_write((void *)buf, nbytes);
 
 	return __transform_errno(_ps2sdk_write(fd, buf, nbytes));
 }


### PR DESCRIPTION
This is a temporal solution meanwhile we find something better for #332 , at least in this way we still can use `PCSX2` for development purposes.

Cheers