### PR TITLE
Expand tcpip makefile patterns to have pattern per file instead of root dir

### DIFF
--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -59,7 +59,13 @@ $(LWIP):
 
 $(EE_OBJS_DIR)ps2ip.o $(EE_OBJS_DIR)ps2ip_shims.o $(EE_OBJS_DIR)sys_arch.o: $(LWIP)
 
-$(LWIP)/%.c: $(LWIP)
+$(LWIP)/src/api/%.c: $(LWIP)
+
+$(LWIP)/src/core/%.c: $(LWIP)
+
+$(LWIP)/src/core/ipv4/%.c: $(LWIP)
+
+$(LWIP)/src/core/netif/%.c: $(LWIP)
 
 $(EE_OBJS_DIR)def.o: $(LWIP)/src/core/def.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -58,7 +58,13 @@ $(LWIP):
 
 $(IOP_OBJS_DIR)ps2ip.o $(IOP_OBJS_DIR)sys_arch.o: $(LWIP)
 
-$(LWIP)/%.c: $(LWIP)
+$(LWIP)/src/api/%.c: $(LWIP)
+
+$(LWIP)/src/core/%.c: $(LWIP)
+
+$(LWIP)/src/core/ipv4/%.c: $(LWIP)
+
+$(LWIP)/src/core/netif/%.c: $(LWIP)
 
 $(IOP_OBJS_DIR)def.o: $(LWIP)/src/core/def.c
 	$(IOP_CC) $(IOP_CFLAGS) -c $< -o $@


### PR DESCRIPTION
Mainly to assist other (non-GNU) Make implementations when building with multiple jobs