### PR TITLE
do not garbage collect sections (can remove .data section)

### DIFF
--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -37,7 +37,7 @@ ifeq ($(DEBUG),1)
 IOP_CFLAGS += -DDEBUG
 endif
 # Linker flags
-IOP_LDFLAGS := -Wl,--gpsize=0 -Wl,-G0 -Wl,--nmagic -Wl,--orphan-handling=error -Wl,--discard-all -Wl,--gc-sections -Wl,--emit-relocs -nostdlib -Wl,-z,max-page-size=128 -Wl,--no-relax $(IOP_LDFLAGS)
+IOP_LDFLAGS := -Wl,--gpsize=0 -Wl,-G0 -Wl,--nmagic -Wl,--orphan-handling=error -Wl,--discard-all -Wl,--emit-relocs -nostdlib -Wl,-z,max-page-size=128 -Wl,--no-relax $(IOP_LDFLAGS)
 
 # Additional C compiler flags for GCC >=v5.3.0
 # -msoft-float is to "remind" GCC/Binutils that the soft-float ABI is to be used. This is due to a bug, which

--- a/iop/startup/src/linkfile
+++ b/iop/startup/src/linkfile
@@ -98,6 +98,7 @@ SECTIONS
 		* ( .symtab )
 		* ( .strtab )
 		* ( .shstrtab )
+		* ( .eh_frame )
 		/*
 		 * This must go because it confuses the IOP kernel (treated as a reloc section).
 		 */


### PR DESCRIPTION
If the IRX_ID in the data section is the only thing in the data section, then it got removed by the garbage collector.

This results in an incomplete IRX header, but since the IRX_ID field is optional, the IRX itself would still work. However in some cases when we try to detect IRX'es by name and or version, this could result in the IRX not being found anymore.

