### PR TITLE
bdm: Compile libbdm if not already compiled

### DIFF
--- a/iop/fs/bdm/Makefile
+++ b/iop/fs/bdm/Makefile
@@ -8,10 +8,10 @@
 
 # IOP_CFLAGS += -DDEBUG
 
-IOP_OBJS = main.o bdm.o part_driver.o imports.o exports.o
-IOP_LIBS = -lbdm
-IOP_CFLAGS = -I$(PS2SDKSRC)/iop/fs/libbdm/include/
-IOP_LDFLAGS = -L$(PS2SDKSRC)/iop/fs/libbdm/lib/
+IOP_OBJS = main.o bdm.o part_driver.o imports.o exports.o $(PS2SDKSRC)/iop/fs/libbdm/lib/libbdm.a
+
+$(PS2SDKSRC)/iop/fs/libbdm/lib/libbdm.a:
+	$(MAKEREC) $(PS2SDKSRC)/iop/fs/libbdm
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make


### PR DESCRIPTION
Fixes one instance of interdependency issue when compiling with multiple jobs