### PR TITLE
Add alignement to iox_stat_t and iox_dirent_t

### DIFF
--- a/common/include/iox_stat.h
+++ b/common/include/iox_stat.h
@@ -106,14 +106,14 @@ typedef struct
     unsigned int private_4;
     /** Sector start.  */
     unsigned int private_5;
-} iox_stat_t;
+} iox_stat_t __attribute__((aligned(64)));
 
 typedef struct
 {
     iox_stat_t stat;
     char name[256];
     unsigned int unknown;
-} iox_dirent_t;
+} iox_dirent_t __attribute__((aligned(64)));
 
 /* The following defines are only supported by ioman.  */
 


### PR DESCRIPTION
I was suffering some issues with `ps2link/ps2client` when listing directories and file stats.
The error was just happening with `fileXio` however with `fio` it worked properly.

After hours of investigation, we faced (with the help of @F0bes) that it was an alignment issue. Something really similar to the error in `wLaunchELF` https://github.com/ps2homebrew/wLaunchELF/pull/89/files

I have tested it in real hardware and in `PCSX2`, in both places, it is working as expected.

Cheers