### PR TITLE
Implement audsrv_free_adpcm

### DIFF
--- a/ee/rpc/audsrv/include/audsrv.h
+++ b/ee/rpc/audsrv/include/audsrv.h
@@ -248,6 +248,13 @@ int audsrv_load_adpcm(audsrv_adpcm_t *adpcm, void *buffer, int size);
 int audsrv_ch_play_adpcm(int ch, audsrv_adpcm_t *adpcm);
 #define audsrv_play_adpcm(adpcm) audsrv_ch_play_adpcm(-1, adpcm) //For backward-compatibility
 
+/** Remove an adpcm sample uploaded with audsrv_load_adpcm() from the list of loaded sounds
+ * @param id    sample identifier, as specified in load()
+ *
+ * SPU memory is freed only when there are no sounds in the list that where loaded after the ones that have been freed
+ */
+int audsrv_free_adpcm(audsrv_adpcm_t *adpcm);
+
 /** Installs a callback function upon completion of a cdda track
  * @param cb your callback
  * @param arg extra parameter to pass to callback function later

--- a/ee/rpc/audsrv/src/audsrv_rpc.c
+++ b/ee/rpc/audsrv/src/audsrv_rpc.c
@@ -484,6 +484,12 @@ int audsrv_ch_play_adpcm(int ch, audsrv_adpcm_t *adpcm)
 	return call_rpc_2(AUDSRV_PLAY_ADPCM, ch, (u32)adpcm);
 }
 
+int audsrv_free_adpcm(audsrv_adpcm_t *adpcm)
+{
+	/* on iop side, the sample id is like the pointer on ee side */
+	return call_rpc_1(AUDSRV_FREE_ADPCM, (u32)adpcm);
+}
+
 const char *audsrv_get_error_string()
 {
 	switch(audsrv_get_error())

--- a/ee/rpc/audsrv/src/audsrv_rpc.h
+++ b/ee/rpc/audsrv/src/audsrv_rpc.h
@@ -51,6 +51,7 @@
 #define AUDSRV_LOAD_ADPCM           0x0017
 #define AUDSRV_PLAY_ADPCM           0x0018
 #define AUDSRV_ADPCM_SET_VOLUME     0x0019
+#define AUDSRV_FREE_ADPCM           0x001c
 
 #define AUDSRV_AVAILABLE            0x001a
 #define AUDSRV_QUEUED               0x001b

--- a/iop/sound/audsrv/include/audsrv.h
+++ b/iop/sound/audsrv/include/audsrv.h
@@ -48,6 +48,7 @@
 #define AUDSRV_LOAD_ADPCM           0x0017
 #define AUDSRV_PLAY_ADPCM           0x0018
 #define AUDSRV_SET_ADPCM_VOL        0x0019
+#define AUDSRV_FREE_ADPCM           0x001c
 
 #define AUDSRV_AVAILABLE            0x001a
 #define AUDSRV_QUEUED               0x001b
@@ -98,6 +99,7 @@ int audsrv_adpcm_set_volume(int ch, int voll, int volr);
 void *audsrv_load_adpcm(u32 *buffer, int size, int id);
 #define audsrv_play_adpcm(id)      audsrv_ch_play_adpcm(-1, id) //For backward-compatibility
 int audsrv_ch_play_adpcm(int ch, u32 id);
+int free_sample(u32 id);
 
 #define audsrv_IMPORTS_start DECLARE_IMPORT_TABLE(audsrv, 1, 4)
 #define audsrv_IMPORTS_end END_IMPORT_TABLE

--- a/iop/sound/audsrv/src/rpc_server.c
+++ b/iop/sound/audsrv/src/rpc_server.c
@@ -144,6 +144,10 @@ static void *rpc_command(int func, unsigned *data, int size)
 		ret = audsrv_ch_play_adpcm(data[0], data[1]);
 		break;
 
+		case AUDSRV_FREE_ADPCM:
+		ret = free_sample(data[0]);
+		break;
+
 		case AUDSRV_SET_ADPCM_VOL:
 		ret = audsrv_adpcm_set_volume(data[0], data[1], data[2]);
 		break;


### PR DESCRIPTION
Remove an adpcm sample uploaded with audsrv_load_adpcm() from the list of loaded sounds.

This allows games to free up SPU memeory by removing the latest loaded sounds from the list. For efficient managment commonly used sounds should be loaded first so that they do not need to be unloaded to free up memory.