### PR TITLE
Revert "bdm: Compile libbdm if not already compiled"

### DIFF
--- a/iop/fs/bdm/Makefile
+++ b/iop/fs/bdm/Makefile
@@ -8,10 +8,10 @@
 
 # IOP_CFLAGS += -DDEBUG
 
-IOP_OBJS = main.o bdm.o part_driver.o imports.o exports.o $(PS2SDKSRC)/iop/fs/libbdm/lib/libbdm.a
-
-$(PS2SDKSRC)/iop/fs/libbdm/lib/libbdm.a:
-	$(MAKEREC) $(PS2SDKSRC)/iop/fs/libbdm
+IOP_OBJS = main.o bdm.o part_driver.o imports.o exports.o
+IOP_LIBS = -lbdm
+IOP_CFLAGS = -I$(PS2SDKSRC)/iop/fs/libbdm/include/
+IOP_LDFLAGS = -L$(PS2SDKSRC)/iop/fs/libbdm/lib/
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make


### PR DESCRIPTION
@uyjulian I have reverted this PR because `ps2sdk-ports` was failing 
https://github.com/ps2dev/ps2sdk-ports/actions/runs/3553932933/jobs/5969726140

```bash
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/sio2man.irx sio2man_irx.c sio2man_irx
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/iomanX.irx iomanX_irx.c iomanX_irx
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/fileXio.irx fileXio_irx.c fileXio_irx
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/mcman.irx mcman_irx.c mcman_irx
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/mcserv.irx mcserv_irx.c mcserv_irx
/usr/local/ps2dev/ps2sdk/bin/bin2c /usr/local/ps2dev/ps2sdk/iop/irx/bdm.irx bdm_irx.c bdm_irx
Error opening /usr/local/ps2dev/ps2sdk/iop/irx/bdm.irx for reading.
make[1]: *** [Makefile:69: bdm_irx.c] Error 1
rm mcserv_irx.c mcman_irx.c fileXio_irx.c sio2man_irx.c iomanX_irx.c
make[1]: Leaving directory '/__w/ps2sdk-ports/ps2sdk-ports/ps2_drivers'
make: *** [Makefile:22: ps2_drivers] Error 2
make: *** Waiting for unfinished jobs....
```

Reverts ps2dev/ps2sdk#359

Please, open the PR once you fix it