### PR TITLE
Implement positional audio in adpcm

### DIFF
--- a/ee/rpc/audsrv/include/audsrv.h
+++ b/ee/rpc/audsrv/include/audsrv.h
@@ -221,9 +221,11 @@ int audsrv_adpcm_init();
 /** Sets output volume for the specified voice channel.
  * @param ch       Voice channel ID
  * @param vol      volume in percentage (0-100)
+ * @param pan      left/right offset [-100 .. 0 .. 100]
  * @returns 0 on success, negative otherwise
  */
-int audsrv_adpcm_set_volume(int ch, int vol);
+int audsrv_adpcm_set_volume_and_pan(int ch, int vol, int pan);
+#define audsrv_adpcm_set_volume(ch, vol) audsrv_adpcm_set_volume_and_pan(ch, vol, 0) //For backward-compatibility
 
 /** Uploads a sample to SPU2 memory
  * @param adpcm    adpcm descriptor structure

--- a/ee/rpc/audsrv/samples/playadpcm/playadpcm.c
+++ b/ee/rpc/audsrv/samples/playadpcm/playadpcm.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
 
 	audsrv_adpcm_init();
 	audsrv_set_volume(MAX_VOLUME);
-	audsrv_adpcm_set_volume(0, MAX_VOLUME);
+	audsrv_adpcm_set_volume_and_pan(0, MAX_VOLUME, 0);
 	audsrv_load_adpcm(&sample, buffer, size);
 	audsrv_ch_play_adpcm(0, &sample);
 
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 		nopdelay();
 	}
 
-	audsrv_adpcm_set_volume(1, MAX_VOLUME);
+	audsrv_adpcm_set_volume_and_pan(1, MAX_VOLUME, 0);
 	audsrv_ch_play_adpcm(1, &sample);
 	*/
 

--- a/ee/rpc/audsrv/src/audsrv_rpc.c
+++ b/ee/rpc/audsrv/src/audsrv_rpc.c
@@ -114,6 +114,32 @@ static int call_rpc_2(int func, int arg1, int arg2)
 	return ret;
 }
 
+/** Internal function to simplify RPC calling
+ * @param func    procedure to invoke
+ * @param arg1    optional argument
+ * @param arg2    optional argument
+ * @param arg3    optional argument
+ * @returns value returned by RPC server
+*/
+static int call_rpc_3(int func, int arg1, int arg2, int arg3)
+{
+	int ret;
+
+	WaitSema(completion_sema);
+
+	sbuff[0] = arg1;
+	sbuff[1] = arg2;
+	sbuff[2] = arg2;
+	SifCallRpc(&cd0, func, 0, sbuff, 3*4, sbuff, 4, NULL, NULL);
+
+	ret = sbuff[0];
+	SignalSema(completion_sema);
+
+	set_error(ret);
+
+	return ret;
+}
+
 int audsrv_quit()
 {
 	WaitSema(completion_sema);
@@ -370,7 +396,7 @@ int audsrv_adpcm_init()
 	return call_rpc_1(AUDSRV_INIT_ADPCM, 0);
 }
 
-int audsrv_adpcm_set_volume(int ch, int volume)
+int audsrv_adpcm_set_volume_and_pan(int ch, int volume, int pan)
 {
 	if (volume > MAX_VOLUME)
 	{
@@ -381,7 +407,24 @@ int audsrv_adpcm_set_volume(int ch, int volume)
 		volume = MIN_VOLUME;
 	}
 
-	return call_rpc_2(AUDSRV_ADPCM_SET_VOLUME, ch, vol_values[volume/4]);
+	if (pan > 100)
+	{
+		pan = 100;
+	}
+	else if (pan < -100)
+	{
+		pan = -100;
+	}
+
+	int volumel = volume;
+	int volumer = volume;
+
+	if (pan < 0)
+		volumer = volumer * -pan / 100;
+	else if (pan > 0)
+		volumel = volumel * pan / 100;
+
+	return call_rpc_3(AUDSRV_ADPCM_SET_VOLUME, ch, vol_values[volumel/4], vol_values[volumer/4]);
 }
 
 int audsrv_load_adpcm(audsrv_adpcm_t *adpcm, void *buffer, int size)

--- a/iop/sound/audsrv/include/audsrv.h
+++ b/iop/sound/audsrv/include/audsrv.h
@@ -94,7 +94,7 @@ int audsrv_get_cd_type();
 
 /* adpcm functions */
 int audsrv_adpcm_init();
-int audsrv_adpcm_set_volume(int ch, int vol);
+int audsrv_adpcm_set_volume(int ch, int voll, int volr);
 void *audsrv_load_adpcm(u32 *buffer, int size, int id);
 #define audsrv_play_adpcm(id)      audsrv_ch_play_adpcm(-1, id) //For backward-compatibility
 int audsrv_ch_play_adpcm(int ch, u32 id);

--- a/iop/sound/audsrv/src/adpcm.c
+++ b/iop/sound/audsrv/src/adpcm.c
@@ -196,7 +196,7 @@ static int audsrv_adpcm_alloc_channel(void)
 }
 
 /** Plays an adpcm sample already uploaded with audsrv_load_adpcm()
- * @param ch    channel identifier. Specifies one of the 24 voice channel to play the ADPCM channel on. If set to an invalid channel ID, an unoccupied channel will be selected. 
+ * @param ch    channel identifier. Specifies one of the 24 voice channel to play the ADPCM channel on. If set to an invalid channel ID, an unoccupied channel will be selected.
  * @param id    sample identifier, as specified in load()
  * @returns zero on success, negative value on error
  *
@@ -271,19 +271,20 @@ int audsrv_adpcm_init()
 
 /** Sets output volume for the specified voice channel.
  * @param ch       Voice channel ID
- * @param vol      volume in SPU2 units [0 .. 0x3fff]
+ * @param voll     left volume in SPU2 units [0 .. 0x3fff]
+ * @param volr     right volume in SPU2 units [0 .. 0x3fff]
  * @returns 0 on success, negative otherwise
  */
-int audsrv_adpcm_set_volume(int ch, int vol)
+int audsrv_adpcm_set_volume(int ch, int voll, int volr)
 {
-	if (vol < 0 || vol > MAX_VOLUME)
+	if (voll < 0 || voll > MAX_VOLUME || volr < 0 || volr > MAX_VOLUME)
 	{
 		/* bad joke */
 		return AUDSRV_ERR_ARGS;
 	}
 
-	sceSdSetParam(SD_CORE_1 | (ch << 1) | SD_VPARAM_VOLL, vol);
-	sceSdSetParam(SD_CORE_1 | (ch << 1) | SD_VPARAM_VOLR, vol);
+	sceSdSetParam(SD_CORE_1 | (ch << 1) | SD_VPARAM_VOLL, voll);
+	sceSdSetParam(SD_CORE_1 | (ch << 1) | SD_VPARAM_VOLR, volr);
 
 	return AUDSRV_ERR_NOERROR;
 }

--- a/iop/sound/audsrv/src/rpc_server.c
+++ b/iop/sound/audsrv/src/rpc_server.c
@@ -145,7 +145,7 @@ static void *rpc_command(int func, unsigned *data, int size)
 		break;
 
 		case AUDSRV_SET_ADPCM_VOL:
-		ret = audsrv_adpcm_set_volume(data[0], data[1]);
+		ret = audsrv_adpcm_set_volume(data[0], data[1], data[2]);
 		break;
 
 		case AUDSRV_AVAILABLE:


### PR DESCRIPTION
This adds a 3rd parameter to `audsrv_adpcm_set_volume()` which makes it possible to pan the sound left or right, allowing for positional audio in games.

-100: Sound is all the way to the left
-50: Sound is 45° to the left (50% volume on the right)
0: Sound is centered
50 Sound is 45° to the right (50% volume on the left)
100: Sound is all the way to the right