### PR TITLE
Implement SMAP modular hook interface

### DIFF
--- a/iop/network/smap-modular-netman/Makefile
+++ b/iop/network/smap-modular-netman/Makefile
@@ -6,15 +6,13 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	netman \
-	smap \
-	smap-modular-netman \
-	smap-modular-none \
-	smap-none \
-	smap-ps2ip \
-	smbman \
-	udptty
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/network/smap/src/
+IOP_INC_DIR = $(PS2SDKSRC)/iop/network/smap/include/
+
+SMAP_NETMAN ?= 1
+SMAP_PS2IP ?= 0
+SMAP_MODULAR ?= 1
+
+include $(PS2SDKSRC)/iop/network/smap/Makefile

--- a/iop/network/smap-modular-none/Makefile
+++ b/iop/network/smap-modular-none/Makefile
@@ -6,15 +6,13 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	netman \
-	smap \
-	smap-modular-netman \
-	smap-modular-none \
-	smap-none \
-	smap-ps2ip \
-	smbman \
-	udptty
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/network/smap/src/
+IOP_INC_DIR = $(PS2SDKSRC)/iop/network/smap/include/
+
+SMAP_NETMAN ?= 0
+SMAP_PS2IP ?= 0
+SMAP_MODULAR ?= 1
+
+include $(PS2SDKSRC)/iop/network/smap/Makefile

--- a/iop/network/smap-none/Makefile
+++ b/iop/network/smap-none/Makefile
@@ -6,13 +6,12 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	netman \
-	smap \
-	smap-none \
-	smap-ps2ip \
-	smbman \
-	udptty
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/network/smap/src/
+IOP_INC_DIR = $(PS2SDKSRC)/iop/network/smap/include/
+
+SMAP_NETMAN ?= 0
+SMAP_PS2IP ?= 0
+
+include $(PS2SDKSRC)/iop/network/smap/Makefile

--- a/iop/network/smap/Makefile
+++ b/iop/network/smap/Makefile
@@ -15,6 +15,9 @@ SMAP_NETMAN ?= 1
 # Build against the ps2ip library.
 SMAP_PS2IP ?= 0
 
+# Enable the modular interface.
+SMAP_MODULAR ?= 0
+
 # Poll instead of relying on interrupts when receiving multiple packets.
 # This will avoid the IOP locking up due to the large amount of interrupts.
 SMAP_RX_PACKETS_POLLING_MODE ?= 1
@@ -35,13 +38,17 @@ IOP_CFLAGS += -DBUILDING_SMAP_PS2IP=1
 IOP_INCS += -I$(PS2SDKSRC)/iop/tcpip/tcpip/include
 endif
 
+ifneq (x$(SMAP_MODULAR),x0)
+IOP_CFLAGS += -DBUILDING_SMAP_MODULAR=1
+endif
+
 ifneq (x$(SMAP_RX_PACKETS_POLLING_MODE),x0)
 IOP_CFLAGS += -DSMAP_RX_PACKETS_POLLING_MODE=1
 endif
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/dev9/dev9/include
 
-IOP_OBJS = main.o smap.o xfer.o imports.o exports.o
+IOP_OBJS = ipstack.o main.o smap.o xfer.o imports.o exports.o
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make

--- a/iop/network/smap/include/smap_modular.h
+++ b/iop/network/smap/include/smap_modular.h
@@ -1,0 +1,54 @@
+
+#ifndef _SMAP_MODULAR_H
+#define _SMAP_MODULAR_H
+
+#include <tamtypes.h>
+
+// This struct needs to be the exact same layout as struct RuntimeStats!
+typedef struct SmapModularRuntimeStats
+{
+    u32 RxDroppedFrameCount;
+    u32 RxErrorCount;
+    u16 RxFrameOverrunCount;
+    u16 RxFrameBadLengthCount;
+    u16 RxFrameBadFCSCount;
+    u16 RxFrameBadAlignmentCount;
+    u32 TxDroppedFrameCount;
+    u32 TxErrorCount;
+    u16 TxFrameLOSSCRCount;
+    u16 TxFrameEDEFERCount;
+    u16 TxFrameCollisionCount;
+    u16 TxFrameUnderrunCount;
+    u16 RxAllocFail;
+} SmapModularRuntimeStats_t;
+
+typedef struct SmapModularHookTable
+{
+	int Version;
+	int (*TxPacketNext)(void **data);
+	int (*TxPacketDeQ)(void **data);
+	int (*LinkStateDown)(void);
+	int (*LinkStateUp)(void);
+	void *(*StackAllocRxPacket)(u16 LengthRounded, void **payload);
+	int (*EnQRxPacket)(void *pbuf);
+} SmapModularHookTable_t;
+
+typedef struct SmapModularExportTable
+{
+	int Version;
+	int (*GetMACAddress)(u8 *buffer);
+	void (*Xmit)(void);
+	void (*OutputDebugInformation)(void);
+	int (*RegisterHook)(const SmapModularHookTable_t *hooktbl, int priority);
+	unsigned char *RxBDIndexPtr;
+	SmapModularRuntimeStats_t *RuntimeStatsPtr;
+} SmapModularExportTable_t;
+
+extern const SmapModularExportTable_t *SmapModularGetExportTable(void);
+
+#define smapmodu_IMPORTS_start DECLARE_IMPORT_TABLE(smapmodu, 1, 1)
+#define smapmodu_IMPORTS_end END_IMPORT_TABLE
+
+#define I_SmapModularGetExportTable DECLARE_IMPORT(4, SmapModularGetExportTable)
+
+#endif

--- a/iop/network/smap/src/exports.tab
+++ b/iop/network/smap/src/exports.tab
@@ -1,10 +1,21 @@
-#ifdef BUILDING_SMAP_NETMAN
+
 void _retonly(){};
 
+#ifdef BUILDING_SMAP_NETMAN
 DECLARE_EXPORT_TABLE(smap, 1, 1)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
+END_EXPORT_TABLE
+#endif
+
+#ifdef BUILDING_SMAP_MODULAR
+DECLARE_EXPORT_TABLE(smapmodu, 1, 1)
+	DECLARE_EXPORT(_retonly)
+	DECLARE_EXPORT(_retonly)
+	DECLARE_EXPORT(_retonly)
+	DECLARE_EXPORT(_retonly)
+	DECLARE_EXPORT(SmapModularGetExportTable)
 END_EXPORT_TABLE
 #endif

--- a/iop/network/smap/src/include/ipstack.h
+++ b/iop/network/smap/src/include/ipstack.h
@@ -2,94 +2,11 @@
 #ifndef IPSTACK_H
 #define IPSTACK_H
 
-#ifdef BUILDING_SMAP_NETMAN
-#include <netman.h>
-#endif
-#ifdef BUILDING_SMAP_PS2IP
-#include <ps2ip.h>
-#endif
-
-static inline int SMAPCommonTxPacketNext(void **data)
-{
-#if defined(BUILDING_SMAP_NETMAN)
-    return NetManTxPacketNext(data);
-#elif defined(BUILDING_SMAP_PS2IP)
-    return SMapTxPacketNext(data);
-#else
-    return 0;
-#endif
-}
-
-static inline void SMAPCommonTxPacketDeQ(void **data)
-{
-	(void)data;
-#if defined(BUILDING_SMAP_NETMAN)
-    NetManTxPacketDeQ();
-#elif defined(BUILDING_SMAP_PS2IP)
-    SMapTxPacketDeQ();
-#endif
-}
-
-static inline void SMapCommonLinkStateDown(struct SmapDriverData *SmapDrivPrivData)
-{
-#if defined(BUILDING_SMAP_NETMAN)
-    NetManToggleNetIFLinkState(SmapDrivPrivData->NetIFID, NETMAN_NETIF_ETH_LINK_STATE_DOWN);
-#elif defined(BUILDING_SMAP_PS2IP)
-    (void)SmapDrivPrivData;
-
-    PS2IPLinkStateDown();
-#else
-    (void)SmapDrivPrivData;
-#endif
-}
-
-static inline void SMapCommonLinkStateUp(struct SmapDriverData *SmapDrivPrivData)
-{
-#if defined(BUILDING_SMAP_NETMAN)
-    NetManToggleNetIFLinkState(SmapDrivPrivData->NetIFID, NETMAN_NETIF_ETH_LINK_STATE_UP);
-#elif defined(BUILDING_SMAP_PS2IP)
-    (void)SmapDrivPrivData;
-
-    PS2IPLinkStateUp();
-#else
-    (void)SmapDrivPrivData;
-#endif
-}
-
-static inline void *SMapCommonStackAllocRxPacket(u16 LengthRounded, void **payload)
-{
-	void *pbuf;
-#if defined(BUILDING_SMAP_NETMAN)
-	pbuf = NetManNetProtStackAllocRxPacket(LengthRounded, payload);
-#elif defined(BUILDING_SMAP_PS2IP)
-	struct pbuf *pbuf_struct;
-
-	pbuf_struct = pbuf_alloc(PBUF_RAW, LengthRounded, PBUF_POOL);
-	pbuf = (void *)pbuf_struct;
-
-	if (pbuf_struct != NULL && payload != NULL) {
-		*payload = pbuf_struct->payload;
-	}
-#else
-	(void)LengthRounded;
-	if (payload != NULL)
-	{
-		*payload = NULL;
-	}
-	pbuf = NULL;
-#endif
-	return pbuf;
-}
-
-static inline void SMapStackEnQRxPacket(void *pbuf)
-{
-#if defined(BUILDING_SMAP_NETMAN)
-	NetManNetProtStackEnQRxPacket(pbuf);
-#elif defined(BUILDING_SMAP_PS2IP)
-	SMapLowLevelInput(pbuf);
-#else
-	(void)pbuf;
-#endif
-}
+extern int SMAPCommonTxPacketNext(struct SmapDriverData *SmapDrivPrivData, void **data);
+extern void SMAPCommonTxPacketDeQ(struct SmapDriverData *SmapDrivPrivData, void **data);
+extern void SMapCommonLinkStateDown(struct SmapDriverData *SmapDrivPrivData);
+extern void SMapCommonLinkStateUp(struct SmapDriverData *SmapDrivPrivData);
+extern void *SMapCommonStackAllocRxPacket(struct SmapDriverData *SmapDrivPrivData, u16 LengthRounded, void **payload);
+extern void SMapStackEnQRxPacket(struct SmapDriverData *SmapDrivPrivData, void *pbuf);
 
 #endif

--- a/iop/network/smap/src/include/main.h
+++ b/iop/network/smap/src/include/main.h
@@ -10,6 +10,9 @@
 #ifdef BUILDING_SMAP_PS2IP
 #include <ps2ip.h>
 #endif
+#ifdef BUILDING_SMAP_MODULAR
+#include <smap_modular.h>
+#endif
 
 // In the SONY original, all the calls to DEBUG_PRINTF() were to sceInetPrintf().
 #define DEBUG_PRINTF(args...) printf(args)
@@ -58,6 +61,9 @@ struct SmapDriverData
 #ifdef BUILDING_SMAP_NETMAN
     int NetIFID;
 #endif
+#ifdef BUILDING_SMAP_MODULAR
+    const SmapModularHookTable_t *HookTable[1];
+#endif
 };
 
 /* Event flag bits */
@@ -85,5 +91,8 @@ void SMapLowLevelInput(struct pbuf *pBuf);
 int SMapTxPacketNext(void **payload);
 void SMapTxPacketDeQ(void);
 #endif
+
+/* Data prototypes */
+extern struct SmapDriverData SmapDriverData;
 
 #endif

--- a/iop/network/smap/src/include/main.h
+++ b/iop/network/smap/src/include/main.h
@@ -14,7 +14,7 @@
 // In the SONY original, all the calls to DEBUG_PRINTF() were to sceInetPrintf().
 #define DEBUG_PRINTF(args...) printf(args)
 
-#ifndef BUILDING_SMAP_NETMAN
+// This struct needs to be the exact same layout as struct NetManEthRuntimeStats!
 struct RuntimeStats
 {
     u32 RxDroppedFrameCount;
@@ -31,7 +31,6 @@ struct RuntimeStats
     u16 TxFrameUnderrunCount;
     u16 RxAllocFail;
 };
-#endif
 
 struct SmapDriverData
 {
@@ -55,11 +54,9 @@ struct SmapDriverData
 #ifdef SMAP_RX_PACKETS_POLLING_MODE
     iop_sys_clock_t RxIntrPollingTimer;
 #endif
-#ifdef BUILDING_SMAP_NETMAN
-    struct NetManEthRuntimeStats RuntimeStats;
-    int NetIFID;
-#else
     struct RuntimeStats RuntimeStats;
+#ifdef BUILDING_SMAP_NETMAN
+    int NetIFID;
 #endif
 };
 

--- a/iop/network/smap/src/include/main.h
+++ b/iop/network/smap/src/include/main.h
@@ -14,7 +14,7 @@
 // In the SONY original, all the calls to DEBUG_PRINTF() were to sceInetPrintf().
 #define DEBUG_PRINTF(args...) printf(args)
 
-#ifdef BUILDING_SMAP_PS2IP
+#ifndef BUILDING_SMAP_NETMAN
 struct RuntimeStats
 {
     u32 RxDroppedFrameCount;
@@ -58,8 +58,7 @@ struct SmapDriverData
 #ifdef BUILDING_SMAP_NETMAN
     struct NetManEthRuntimeStats RuntimeStats;
     int NetIFID;
-#endif
-#ifdef BUILDING_SMAP_PS2IP
+#else
     struct RuntimeStats RuntimeStats;
 #endif
 };

--- a/iop/network/smap/src/ipstack.c
+++ b/iop/network/smap/src/ipstack.c
@@ -1,0 +1,164 @@
+
+#include "main.h"
+#include "ipstack.h"
+
+int SMAPCommonTxPacketNext(struct SmapDriverData *SmapDrivPrivData, void **data)
+{
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->TxPacketNext != NULL) {
+            int res;
+
+            res = HookTableAt0->TxPacketNext(data);
+            if (res > 0) {
+                return res;
+            }
+        }
+    }
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    return NetManTxPacketNext(data);
+#elif defined(BUILDING_SMAP_PS2IP)
+    return SMapTxPacketNext(data);
+#else
+    return 0;
+#endif
+}
+
+void SMAPCommonTxPacketDeQ(struct SmapDriverData *SmapDrivPrivData, void **data)
+{
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->TxPacketDeQ != NULL) {
+            if (HookTableAt0->TxPacketDeQ(data)) {
+                return;
+            }
+        }
+    }
+#else
+    (void)data;
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    NetManTxPacketDeQ();
+#elif defined(BUILDING_SMAP_PS2IP)
+    SMapTxPacketDeQ();
+#endif
+}
+
+void SMapCommonLinkStateDown(struct SmapDriverData *SmapDrivPrivData)
+{
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->LinkStateDown != NULL) {
+            if (HookTableAt0->LinkStateDown()) {
+                return;
+            }
+        }
+    }
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    NetManToggleNetIFLinkState(SmapDrivPrivData->NetIFID, NETMAN_NETIF_ETH_LINK_STATE_DOWN);
+#elif defined(BUILDING_SMAP_PS2IP)
+    (void)SmapDrivPrivData;
+
+    PS2IPLinkStateDown();
+#else
+    (void)SmapDrivPrivData;
+#endif
+}
+
+void SMapCommonLinkStateUp(struct SmapDriverData *SmapDrivPrivData)
+{
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->LinkStateUp != NULL) {
+            if (HookTableAt0->LinkStateUp()) {
+                return;
+            }
+        }
+    }
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    NetManToggleNetIFLinkState(SmapDrivPrivData->NetIFID, NETMAN_NETIF_ETH_LINK_STATE_UP);
+#elif defined(BUILDING_SMAP_PS2IP)
+    (void)SmapDrivPrivData;
+
+    PS2IPLinkStateUp();
+#else
+    (void)SmapDrivPrivData;
+#endif
+}
+
+void *SMapCommonStackAllocRxPacket(struct SmapDriverData *SmapDrivPrivData, u16 LengthRounded, void **payload)
+{
+    void *pbuf;
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->StackAllocRxPacket != NULL) {
+            void *res;
+
+            res = HookTableAt0->StackAllocRxPacket(LengthRounded, payload);
+            if (res != NULL) {
+                return res;
+            }
+        }
+    }
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    pbuf = NetManNetProtStackAllocRxPacket(LengthRounded, payload);
+#elif defined(BUILDING_SMAP_PS2IP)
+    struct pbuf *pbuf_struct;
+
+    pbuf_struct = pbuf_alloc(PBUF_RAW, LengthRounded, PBUF_POOL);
+    pbuf        = (void *)pbuf_struct;
+
+    if (pbuf_struct != NULL && payload != NULL) {
+        *payload = pbuf_struct->payload;
+    }
+#else
+    (void)LengthRounded;
+    if (payload != NULL) {
+        *payload = NULL;
+    }
+    pbuf = NULL;
+#endif
+    return pbuf;
+}
+
+void SMapStackEnQRxPacket(struct SmapDriverData *SmapDrivPrivData, void *pbuf)
+{
+#ifdef BUILDING_SMAP_MODULAR
+    {
+        const SmapModularHookTable_t *HookTableAt0;
+
+        HookTableAt0 = SmapDrivPrivData->HookTable[0];
+        if (HookTableAt0 != NULL && HookTableAt0->EnQRxPacket != NULL) {
+            if (HookTableAt0->EnQRxPacket(pbuf)) {
+                return;
+            }
+        }
+    }
+#endif
+#if defined(BUILDING_SMAP_NETMAN)
+    NetManNetProtStackEnQRxPacket(pbuf);
+#elif defined(BUILDING_SMAP_PS2IP)
+    SMapLowLevelInput(pbuf);
+#else
+    (void)pbuf;
+#endif
+}

--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -156,7 +156,7 @@ SMapIFInit(NetIF *pNetIF)
     // Get MAC address.
     SMAPGetMACAddress(pNetIF->hwaddr);
     DEBUG_PRINTF("MAC address : %02x:%02x:%02x:%02x:%02x:%02x\n", pNetIF->hwaddr[0], pNetIF->hwaddr[1], pNetIF->hwaddr[2],
-              pNetIF->hwaddr[3], pNetIF->hwaddr[4], pNetIF->hwaddr[5]);
+                 pNetIF->hwaddr[3], pNetIF->hwaddr[4], pNetIF->hwaddr[5]);
 
     // Enable sending and receiving of data.
     SMAPInitStart();
@@ -273,6 +273,10 @@ void PS2IPLinkStateDown(void)
 extern struct irx_export_table _exp_smap __attribute__((section("data")));
 #endif
 
+#ifdef BUILDING_SMAP_MODULAR
+extern struct irx_export_table _exp_smapmodu;
+#endif
+
 int _start(int argc, char *argv[])
 {
 #ifdef BUILDING_SMAP_PS2IP
@@ -288,6 +292,13 @@ int _start(int argc, char *argv[])
 
 #ifdef BUILDING_SMAP_NETMAN
     if (RegisterLibraryEntries(&_exp_smap) != 0) {
+        DEBUG_PRINTF("smap: module already loaded\n");
+        return MODULE_NO_RESIDENT_END;
+    }
+#endif
+
+#ifdef BUILDING_SMAP_MODULAR
+    if (RegisterLibraryEntries(&_exp_smapmodu) != 0) {
         DEBUG_PRINTF("smap: module already loaded\n");
         return MODULE_NO_RESIDENT_END;
     }

--- a/iop/network/smap/src/smap.c
+++ b/iop/network/smap/src/smap.c
@@ -871,7 +871,7 @@ int SMAPIoctl(unsigned int command, void *args, unsigned int args_len, void *out
         case NETMAN_NETIF_IOCTL_ETH_GET_STATUS:
             ((struct NetManEthStatus *)output)->LinkMode   = SMAPGetLinkMode();
             ((struct NetManEthStatus *)output)->LinkStatus = SMAPGetLinkStatus();
-            ((struct NetManEthStatus *)output)->stats      = SmapDriverData.RuntimeStats;
+            memcpy(&(((struct NetManEthStatus *)output)->stats), &(SmapDriverData.RuntimeStats), sizeof(SmapDriverData.RuntimeStats));
             result                                         = 0;
             break;
         default:

--- a/iop/network/smap/src/xfer.c
+++ b/iop/network/smap/src/xfer.c
@@ -47,6 +47,10 @@ static inline void CopyFromFIFO(volatile u8 *smap_regbase, void *buffer, unsigne
 {
     int i, result;
 
+    if (buffer == NULL) {
+        return;
+    }
+
     SMAP_REG16(SMAP_R_RXFIFO_RD_PTR) = RxBdPtr;
 
     result = SmapDmaTransfer(smap_regbase, buffer, length, DMAC_TO_MEM);
@@ -59,6 +63,10 @@ static inline void CopyFromFIFO(volatile u8 *smap_regbase, void *buffer, unsigne
 static inline void CopyToFIFO(volatile u8 *smap_regbase, const void *buffer, unsigned int length)
 {
     int i, result;
+
+    if (buffer == NULL) {
+        return;
+    }
 
     result = SmapDmaTransfer(smap_regbase, (void *)buffer, length, DMAC_FROM_MEM);
 

--- a/iop/network/smap/src/xfer.c
+++ b/iop/network/smap/src/xfer.c
@@ -21,8 +21,6 @@
 #include "xfer.h"
 #include "ipstack.h"
 
-extern struct SmapDriverData SmapDriverData;
-
 static int SmapDmaTransfer(volatile u8 *smap_regbase, void *buffer, unsigned int size, int direction)
 {
     unsigned int NumBlocks;
@@ -118,9 +116,9 @@ int HandleRxIntr(struct SmapDriverData *SmapDrivPrivData)
             } else {
                 void *pbuf, *payload;
 
-                if ((pbuf = SMapCommonStackAllocRxPacket(LengthRounded, &payload)) != NULL) {
+                if ((pbuf = SMapCommonStackAllocRxPacket(SmapDrivPrivData, LengthRounded, &payload)) != NULL) {
                     CopyFromFIFO(SmapDrivPrivData->smap_regbase, payload, length, pointer);
-                    SMapStackEnQRxPacket(pbuf);
+                    SMapStackEnQRxPacket(SmapDrivPrivData, pbuf);
                     NumPacketsReceived++;
                 } else {
                     SmapDrivPrivData->RuntimeStats.RxAllocFail++;
@@ -153,7 +151,7 @@ int HandleTxReqs(struct SmapDriverData *SmapDrivPrivData)
         int length;
 
         data = NULL;
-        if ((length = SMAPCommonTxPacketNext(&data)) < 1) {
+        if ((length = SMAPCommonTxPacketNext(SmapDrivPrivData, &data)) < 1) {
             return result;
         }
         SmapDrivPrivData->packetToSend = data;
@@ -187,6 +185,6 @@ int HandleTxReqs(struct SmapDriverData *SmapDrivPrivData)
             return result; // Queue full
 
         SmapDrivPrivData->packetToSend = NULL;
-        SMAPCommonTxPacketDeQ(&data);
+        SMAPCommonTxPacketDeQ(SmapDrivPrivData, &data);
     }
 }


### PR DESCRIPTION
Mainly intended for lightweight usages, like UDPBD, without needing to add its network stack code into the SMAP module itself.  
