### PR TITLE
Return channel id when sample is successufully started

### DIFF
--- a/ee/rpc/audsrv/include/audsrv.h
+++ b/ee/rpc/audsrv/include/audsrv.h
@@ -238,7 +238,7 @@ int audsrv_load_adpcm(audsrv_adpcm_t *adpcm, void *buffer, int size);
 /** Plays an adpcm sample already uploaded with audsrv_load_adpcm()
  * @param ch    channel identifier. Specifies one of the 24 voice channel to play the ADPCM channel on.
  * @param id    sample identifier, as specified in load()
- * @returns zero on success, negative value on error
+ * @returns channel identifier on success, negative value on error
  *
  * When ch is set to an invalid channel ID, the sample will be played in an unoccupied channel.
  * If all 24 channels are used, then -AUDSRV_ERR_NO_MORE_CHANNELS is returned.

--- a/ee/rpc/audsrv/samples/playadpcm/playadpcm.c
+++ b/ee/rpc/audsrv/samples/playadpcm/playadpcm.c
@@ -70,9 +70,9 @@ int main(int argc, char *argv[])
 
 	audsrv_adpcm_init();
 	audsrv_set_volume(MAX_VOLUME);
-	audsrv_adpcm_set_volume_and_pan(0, MAX_VOLUME, 0);
 	audsrv_load_adpcm(&sample, buffer, size);
-	audsrv_ch_play_adpcm(0, &sample);
+	int channel = audsrv_ch_play_adpcm(-1, &sample);
+	audsrv_adpcm_set_volume_and_pan(channel, MAX_VOLUME, 0);
 
 	/* Uncomment to hear two samples played simultaenously
 	for (i=0; i<100; i++)
@@ -80,8 +80,8 @@ int main(int argc, char *argv[])
 		nopdelay();
 	}
 
-	audsrv_adpcm_set_volume_and_pan(1, MAX_VOLUME, 0);
-	audsrv_ch_play_adpcm(1, &sample);
+	int channel = audsrv_ch_play_adpcm(-1, &sample);
+	audsrv_adpcm_set_volume_and_pan(channel, MAX_VOLUME, 0);
 	*/
 
 	printf("sample played..\n");

--- a/iop/sound/audsrv/src/adpcm.c
+++ b/iop/sound/audsrv/src/adpcm.c
@@ -201,7 +201,7 @@ static int audsrv_adpcm_alloc_channel(void)
 /** Plays an adpcm sample already uploaded with audsrv_load_adpcm()
  * @param ch    channel identifier. Specifies one of the 24 voice channel to play the ADPCM channel on. If set to an invalid channel ID, an unoccupied channel will be selected.
  * @param id    sample identifier, as specified in load()
- * @returns zero on success, negative value on error
+ * @returns channel identifier on success, negative value on error
  *
  * When ch is set to an invalid channel ID, the sample will be played in an unoccupied channel.
  * If all 24 channels are used, then -AUDSRV_ERR_NO_MORE_CHANNELS is returned.
@@ -243,7 +243,7 @@ int audsrv_ch_play_adpcm(int ch, u32 id)
 	sceSdSetParam(SD_CORE_1 | (channel << 1) | SD_VPARAM_PITCH, a->pitch);
 	sceSdSetAddr(SD_CORE_1 | (channel << 1) | SD_VOICE_START, a->spu2_addr);
 	sceSdSetSwitch(SD_CORE_1 | SD_SWITCH_KON, (1 << channel));
-	return AUDSRV_ERR_NOERROR;
+	return channel;
 }
 
 /** Initializes adpcm unit of audsrv


### PR DESCRIPTION
Returning the assigned channel lets us control the volume and other properties while using dynamically assigned channels.