### PR TITLE
mcman: Proper setting and checking of mcdi->cardform

### DIFF
--- a/iop/memorycard/mcman/src/main.c
+++ b/iop/memorycard/mcman/src/main.c
@@ -229,7 +229,7 @@ int McGetFreeClusters(int port, int slot) // Export #38
 	DPRINTF("McGetFreeClusters port%d slot%d\n", port, slot);
 
 	mcfree = 0;
-	if (mcdi->cardform)	{
+	if (mcdi->cardform > 0)	{
 		switch (mcdi->cardtype) {
    			case sceMcTypePS2:
    				mcfree = mcman_findfree2(port, slot, 0);
@@ -1268,9 +1268,13 @@ int mcman_setdevinfos(int port, int slot)
 
 	mcman_wmemset((void *)mcdi, sizeof(MCDevInfo), 0);
 
+	mcdi->cardform = 0;
+
 	r = mcman_setdevspec(port, slot);
 	if (r != sceMcResSucceed)
 		return -49;
+
+	mcdi->cardform = -1;
 
 	r = McReadPage(port, slot, 0, &mcman_pagebuf);
 	if (r == sceMcResNoFormat)
@@ -2453,6 +2457,8 @@ int mcman_setPS1devinfos(int port, int slot)
 	if (mcman_sio2outbufs_PS1PDA[1] != 0)
 		return -15;
 #endif
+
+	mcdi->cardform = -1;
 
 	if (mcman_PS1PDApagebuf.byte[0] != 0x4d)
 		return sceMcResNoFormat;

--- a/iop/memorycard/mcman/src/mcsio2.c
+++ b/iop/memorycard/mcman/src/mcsio2.c
@@ -808,14 +808,14 @@ int mcman_probePS2Card2(int port, int slot)
 
 	if (p[3] == 0x5a) {
 		r = McGetFormat(port, slot);
-		if (r > 0) {
+		if (r > 0)
+		{
 			DPRINTF("mcman_probePS2Card2 succeeded\n");
 
 			return sceMcResSucceed;
 		}
-
-		r = McGetFormat(port, slot);
-		if (r < 0) {
+		else if (r < 0)
+		{
 			DPRINTF("mcman_probePS2Card2 sio2cmd failed (no format)\n");
 
 			return sceMcResNoFormat;
@@ -842,7 +842,6 @@ int mcman_probePS2Card2(int port, int slot)
 int mcman_probePS2Card(int port, int slot) //2
 {
 	register int r;
-	register MCDevInfo *mcdi;
 #ifndef BUILDING_XFROMMAN
 	register int retries;
 	u8 *p = mcman_sio2packet.out_dma.addr;
@@ -853,10 +852,17 @@ int mcman_probePS2Card(int port, int slot) //2
 	r = mcman_cardchanged(port, slot);
 	if (r == sceMcResSucceed) {
 		r = McGetFormat(port, slot);
-		if (r != 0) {
+		if (r > 0)
+		{
 			DPRINTF("mcman_probePS2Card sio2cmd succeeded\n");
 
 			return sceMcResSucceed;
+		}
+		else if (r < 0)
+		{
+			DPRINTF("mcman_probePS2Card sio2cmd failed (no format)\n");
+
+			return sceMcResNoFormat;
 		}
 	}
 
@@ -926,9 +932,6 @@ int mcman_probePS2Card(int port, int slot) //2
 		return sceMcResFailDetect2;
 	}
 
-	mcdi = &mcman_devinfos[port][slot];
-	mcdi->cardform = r;
-
 	DPRINTF("mcman_probePS2Card sio2cmd succeeded\n");
 
 	return r;
@@ -979,7 +982,7 @@ int mcman_probePS1Card2(int port, int slot)
 	if (mcman_sio2outbufs_PS1PDA[1] == 0) {
 		if (mcdi->cardform > 0)
 			return sceMcResSucceed;
-		if (mcdi->cardform < 0)
+		else if (mcdi->cardform < 0)
 			return sceMcResNoFormat;
 	}
 	else if (mcman_sio2outbufs_PS1PDA[1] != 8) {
@@ -1039,6 +1042,8 @@ int mcman_probePS1Card(int port, int slot)
 	if (mcman_sio2outbufs_PS1PDA[1] == 0) {
 		if (mcdi->cardform != 0)
 			return sceMcResSucceed;
+		else
+			return sceMcResNoFormat;
 	}
 	else if (mcman_sio2outbufs_PS1PDA[1] != 8) {
 		return -12;
@@ -1057,8 +1062,6 @@ int mcman_probePS1Card(int port, int slot)
 	r = mcman_setPS1devinfos(port, slot);
 	if (r == 0)
 		return sceMcResChangedCard;
-
-	mcdi->cardform = r;
 
 	return r;
 #endif

--- a/iop/memorycard/mcman/src/ps1mc_fio.c
+++ b/iop/memorycard/mcman/src/ps1mc_fio.c
@@ -29,6 +29,8 @@ int mcman_format1(int port, int slot)
 
 	mcman_invhandles(port, slot);
 
+	mcdi->cardform = -1;
+
 	for (i = 0; i < 56; i++) {
 		r = mcman_PS1pagetest(port, slot, i);
 		if (r == 0)

--- a/iop/memorycard/mcman/src/ps2mc_fio.c
+++ b/iop/memorycard/mcman/src/ps2mc_fio.c
@@ -47,7 +47,7 @@ int mcman_format2(int port, int slot)
 
 	DPRINTF("mcman_format2 port%d, slot%d cardform %d\n", port, slot, mcdi->cardform);
 
-	if (mcdi->cardform == sceMcResNoFormat) {
+	if (mcdi->cardform < 0) {
 		for (i = 0; i < 32; i++)
 			mcdi->bad_block_list[i] = -1;
 		mcdi->rootdir_cluster = 0;


### PR DESCRIPTION
Avoids the situation where a crash may occur when accessing an unformatted memory card