### PR TITLE
Fix alignment of variables in IOP modules to be max 16 bytes

### DIFF
--- a/common/sbus/src/ps2_dbg.c
+++ b/common/sbus/src/ps2_dbg.c
@@ -5,7 +5,13 @@
 
 #define DBG_CMD_PUTS (1)
 
-u32 _dbg_cmd_dma_buf[128] __attribute__((aligned(128)));
+#ifdef _EE
+#define DMA_BUF_ALIGNMENT 128
+#else
+#define DMA_BUF_ALIGNMENT 16
+#endif
+
+u32 _dbg_cmd_dma_buf[128] __attribute__((aligned(DMA_BUF_ALIGNMENT)));
 
 #ifdef _EE
 

--- a/common/sbus/src/sif2cmd.c
+++ b/common/sbus/src/sif2cmd.c
@@ -18,6 +18,12 @@ This file contains all common code for both EE and IOP SIF management.
 #include <sysclib.h>
 #endif
 
+#ifdef _EE
+#define DMA_BUF_ALIGNMENT 128
+#else
+#define DMA_BUF_ALIGNMENT 16
+#endif
+
 #define SBUS_IRQ_XFER (30)
 #define SBUS_IRQ_EXEC (31)
 
@@ -37,7 +43,7 @@ static int __sif2_cmd_inited = 0;
 static SIF2_CmdHandler _sif2_cmd_handlers[SIF2_MAX_CMD_HANDLERS];
 
 // 512 byte command buffer(aligned 16 bytes)
-static u32 _sif2_dma_cmd_buf[128] __attribute__((aligned(128)));
+static u32 _sif2_dma_cmd_buf[128] __attribute__((aligned(DMA_BUF_ALIGNMENT)));
 
 int SIF2_set_cmd_handler(int cid, SIF2_CmdHandlerFunc func, void *param)
 {

--- a/iop/memorycard/mcserv/src/mcserv.c
+++ b/iop/memorycard/mcserv/src/mcserv.c
@@ -96,14 +96,14 @@ static void *rpc_funcs_array[21] = {
 
 static int mcserv_tidS_0400;
 
-static SifRpcDataQueue_t mcserv_qdS_0400 __attribute__((aligned(64)));
-static SifRpcServerData_t mcserv_sdS_0400 __attribute__((aligned(64)));
+static SifRpcDataQueue_t mcserv_qdS_0400 __attribute__((aligned(16)));
+static SifRpcServerData_t mcserv_sdS_0400 __attribute__((aligned(16)));
 
 static u8 mcserv_rpc_buf[2048] __attribute__((__aligned__(4)));
-static mcRpcStat_t rpc_stat __attribute__((aligned(64)));
+static mcRpcStat_t rpc_stat __attribute__((aligned(16)));
 
 #define MCSERV_BUFSIZE 8192
-static u8 mcserv_buf[MCSERV_BUFSIZE] __attribute__((aligned(64)));
+static u8 mcserv_buf[MCSERV_BUFSIZE] __attribute__((aligned(16)));
 
 extern struct irx_export_table _exp_mcserv;
 

--- a/iop/network/smbman/src/auth.c
+++ b/iop/network/smbman/src/auth.c
@@ -11,7 +11,7 @@
 #include "des.h"
 #include "md4.h"
 
-static u8 passwd_buf[512] __attribute__((aligned(64)));
+static u8 passwd_buf[512] __attribute__((aligned(16)));
 
 /*
  * LM_Password_Hash: this function create a LM password hash from a given password

--- a/iop/network/smbman/src/des.c
+++ b/iop/network/smbman/src/des.c
@@ -436,7 +436,7 @@ static unsigned char *key7TOkey8(const unsigned char *key7, unsigned char *key8)
     return (unsigned char *)key8;
 }
 
-static unsigned char DES_Keys[128] __attribute__((aligned(64)));
+static unsigned char DES_Keys[128] __attribute__((aligned(16)));
 
 /*
  * des_create_keys: take 64bit user key (key) as input and outputs

--- a/iop/sound/audsrv/src/adpcm.c
+++ b/iop/sound/audsrv/src/adpcm.c
@@ -42,7 +42,7 @@ typedef struct adpcm_list_t
 static adpcm_list_t *adpcm_list_head = 0;
 static adpcm_list_t *adpcm_list_tail = 0;
 
-static u32 sbuffer[16] __attribute__((aligned(64)));
+static u32 sbuffer[16] __attribute__((aligned(16)));
 
 /** Allocates memory for a new sample. */
 static adpcm_list_t *alloc_new_sample(void)

--- a/iop/sound/audsrv/src/audsrv.c
+++ b/iop/sound/audsrv/src/audsrv.c
@@ -77,7 +77,7 @@ static int fillbuf_threshold = 0;
 static int format_changed = 0;
 
 /** double buffer for streaming */
-static u8 core1_buf[0x1000] __attribute__((aligned (64)));
+static u8 core1_buf[0x1000] __attribute__((aligned (16)));
 
 static short rendered_left [ 512 ];
 static short rendered_right[ 512 ];

--- a/iop/sound/audsrv/src/cdrom.c
+++ b/iop/sound/audsrv/src/cdrom.c
@@ -56,10 +56,10 @@ static unsigned char raw_toc[3000];
 static int cd_transfer_sema = -1;
 
 /** cdda ring buffer */
-static u8 cd_ringbuf[SECTOR_SIZE*8] __attribute__((aligned (64)));
+static u8 cd_ringbuf[SECTOR_SIZE*8] __attribute__((aligned (16)));
 /** used upon overflow */
-static u8 cd_sparebuf[1880] __attribute__((aligned (64)));
-static u8 core0_buf[0x1000] __attribute__((aligned (64)));
+static u8 cd_sparebuf[1880] __attribute__((aligned (16)));
+static u8 core0_buf[0x1000] __attribute__((aligned (16)));
 
 static short cd_rendered_left[512];
 static short cd_rendered_right[512];

--- a/iop/usb/camera/src/ps2cam.c
+++ b/iop/usb/camera/src/ps2cam.c
@@ -39,8 +39,8 @@ IRX_ID(MODNAME, 1, 1);
 #define MAX_CAM_DEVICE_HANDLE	2
 
 
-static SifRpcDataQueue_t	rpc_queue			__attribute((aligned(64)));
-static SifRpcServerData_t	rpc_server			__attribute((aligned(64)));
+static SifRpcDataQueue_t	rpc_queue			__attribute__((__aligned__(16)));
+static SifRpcServerData_t	rpc_server			__attribute__((__aligned__(16)));
 static int					_rpc_buffer[1024]	 __attribute__((__aligned__(4)));
 //static int					threadId;
 static int					maintain_thread;
@@ -54,7 +54,7 @@ sceUsbdLddOps					cam_driver = {NULL,
 
 
 
-char						campacket[896]		__attribute((aligned(64)));
+char						campacket[896]		__attribute__((__aligned__(16)));
 char						irx_initialized	= 0;
 int							ps2cam_sema=0;
 CAMERA_DEVICE				Camera[MAX_CAM_DEVICE];

--- a/iop/usb/mouse/src/ps2mouse.c
+++ b/iop/usb/mouse/src/ps2mouse.c
@@ -46,8 +46,8 @@ IRX_ID(MODNAME, 1, 1);
 #define PS2MOUSE_DEFACCEL (1 << 16)
 #define PS2MOUSE_DEFTHRES 65536;
 
-static SifRpcDataQueue_t ps2mouse_queue __attribute__((aligned(64)));
-static SifRpcServerData_t ps2mouse_server __attribute((aligned(64)));
+static SifRpcDataQueue_t ps2mouse_queue __attribute__((aligned(16)));
+static SifRpcServerData_t ps2mouse_server __attribute__((aligned(16)));
 static int _rpc_buffer[512]  __attribute__((__aligned__(4)));
 
 #define ABS(x) (x < 0 ? -x : x)


### PR DESCRIPTION
The IRX loader can only handle max alignment of 16 bytes.  
Future updates to the toolchain will make this a hard requirement.