### PR TITLE
Dispatch to `ps2sdk-ports` instead `gsKit`

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,9 +20,12 @@ jobs:
         run: |
           apk add build-base git bash
 
+      # Still compilation is not fully compatible with multi-thread
       - name: Compile project ${{ matrix.debug }}
         run: |
-          make clean ${{ matrix.debug }} install
+          make -j $(getconf _NPROCESSORS_ONLN) clean
+          make -j 1 ${{ matrix.debug }}
+          make -j $(getconf _NPROCESSORS_ONLN) install
           ln -sf "$PS2SDK/ee/lib/libcglue.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcglue.a"
           ln -sf "$PS2SDK/ee/lib/libpthreadglue.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libpthreadglue.a"
           ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,11 +67,11 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
 
-    - name: Repository Dispatch to gsKit
+    - name: Repository Dispatch to ps2sdk-ports
       uses: peter-evans/repository-dispatch@v2
       if: env.DISPATCH_TOKEN != null
       with:
-        repository: ${{ github.repository_owner }}/gskit
+        repository: ${{ github.repository_owner }}/ps2sdk-ports
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}
         client-payload: '{"ref": "${{ github.ref }}"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM $BASE_DOCKER_IMAGE
 COPY . /src
 
 RUN apk add build-base git bash
+
 # Still compilation is not fully compatible with multi-thread
 RUN cd /src && \
     make -j $(getconf _NPROCESSORS_ONLN) clean && \


### PR DESCRIPTION
This PR is to avoid having circular dependencies between `gsKit` and `ps2sdk-ports`, so now `gsKit` is part of `ps2sdk-ports`