### PR TITLE
fix for sandisk sdcards

### DIFF
--- a/iop/sio/mx4sio_bd/src/mx4sio.c
+++ b/iop/sio/mx4sio_bd/src/mx4sio.c
@@ -518,11 +518,25 @@ static bool ps2_spi_is_present(void)
 
 static uint8_t ps2_spi_wr_rd_byte(uint8_t byte)
 {
+    /* This check renders all instances of the following useless:
+     * 
+     *   _io->wr_rd_byte(DUMMY_BYTE);
+     *   _io->select();
+     *
+     *  _io->relese();
+     *  _io->wr_rd_byte(DUMMY_BYTE);
+     * 
+     * As a result the clock is not toggled when it should be
+     * this leads to incompatibity with sandisk sdcards
+    */
+
+    /*
     if (spi_ss == 0) {
         // We're ignoring a lot of dummy read/writes, this is not an error
         // M_DEBUG("%s(%d) - ignoring, not selected\n", __FUNCTION__, byte);
         return 0;
     }
+    */
 
     // M_DEBUG("%s(%d)\n", __FUNCTION__, byte);
     return sendCmd_Tx1_Rx1(byte, PORT_NR);

--- a/iop/sio/mx4sio_bd/src/mx4sio.c
+++ b/iop/sio/mx4sio_bd/src/mx4sio.c
@@ -234,7 +234,7 @@ static void _init_td(sio2_transfer_data_t *td, int portNr)
      * 0x78 = 400KHz - Initialization speed
      */
     const int slowDivVal   = 0x78;
-    const int fastDivVal   = 2;
+    const int fastDivVal   = 0x2;
     const int interBytePer = 0; // 2;
 
     for (i = 0; i < 4; i++) {
@@ -518,26 +518,6 @@ static bool ps2_spi_is_present(void)
 
 static uint8_t ps2_spi_wr_rd_byte(uint8_t byte)
 {
-    /* This check renders all instances of the following useless:
-     * 
-     *   _io->wr_rd_byte(DUMMY_BYTE);
-     *   _io->select();
-     *
-     *  _io->relese();
-     *  _io->wr_rd_byte(DUMMY_BYTE);
-     * 
-     * As a result the clock is not toggled when it should be
-     * this leads to incompatibity with sandisk sdcards
-    */
-
-    /*
-    if (spi_ss == 0) {
-        // We're ignoring a lot of dummy read/writes, this is not an error
-        // M_DEBUG("%s(%d) - ignoring, not selected\n", __FUNCTION__, byte);
-        return 0;
-    }
-    */
-
     // M_DEBUG("%s(%d)\n", __FUNCTION__, byte);
     return sendCmd_Tx1_Rx1(byte, PORT_NR);
 }
@@ -545,11 +525,6 @@ static uint8_t ps2_spi_wr_rd_byte(uint8_t byte)
 static void ps2_spi_write(uint8_t const *buffer, uint32_t size)
 {
     uint32_t ts;
-
-    if (spi_ss == 0) {
-        M_DEBUG("%s(..., %d) - ignoring, not selected\n", __FUNCTION__, (int)size);
-        return;
-    }
 
     // M_DEBUG("%s(..., %d)\n", __FUNCTION__, (int)size);
     while (size > 0) {
@@ -563,11 +538,6 @@ static void ps2_spi_write(uint8_t const *buffer, uint32_t size)
 static void ps2_spi_read(uint8_t *buffer, uint32_t size)
 {
     uint32_t ts;
-
-    if (spi_ss == 0) {
-        M_DEBUG("%s(..., %d) - ignoring, not selected\n", __FUNCTION__, (int)size);
-        return;
-    }
 
     // M_DEBUG("%s(..., %d)\n", __FUNCTION__, (int)size);
     while (size > 0) {


### PR DESCRIPTION
```
if (spi_ss == 0) {
        // We're ignoring a lot of dummy read/writes, this is not an error
        // M_DEBUG("%s(%d) - ignoring, not selected\n", __FUNCTION__, byte);
        return 0;
}
```
This check renders every instance of the following useless:
```
in spi_sdcard_driver.c:
_io->wr_rd_byte(DUMMY_BYTE);
_io->select();

_io->relese();
_io->wr_rd_byte(DUMMY_BYTE);
```  
As a result the clock is not toggled when it should be and this leads to issues with SanDisk sdcards. I'm not sure if this check was a means of optimization or an oversight. I haven't done any performance testing beyond loading up Half-Life with OPL, which seems okay. 

I've tested this fix with a 128GB SanDisk SDXC and a 16GB no brand SDHC, both seem to be fully working. Previously the 16GB would only be detected and wasnt able to get far enough to load a list of games and the SanDisk wouldn't respond at all.



EDIT:
test_bdm results on a SCPH-750001.

128GB SanDisk SDXC:
```
Read 1024KiB, in 5149ms, blocksize=64, speed=203KB/s
Read 1024KiB, in 2970ms, blocksize=128, speed=353KB/s
Read 1024KiB, in 1845ms, blocksize=256, speed=568KB/s
Read 1024KiB, in 1414ms, blocksize=512, speed=741KB/s
Read 1024KiB, in 1184ms, blocksize=1024, speed=885KB/s
Read 1024KiB, in 1085ms, blocksize=2048, speed=966KB/s
Read 1024KiB, in 1059ms, blocksize=4096, speed=990KB/s
Read 1024KiB, in 1049ms, blocksize=8192, speed=999KB/s
Read 1024KiB, in 1040ms, blocksize=16384, speed=1008KB/s
Read 1024KiB, in 1039ms, blocksize=32768, speed=1009KB/s
```  

16GB no brand SDHC:
```
Read 1024KiB, in 5104ms, blocksize=64, speed=205KB/s
Read 1024KiB, in 2947ms, blocksize=128, speed=355KB/s
Read 1024KiB, in 1837ms, blocksize=256, speed=570KB/s
Read 1024KiB, in 1408ms, blocksize=512, speed=744KB/s
Read 1024KiB, in 1164ms, blocksize=1024, speed=900KB/s
Read 1024KiB, in 1023ms, blocksize=2048, speed=1025KB/s
Read 1024KiB, in 983ms, blocksize=4096, speed=1066KB/s
Read 1024KiB, in 955ms, blocksize=8192, speed=1097KB/s
Read 1024KiB, in 940ms, blocksize=16384, speed=1115KB/s
Read 1024KiB, in 941ms, blocksize=32768, speed=1114KB/s
``` 

Unfortunately, I have no way of testing if this change will result in performance regression on already supported cards.