### PR TITLE
Add SIO2MAN/PADMAN old API variants

### DIFF
--- a/iop/system/padman-old/Makefile
+++ b/iop/system/padman-old/Makefile
@@ -6,29 +6,12 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	alloc \
-	eesync \
-	eesync-nano \
-	iomanx \
-	iopmgr \
-	mtapman \
-	padman \
-	padman-old \
-	rmman \
-	rmtapman \
-	rpadman \
-	rsio2man \
-	sbusintr \
-	siftoo \
-	sio2log \
-	sio2man \
-	sio2man-old \
-	sysclib \
-	sysclib-full \
-	sysclib-nano \
-	udnl \
-	udnl-t300
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/system/padman/src/
+
+IOP_BIN ?= padman-old.irx
+
+PADMAN_BUILDING_XPADMAN ?= 0
+
+include $(PS2SDKSRC)/iop/system/padman/Makefile

--- a/iop/system/padman/Makefile
+++ b/iop/system/padman/Makefile
@@ -14,6 +14,21 @@ IOP_INCS += -I$(PS2SDKSRC)/iop/system/sio2man/include
 
 IOP_OBJS = freepad.o rpcserver.o exports.o imports.o padInit.o padPortOpen.o padMiscFuncs.o sio2Cmds.o padData.o padCmds.o
 
+# Build the newer version of the gamepad module?
+PADMAN_BUILDING_XPADMAN ?= 1
+
+# Build the newer version of the gamepad module that links against the remote-compatible SIO2MAN?
+PADMAN_BUILDING_XPADMAN_V2 ?= 0
+
+ifneq (x$(PADMAN_BUILDING_XPADMAN),x0)
+IOP_CFLAGS += -DBUILDING_XPADMAN
+endif
+
+ifneq (x$(PADMAN_BUILDING_XPADMAN_V2),x0)
+IOP_CFLAGS += -DBUILDING_XPADMAN_V2
+IOP_INCS += -I$(PS2SDKSRC)/iop/system/rsio2man/include
+endif
+
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make
 include $(PS2SDKSRC)/iop/Rules.make

--- a/iop/system/padman/src/imports.lst
+++ b/iop/system/padman/src/imports.lst
@@ -57,7 +57,8 @@ I_RegisterVblankHandler
 I_ReleaseVblankHandler
 vblank_IMPORTS_end
 
-#ifndef SIO2MAN_V2
+#ifdef BUILDING_XPADMAN
+#ifndef BUILDING_XPADMAN_V2
 xsio2man_IMPORTS_start
 #else
 rsio2man_IMPORTS_start
@@ -69,10 +70,17 @@ I_sio2_transfer_reset2
 I_sio2_mtap_change_slot
 I_sio2_mtap_get_slot_max
 I_sio2_mtap_update_slots
-#ifndef SIO2MAN_V2
+#ifndef BUILDING_XPADMAN_V2
 xsio2man_IMPORTS_end
 #else
 rsio2man_IMPORTS_end
+#endif
+#else
+sio2man_IMPORTS_start
+I_sio2_stat70_get
+I_sio2_pad_transfer_init
+I_sio2_transfer
+sio2man_IMPORTS_end
 #endif
 
 sysmem_IMPORTS_start

--- a/iop/system/padman/src/irx_imports.h
+++ b/iop/system/padman/src/irx_imports.h
@@ -24,10 +24,14 @@
 #include <thbase.h>
 #include <thevent.h>
 #include <vblank.h>
-#ifndef SIO2MAN_V2
-#include <xsio2man.h>
-#else
+#ifdef BUILDING_XPADMAN
+#ifdef BUILDING_XPADMAN_V2
 #include <rsio2man.h>
+#else
+#include <xsio2man.h>
+#endif
+#else
+#include <sio2man.h>
 #endif
 #include <sysmem.h>
 

--- a/iop/system/padman/src/padInit.c
+++ b/iop/system/padman/src/padInit.c
@@ -16,7 +16,9 @@
 #include "thbase.h"
 #include "intrman.h"
 #include "vblank.h"
+#ifdef BUILDING_XPADMAN
 #include "xsio2man.h"
+#endif
 #include "sifman.h"
 #include "sio2Cmds.h"
 #include "sysmem.h"
@@ -441,7 +443,9 @@ static void MainThread(void *arg)
 
 		mainThreadCount++;
 
+#ifdef BUILDING_XPADMAN
 		if( mainThreadCount % 30 == 0 ) sio2_mtap_update_slots();
+#endif
 
 		for(port=0; port < 2; port++)
 		{

--- a/iop/system/padman/src/padMiscFuncs.c
+++ b/iop/system/padman/src/padMiscFuncs.c
@@ -12,7 +12,9 @@
 #include "types.h"
 #include "freepad.h"
 #include "stdio.h"
+#ifdef BUILDING_XPADMAN
 #include "xsio2man.h"
+#endif
 #include "sio2Cmds.h"
 #include "sysmem.h"
 #include "thevent.h"
@@ -418,7 +420,11 @@ u32 padGetPortMax(void)
 
 u32 padGetSlotMax(u32 port)
 {
+#ifdef BUILDING_XPADMAN
 	return sio2_mtap_get_slot_max(port);
+#else
+	return 1;
+#endif
 }
 
 u32 padGetModVersion(void)

--- a/iop/system/padman/src/padPortOpen.c
+++ b/iop/system/padman/src/padPortOpen.c
@@ -672,7 +672,11 @@ s32 padPortOpen(s32 port, s32 slot, s32 pad_area_ee_addr, u32 *buf)
 		return 0;
 	}
 
+#ifdef BUILDING_XPADMAN
 	if(slot >= 4)
+#else
+	if(slot >= 1)
+#endif
 	{
 		M_PRINTF("Invalid slot number: %d\n", (int)port);
 		return 0;

--- a/iop/system/padman/src/rpcserver.c
+++ b/iop/system/padman/src/rpcserver.c
@@ -24,6 +24,7 @@
 #define PAD_BIND_OLD_RPC_ID2 0x8000011f
 
 enum PAD_RPCCMD {
+#ifdef BUILDING_XPADMAN
 	PAD_RPCCMD_OPEN	= 0x01,
 	// 0x2 undefined
 	PAD_RPCCMD_INFO_ACT	= 0x03,
@@ -43,6 +44,23 @@ enum PAD_RPCCMD {
 	// 0x11 undefined
 	PAD_RPCCMD_GET_MODVER	= 0x12,
 	PAD_RPCCMD_13
+#else
+	PAD_RPCCMD_OPEN	= 0x80000100,
+	// 0x80000101 undefined
+	PAD_RPCCMD_INFO_ACT	= 0x80000102,
+	PAD_RPCCMD_INFO_COMB,
+	PAD_RPCCMD_INFO_MODE,
+	PAD_RPCCMD_SET_MMODE,
+	PAD_RPCCMD_SET_ACTDIR,
+	PAD_RPCCMD_SET_ACTALIGN,
+	PAD_RPCCMD_GET_BTNMASK,
+	PAD_RPCCMD_SET_BTNINFO,
+	PAD_RPCCMD_SET_VREF,
+	PAD_RPCCMD_GET_PORTMAX,
+	PAD_RPCCMD_GET_SLOTMAX,
+	PAD_RPCCMD_CLOSE,
+	PAD_RPCCMD_END,
+#endif
 };
 
 // RPC Server
@@ -159,19 +177,23 @@ static void* RpcPadEnd(u32 *data)
 	return data;
 }
 
+#ifdef BUILDING_XPADMAN
 static void* RpcPadInit(u32 *data)
 {
 	data[3] = padInit((void*)data[4]);
 
 	return data;
 }
+#endif
 
+#ifdef BUILDING_XPADMAN
 static void* RpcGetModVersion(u32 *data)
 {
 	data[3] = padGetModVersion();
 
 	return data;
 }
+#endif
 
 static void* RpcServer(int fno, void *buffer, int length)
 {
@@ -181,6 +203,7 @@ static void* RpcServer(int fno, void *buffer, int length)
 	(void)fno;
 	(void)length;
 
+#ifdef BUILDING_XPADMAN
 	if ((0x00000100 & command) != 0)
 	{
 		if ((0x80000000 & command) != 0)
@@ -194,12 +217,17 @@ static void* RpcServer(int fno, void *buffer, int length)
 			return buffer;
 		}
 	}
+#endif
 
 	switch(command)
 	{
+#ifdef BUILDING_XPADMAN
 		case PAD_RPCCMD_INIT:			return RpcPadInit(data);
+#endif
 		case PAD_RPCCMD_END:			return RpcPadEnd(data);
+#ifdef BUILDING_XPADMAN
 		case PAD_RPCCMD_GET_MODVER:		return RpcGetModVersion(data);
+#endif
 		case PAD_RPCCMD_OPEN:			return RpcPadOpen(data);
 		case PAD_RPCCMD_CLOSE:			return RpcPadClose(data);
 		case PAD_RPCCMD_INFO_ACT:		return RpcPadInfoAct(data);
@@ -245,7 +273,9 @@ static void RpcThread(void *arg)
 
 	sceSifInitRpc(0);
 	sceSifSetRpcQueue(&qd, GetThreadId());
+#ifdef BUILDING_XPADMAN
 	sceSifRegisterRpc(&sd[0], PAD_BIND_RPC_ID1, &RpcServer, sb[0], NULL, NULL, &qd);
+#endif
 	sceSifRegisterRpc(&sd[1], PAD_BIND_OLD_RPC_ID1, &RpcServer, sb[1], NULL, NULL, &qd);
 	sceSifRpcLoop(&qd);
 }
@@ -262,7 +292,9 @@ static void RpcThreadExt(void *arg)
 
 	sceSifInitRpc(0);
 	sceSifSetRpcQueue(&qdext, GetThreadId());
+#ifdef BUILDING_XPADMAN
 	sceSifRegisterRpc(&sdext[0], PAD_BIND_RPC_ID2, &RpcServerExt, sbext[0], NULL, NULL, &qdext);
+#endif
 	sceSifRegisterRpc(&sdext[1], PAD_BIND_OLD_RPC_ID2, &RpcServerExt, sbext[1], NULL, NULL, &qdext);
 	sceSifRpcLoop(&qdext);
 }

--- a/iop/system/rpadman/Makefile
+++ b/iop/system/rpadman/Makefile
@@ -10,8 +10,8 @@ IOP_BIN_ALTNAMES =
 
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/system/padman/src/
 
-IOP_CFLAGS += -DSIO2MAN_V2 # -DDEBUG
+IOP_BIN ?= rpadman.irx
 
-IOP_INCS += -I$(PS2SDKSRC)/iop/system/rsio2man/include
+PADMAN_BUILDING_XPADMAN_V2 ?= 1
 
 include $(PS2SDKSRC)/iop/system/padman/Makefile

--- a/iop/system/rsio2man/Makefile
+++ b/iop/system/rsio2man/Makefile
@@ -11,6 +11,8 @@ IOP_BIN_ALTNAMES =
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/system/sio2man/src/
 IOP_INC_DIR = $(PS2SDKSRC)/iop/system/sio2man/include/
 
-IOP_CFLAGS += -DSIO2MAN_V2
+IOP_BIN ?= rsio2man.irx
+
+SIO2MAN_BUILDING_XSIO2MAN_V2 ?= 1
 
 include $(PS2SDKSRC)/iop/system/sio2man/Makefile

--- a/iop/system/sio2log/Makefile
+++ b/iop/system/sio2log/Makefile
@@ -11,6 +11,8 @@ IOP_BIN_ALTNAMES =
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/system/sio2man/src/
 IOP_INC_DIR = $(PS2SDKSRC)/iop/system/sio2man/include/
 
-IOP_CFLAGS += -DSIO2LOG
+IOP_BIN ?= sio2log.irx
+
+SIO2MAN_ENABLE_LOGGING ?= 1
 
 include $(PS2SDKSRC)/iop/system/sio2man/Makefile

--- a/iop/system/sio2man-old/Makefile
+++ b/iop/system/sio2man-old/Makefile
@@ -6,29 +6,13 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	alloc \
-	eesync \
-	eesync-nano \
-	iomanx \
-	iopmgr \
-	mtapman \
-	padman \
-	padman-old \
-	rmman \
-	rmtapman \
-	rpadman \
-	rsio2man \
-	sbusintr \
-	siftoo \
-	sio2log \
-	sio2man \
-	sio2man-old \
-	sysclib \
-	sysclib-full \
-	sysclib-nano \
-	udnl \
-	udnl-t300
+IOP_BIN_ALTNAMES =
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_SRC_DIR = $(PS2SDKSRC)/iop/system/sio2man/src/
+IOP_INC_DIR = $(PS2SDKSRC)/iop/system/sio2man/include/
+
+IOP_BIN ?= sio2man-old.irx
+
+SIO2MAN_BUILDING_XSIO2MAN ?= 0
+
+include $(PS2SDKSRC)/iop/system/sio2man/Makefile

--- a/iop/system/sio2man/Makefile
+++ b/iop/system/sio2man/Makefile
@@ -10,6 +10,27 @@ IOP_BIN_ALTNAMES ?= freesio2.irx
 
 IOP_OBJS = sio2man.o log.o imports.o exports.o
 
+# Build the newer version of the SIO2 module with support for multitap?
+SIO2MAN_BUILDING_XSIO2MAN ?= 1
+
+# Build the newer version of the SIO2 module with support for remote and PDA devices?
+SIO2MAN_BUILDING_XSIO2MAN_V2 ?= 0
+
+# Enable logging?
+SIO2MAN_ENABLE_LOGGING ?= 0
+
+ifneq (x$(SIO2MAN_BUILDING_XSIO2MAN),x0)
+IOP_CFLAGS += -DBUILDING_XSIO2MAN
+endif
+
+ifneq (x$(SIO2MAN_BUILDING_XSIO2MAN_V2),x0)
+IOP_CFLAGS += -DBUILDING_XSIO2MAN_V2
+endif
+
+ifneq (x$(SIO2MAN_ENABLE_LOGGING),x0)
+IOP_CFLAGS += -DSIO2LOG
+endif
+
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make
 include $(PS2SDKSRC)/iop/Rules.make

--- a/iop/system/sio2man/src/exports.tab
+++ b/iop/system/sio2man/src/exports.tab
@@ -1,7 +1,7 @@
-#ifndef SIO2MAN_V2
-DECLARE_EXPORT_TABLE(sio2man, 1, 2)
-#else
+#ifdef SIO2MAN_V2
 DECLARE_EXPORT_TABLE(sio2man, 2, 3)
+#else
+DECLARE_EXPORT_TABLE(sio2man, 1, 2)
 #endif
 	DECLARE_EXPORT(_start)
 	DECLARE_EXPORT(_retonly)

--- a/iop/system/sio2man/src/exports.tab
+++ b/iop/system/sio2man/src/exports.tab
@@ -1,7 +1,11 @@
-#ifdef SIO2MAN_V2
+#ifdef BUILDING_XSIO2MAN
+#ifdef BUILDING_XSIO2MAN_V2
 DECLARE_EXPORT_TABLE(sio2man, 2, 3)
 #else
 DECLARE_EXPORT_TABLE(sio2man, 1, 2)
+#endif
+#else
+DECLARE_EXPORT_TABLE(sio2man, 1, 1)
 #endif
 	DECLARE_EXPORT(_start)
 	DECLARE_EXPORT(_retonly)
@@ -33,6 +37,7 @@ DECLARE_EXPORT_TABLE(sio2man, 1, 2)
 	DECLARE_EXPORT(sio2_pad_transfer_init)
 	DECLARE_EXPORT(sio2_mc_transfer_init)
 	DECLARE_EXPORT(sio2_transfer) // 25
+#ifdef BUILDING_XSIO2MAN
 	DECLARE_EXPORT(sio2_transfer_reset)
 
 	/* Repeat of register routines 27 - 45 */
@@ -76,6 +81,7 @@ DECLARE_EXPORT_TABLE(sio2man, 1, 2)
 	DECLARE_EXPORT(sio2_mtap_get_slot_max)
 	DECLARE_EXPORT(sio2_mtap_get_slot_max2)
 	DECLARE_EXPORT(sio2_mtap_update_slots)
+#endif
 
 END_EXPORT_TABLE
 

--- a/iop/system/sio2man/src/sio2man.c
+++ b/iop/system/sio2man/src/sio2man.c
@@ -38,10 +38,10 @@
 #ifdef SIO2LOG
 	IRX_ID("sio2man_logger", 2, 1);
 #else
-#ifndef SIO2MAN_V2
-	IRX_ID("sio2man", 2, 1);
-#else
+#ifdef SIO2MAN_V2
 	IRX_ID("sio2man", 2, 4);
+#else
+	IRX_ID("sio2man", 2, 1);
 #endif
 #endif
 
@@ -67,12 +67,7 @@ extern struct irx_export_table _exp_sio2man;
 #define EF_MC_TRANSFER_READY	0x00000008
 #define EF_MTAP_TRANSFER_INIT	0x00000010
 #define EF_MTAP_TRANSFER_READY	0x00000020
-#ifndef SIO2MAN_V2
-	#define EF_TRANSFER_START	0x00000040
-	#define EF_TRANSFER_FINISH	0x00000080
-	#define EF_TRANSFER_RESET	0x00000100
-	#define EF_SIO2_INTR_COMPLETE	0x00000200
-#else
+#ifdef SIO2MAN_V2
 	#define EF_RM_TRANSFER_INIT	0x00000040
 	#define EF_RM_TRANSFER_READY	0x00000080
 	#define EF_UNK_TRANSFER_INIT	0x00000100
@@ -81,6 +76,11 @@ extern struct irx_export_table _exp_sio2man;
 	#define EF_TRANSFER_FINISH	0x00000800
 	#define EF_TRANSFER_RESET	0x00001000
 	#define EF_SIO2_INTR_COMPLETE	0x00002000
+#else
+	#define EF_TRANSFER_START	0x00000040
+	#define EF_TRANSFER_FINISH	0x00000080
+	#define EF_TRANSFER_RESET	0x00000100
+	#define EF_SIO2_INTR_COMPLETE	0x00000200
 #endif
 
 #define EPRINTF(format, args...) printf("%s: " format, _irx_id.n , ## args)


### PR DESCRIPTION
Backwards compatibility for old SIO2MAN/PADMAN.  

These are implemented as module variants, instead of attempting to combine the different versions of the RPC interface into one module.  

This mainly serves as a OSS replacement for `rom0:SIO2MAN` and `rom0:PADMAN` which old homebrew may rely on.  