### PR TITLE
Changes to use and cache real time clock value based on offset from timer

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -8,7 +8,7 @@
 
 EE_LIB = libcglue.a
 
-CORE_OBJS = timezone.o
+CORE_OBJS = timezone.o rtc.o
 
 INIT_OBJS = __libpthreadglue_init.o __libpthreadglue_deinit.o _libcglue_init.o _libcglue_deinit.o _libcglue_args_parse.o
 

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -54,6 +54,9 @@ static inline ps2_clock_t ps2_clock(void) {
 
 extern void _libcglue_timezone_update();
 
+extern s64 _ps2sdk_rtc_offset_from_busclk;
+extern void _libcglue_rtc_update();
+
 // The newlib port does not support 64bit
 // this should have been defined in unistd.h
 typedef int64_t off64_t;

--- a/ee/libcglue/samples/mem_test/main.c
+++ b/ee/libcglue/samples/mem_test/main.c
@@ -47,6 +47,7 @@ void _libcglue_deinit() {}
 #endif
 
 void _libcglue_timezone_update() {}
+void _libcglue_rtc_update() {}
 
 // "weak" function called by crt0.o
 void _ps2sdk_memory_init()

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -699,7 +699,7 @@ int clock_getres(clockid_t clk_id, struct timespec *res) {
 
 	/* Return the actual time since epoch */
 	res->tv_sec = tv.tv_sec;
-	res->tv_nsec = 0;
+	res->tv_nsec = tv.tv_usec * 1000;
 
 	return 0;
 }
@@ -713,7 +713,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
 	/* Return the actual time since epoch */
 	tp->tv_sec = tv.tv_sec;
-	tp->tv_nsec = 0;
+	tp->tv_nsec = tv.tv_usec * 1000;
 
 	return 0;
 }

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -41,6 +41,7 @@
 #include "io_common.h"
 #include "iox_stat.h"
 #include "ps2sdkapi.h"
+#include "timer_alarm.h"
 
 
 extern void * _end;
@@ -632,27 +633,30 @@ void * _sbrk(size_t incr) {
 #endif
 
 #ifdef F__gettimeofday
-/*
- * Implement in terms of time, which means we can't
- * return the microseconds.
- */
+int _gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+	if (tv == NULL)
+	{
+		errno = EINVAL;
+		return -1;
+	}
 
-time_t ps2time(time_t *t);
+	{
+		u32 busclock_sec;
+		u32 busclock_usec;
 
-int _gettimeofday(struct timeval *tv, struct timezone *tz) {
-	if (tv == NULL) {
-      errno = EINVAL;
-      return -1;
-    }
+		TimerBusClock2USec(GetTimerSystemTime(), &busclock_sec, &busclock_usec);
+		tv->tv_sec = (time_t)(_ps2sdk_rtc_offset_from_busclk + ((s64)busclock_sec));
+		tv->tv_usec = busclock_usec;
+	}
 
-  	tv->tv_sec = (time_t) ps2time((time_t *) NULL);
-  	tv->tv_usec = 0L;
-  	if (tz != NULL) {
+	if (tz != NULL)
+	{
 		tz->tz_minuteswest = _timezone / 60;
 		tz->tz_dsttime = 0;
-    }
+	}
 
-  	return 0;
+	return 0;
 }
 #endif
 

--- a/ee/libcglue/src/init.c
+++ b/ee/libcglue/src/init.c
@@ -14,6 +14,7 @@
  */
 
 void _libcglue_timezone_update();
+void _libcglue_rtc_update();
 void pthread_init();
 void pthread_terminate();
 
@@ -53,6 +54,7 @@ void _libcglue_init()
 	__libpthreadglue_init();
 
     _libcglue_timezone_update();
+    _libcglue_rtc_update();
 }
 #endif
 

--- a/ee/libcglue/src/rtc.c
+++ b/ee/libcglue/src/rtc.c
@@ -1,0 +1,40 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * Set real time clock-related variables based on the real time clock value in the Mechacon.
+ */
+
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ps2sdkapi.h"
+#define OSD_CONFIG_NO_LIBCDVD
+#include "osd_config.h"
+#include "timer_alarm.h"
+
+// The definition for this function is located in ee/rpc/cdvd/src/scmd.c
+extern time_t ps2time(time_t *t);
+
+s64 _ps2sdk_rtc_offset_from_busclk = 0;
+
+__attribute__((weak))
+void _libcglue_rtc_update()
+{
+	time_t rtc_sec;
+	u32 busclock_sec;
+	u32 busclock_usec;
+
+	rtc_sec = ps2time(NULL);
+	TimerBusClock2USec(GetTimerSystemTime(), &busclock_sec, &busclock_usec);
+
+	_ps2sdk_rtc_offset_from_busclk = ((s64)rtc_sec) - ((s64)busclock_sec);
+}


### PR DESCRIPTION
Mainly for applications that call `time` or related functions very often