### PR TITLE
iop/Rules.make: readd -Werror

### DIFF
--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -27,7 +27,7 @@ IOP_INCS := $(IOP_INCS) -I$(IOP_SRC_DIR) -I$(IOP_SRC_DIR)include -I$(IOP_INC_DIR
 IOP_OPTFLAGS ?= -Os
 
 # Warning compiler flags
-IOP_WARNFLAGS ?= -Wall -W
+IOP_WARNFLAGS ?= -Wall -Werror
 
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,


### PR DESCRIPTION
`-Werror` was removed by mistake.

Add it back in.