### PR TITLE
Libgs: Treat EE->GIF data as volatile like (Fixes libgs)

### DIFF
--- a/ee/libgs/src/dma.c
+++ b/ee/libgs/src/dma.c
@@ -112,6 +112,11 @@ void GsDmaSend(const void *addr, u32 qwords)
 	chcr.tag		=0;
 	chcr.pad1		=0;
 	chcr.pad2		=0;
+
+	// This prevents the compiler from assuming the values in addr are unused,
+	// and that the writes to addr can be delayed until after this function call
+	asm("":::"memory");
+
 	*((volatile DMA_CHCR *)(gif_chcr)) = chcr;
 }
 
@@ -142,10 +147,16 @@ void GsDmaSend_tag(const void *addr, u32 qwords, const GS_GIF_DMACHAIN_TAG *tag)
 	chcr.tag		=0;
 	chcr.pad1		=0;
 	chcr.pad2		=0;
+
+	// This prevents the compiler from assuming the values in addr are unused,
+	// and that the writes to addr can be delayed until after this function call
+	asm("":::"memory");
+
 	*((volatile DMA_CHCR *)(gif_chcr)) = chcr;
 }
 
 void GsDmaWait(void)
 {
 	while(*((vu32 *)(0x1000a000)) & ((u32)1<<8));
+	asm("":::"memory");
 }


### PR DESCRIPTION
libgs shares a block of data for all of it's GIF data.
Because this block was marked as non-volatile and there were no memory barriers in place, the compiler was assuming that data in this block was unused in GsDmaSend(_tag).
This ended up having the GIF tag write be delayed until later, effectively sending 0 as a tag to the GIF (oops!).
This made it so libgs was broken both on hardware and emulation.

This PR adds a memory barrier by clobbering memory.

Thanks goes to TellowKrinkle :)