### PR TITLE
Tweak IOP modules printf

### DIFF
--- a/iop/cdvd/cdfs/src/cdfs_iop.h
+++ b/iop/cdvd/cdfs/src/cdfs_iop.h
@@ -1,8 +1,9 @@
 #ifndef _CDFS_IOP_H
 #define _CDFS_IOP_H
 
+#define MODNAME "cdfs_driver"
 #ifdef DEBUG
-#define DPRINTF(args...)	printf(args)
+#define DPRINTF(args...)	printf(MODNAME ": "args)
 #else
 #define DPRINTF(args...)	do { } while(0)
 #endif

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -16,7 +16,6 @@
 #define DRIVER_UNIT_VERSION 2
 #define VERSION_STRINGIFY(x) #x
 
-#define MODNAME "cdfs_driver"
 
 IRX_ID(MODNAME, 1, 1);
 

--- a/iop/debug/ioptrap/src/ioptrap.c
+++ b/iop/debug/ioptrap/src/ioptrap.c
@@ -25,8 +25,8 @@
 #include "stdio.h"
 #include "sysclib.h"
 #include "thbase.h"
-
-IRX_ID("ioptrap_driver", 1, 1);
+#define MODNAME "ioptrap_driver"
+IRX_ID(MODNAME, 1, 1);
 
 extern struct irx_export_table _exp_ioptrap;
 
@@ -140,7 +140,7 @@ char *ExceptionGetModuleName(u32 epc, u32 *r_epc)
 #define JUMP_BUF_GP 11
 
 // Define this to something else if you want... maybe some ee_sio stuff :P
-#define TRAP_PRINTF(args...) printf(args)
+#define TRAP_PRINTF(args...) printf(MODNAME ": " args)
 
 static trap_exception_handler_t handlers[16];
 

--- a/iop/dvrp/dvrav/src/dvrav.c
+++ b/iop/dvrp/dvrav/src/dvrav.c
@@ -17,6 +17,13 @@
 #include "thsemap.h"
 #include "speedregs.h"
 #include "errno.h"
+#define MODNAME "DVRAV"
+
+#ifdef DEBUG
+#define DPRINTF(x...) printf(MODNAME ": " x)
+#else
+#define DPRINTF(x...)
+#endif
 
 extern int module_start();
 extern int module_stop();
@@ -142,7 +149,6 @@ s32 sema_id;
 
 // Based off of DESR / PSX DVR system software version 1.31.
 // Added additional functions from DESR / PSX DVR system software version 2.11.
-#define MODNAME "DVRAV"
 IRX_ID(MODNAME, 1, 1);
 
 int _start(int argc, char *argv[])
@@ -165,7 +171,7 @@ int module_start()
         DelayThread(1000);
     }
     if (i == 30000) {
-        printf("AV task of DVRP is not running...\n");
+        DPRINTF("AV task of DVRP is not running...\n");
         return MODULE_NO_RESIDENT_END;
     } else {
         if (iomanX_AddDrv(&DVRAV) != 0)
@@ -298,10 +304,10 @@ int avioctl2_get_tun_offset(
     cmdack.command = 0x3102;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_tun_offset -> Handshake error!\n");
+        DPRINTF("avioctl2_get_tun_offset -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_get_tun_offset -> Status error!\n");
+        DPRINTF("avioctl2_get_tun_offset -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -329,10 +335,10 @@ int avioctl2_tun_offset_up(
     cmdack.command = 0x3103;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_tun_offset_up -> Handshake error!\n");
+        DPRINTF("avioctl2_tun_offset_up -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_tun_offset_up -> Status error!\n");
+        DPRINTF("avioctl2_tun_offset_up -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -363,10 +369,10 @@ int avioctl2_tun_offset_down(
     cmdack.command = 0x3104;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_tun_offset_down -> Handshake error!\n");
+        DPRINTF("avioctl2_tun_offset_down -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_tun_offset_down -> Status error!\n");
+        DPRINTF("avioctl2_tun_offset_down -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -400,10 +406,10 @@ int avioctl2_tun_scan_ch(
     cmdack.input_word_count = 3;
     cmdack.timeout = 35000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("avioctl2_tun_scan_ch -> Handshake error!\n");
+        DPRINTF("avioctl2_tun_scan_ch -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("avioctl2_tun_scan_ch -> Status error!\n");
+        DPRINTF("avioctl2_tun_scan_ch -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.return_result_word[0];
@@ -435,11 +441,11 @@ int avioctl2_get_bs_gain(
     cmdack.command = 0x3106;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_bs_gain -> Handshake error!\n");
+        DPRINTF("avioctl2_get_bs_gain -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_get_bs_gain -> Status error!\n");
+            DPRINTF("avioctl2_get_bs_gain -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -469,11 +475,11 @@ int avioctl2_set_preset_info(
     cmdack.input_word[1] = *((u16 *)arg + 1);
     cmdack.input_word_count = 2;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_set_preset_info -> Handshake error!\n");
+        DPRINTF("avioctl2_set_preset_info -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_set_preset_info -> Status error!\n");
+            DPRINTF("avioctl2_set_preset_info -> Status error!\n");
             return -68;
         }
     }
@@ -499,11 +505,11 @@ int avioctl2_change_sound(
     cmdack.command = 0x3108;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_change_sound -> Handshake error!\n");
+        DPRINTF("avioctl2_change_sound -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_change_sound -> Status error!\n");
+            DPRINTF("avioctl2_change_sound -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -535,11 +541,11 @@ int avioctl2_set_d_audio_sel(
     cmdack.input_word[3] = *((u16 *)arg + 3);
     cmdack.input_word_count = 4;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_set_d_audio_sel -> Handshake error!\n");
+        DPRINTF("avioctl2_set_d_audio_sel -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_set_d_audio_sel -> Status error!\n");
+            DPRINTF("avioctl2_set_d_audio_sel -> Status error!\n");
             return -68;
         }
     }
@@ -566,11 +572,11 @@ int avioctl2_set_d_video_sel(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_set_d_video_sel -> Handshake error!\n");
+        DPRINTF("avioctl2_set_d_video_sel -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_set_d_video_sel -> Status error!\n");
+            DPRINTF("avioctl2_set_d_video_sel -> Status error!\n");
             return -68;
         }
     }
@@ -596,10 +602,10 @@ int avioctl2_get_av_src(
     cmdack.command = 0x310B;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_av_src -> Handshake error!\n");
+        DPRINTF("avioctl2_get_av_src -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_get_av_src -> Status error!\n");
+        DPRINTF("avioctl2_get_av_src -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -627,11 +633,11 @@ int avioctl2_get_preset_info(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_preset_info -> Handshake error!\n");
+        DPRINTF("avioctl2_get_preset_info -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_get_preset_info -> Status error!\n");
+            DPRINTF("avioctl2_get_preset_info -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -660,11 +666,11 @@ int avioctl2_select_position(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_select_position -> Handshake error!\n");
+        DPRINTF("avioctl2_select_position -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_select_position -> Status error!\n");
+            DPRINTF("avioctl2_select_position -> Status error!\n");
             return -68;
         }
     }
@@ -690,11 +696,11 @@ int avioctl2_position_up(
     cmdack.command = 0x310F;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_position_up -> Handshake error!\n");
+        DPRINTF("avioctl2_position_up -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_position_up -> Status error!\n");
+            DPRINTF("avioctl2_position_up -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -722,11 +728,11 @@ int avioctl2_position_down(
     cmdack.command = 0x3110;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_position_down -> Handshake error!\n");
+        DPRINTF("avioctl2_position_down -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_position_down -> Status error!\n");
+            DPRINTF("avioctl2_position_down -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -754,14 +760,14 @@ int avioctl2_get_position(
     cmdack.command = 0x3111;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_position -> Handshake error!\n");
+        DPRINTF("avioctl2_get_position -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_get_position -> Status error!\n");
+        DPRINTF("avioctl2_get_position -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
-        printf("Now position = %d\n", cmdack.output_word[0]);
+        DPRINTF("Now position = %d\n", cmdack.output_word[0]);
         return 0;
     }
 }
@@ -790,11 +796,11 @@ int avioctl2_set_position_info(
     cmdack.input_word[4] = *((u16 *)arg + 4);
     cmdack.input_word_count = 5;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_set_position_info -> Handshake error!\n");
+        DPRINTF("avioctl2_set_position_info -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_set_position_info -> Status error!\n");
+            DPRINTF("avioctl2_set_position_info -> Status error!\n");
             return -68;
         }
     }
@@ -820,10 +826,10 @@ int avioctl2_get_position_info(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_position_info -> Handshake error!\n");
+        DPRINTF("avioctl2_get_position_info -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("avioctl2_get_position_info -> Status error!\n");
+        DPRINTF("avioctl2_get_position_info -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = *(u16 *)arg;
@@ -855,11 +861,11 @@ int avioctl2_tun_scan_mode(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_tun_scan_mode -> Handshake error!\n");
+        DPRINTF("avioctl2_tun_scan_mode -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_tun_scan_mode -> Status error!\n");
+            DPRINTF("avioctl2_tun_scan_mode -> Status error!\n");
             return -68;
         }
     }
@@ -886,11 +892,11 @@ int avioctl2_f_select_position(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_f_select_position -> Handshake error!\n");
+        DPRINTF("avioctl2_f_select_position -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_f_select_position -> Status error!\n");
+            DPRINTF("avioctl2_f_select_position -> Status error!\n");
             return -68;
         }
     }
@@ -918,10 +924,10 @@ int avioctl2_select_rec_src(
     cmdack.timeout = 10000000;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("avioctl2_select_rec_src -> Handshake error!\n");
+        DPRINTF("avioctl2_select_rec_src -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("avioctl2_select_rec_src -> Status error!\n");
+        DPRINTF("avioctl2_select_rec_src -> Status error!\n");
         return -68;
     }
     return 0;
@@ -946,11 +952,11 @@ int avioctl2_get_rec_src(
     cmdack.command = 0x3117;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("avioctl2_get_rec_src -> Handshake error!\n");
+        DPRINTF("avioctl2_get_rec_src -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("avioctl2_get_rec_src -> Status error!\n");
+            DPRINTF("avioctl2_get_rec_src -> Status error!\n");
             return -68;
         } else {
             *(u16 *)buf = cmdack.output_word[0];
@@ -988,11 +994,11 @@ int avioctl2_cmd_ack(
     }
     cmdack.input_word_count = arglen >> 1;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf(" %s  -> Handshake error!\n", a1);
+        DPRINTF(" %s  -> Handshake error!\n", a1);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf(" %s  -> Status error!\n", a1);
+            DPRINTF(" %s  -> Status error!\n", a1);
             return -68;
         } else {
             u16 *input_word;
@@ -1043,10 +1049,10 @@ int avioctl2_cmd_ack_comp(
     cmdack.input_word_count = arglen >> 1;
     cmdack.timeout = a2;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf(" %s  -> Handshake error!\n", a1);
+        DPRINTF(" %s  -> Handshake error!\n", a1);
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf(" %s  -> Status error!\n", a1);
+        DPRINTF(" %s  -> Status error!\n", a1);
         return -68;
     } else {
         int out_count;

--- a/iop/dvrp/dvrdv/src/dvrdv.c
+++ b/iop/dvrp/dvrdv/src/dvrdv.c
@@ -18,6 +18,13 @@
 #include "speedregs.h"
 #include "errno.h"
 
+#define MODNAME "DVRDV"
+#ifdef DEBUG
+#define DPRINTF(x...) printf(MODNAME ": " x)
+#else
+#define DPRINTF(x...)
+#endif
+
 extern int module_start();
 extern int module_stop();
 extern int dvrdv_df_init(iomanX_iop_device_t *dev);
@@ -86,7 +93,6 @@ static iomanX_iop_device_t DVR = {
 s32 sema_id;
 
 // Based off of DESR / PSX DVR system software version 2.11.
-#define MODNAME "DVRDV"
 IRX_ID(MODNAME, 1, 0);
 
 int _start(int argc, char *argv[])
@@ -109,7 +115,7 @@ int module_start()
         DelayThread(1000);
     }
     if (i == 30000) {
-        printf("DVR task of DVRP is not running...\n");
+        DPRINTF("DVR task of DVRP is not running...\n");
         return MODULE_NO_RESIDENT_END;
     } else {
         if (iomanX_AddDrv(&DVR) != 0)
@@ -248,16 +254,16 @@ int dvrioctl2_dv_dubb_start(
     (void)buf;
     (void)buflen;
 
-    printf("------------------------------ dv dubb start!!!\n");
+    DPRINTF("------------------------------ dv dubb start!!!\n");
     cmdack.command = 0x4101;
     cmdack.input_word_count = 0;
     cmdack_err = DvrdrvExecCmdAck(&cmdack);
     if (cmdack_err) {
-        printf("dvrioctl2_dv_dubb_start -> Handshake error!,%d\n", cmdack_err);
+        DPRINTF("dvrioctl2_dv_dubb_start -> Handshake error!,%d\n", cmdack_err);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_dv_dubb_start -> Status error!,%04X\n", cmdack.ack_status_ack);
+            DPRINTF("dvrioctl2_dv_dubb_start -> Status error!,%04X\n", cmdack.ack_status_ack);
             return -68;
         }
     }
@@ -284,16 +290,16 @@ int dvrioctl2_dv_dubb_stop(
     (void)buf;
     (void)buflen;
 
-    printf("------------------------------ dv dubb stop!!!\n");
+    DPRINTF("------------------------------ dv dubb stop!!!\n");
     cmdack.command = 0x4102;
     cmdack.input_word_count = 0;
     cmdack_err = DvrdrvExecCmdAck(&cmdack);
     if (cmdack_err) {
-        printf("dvrioctl2_dv_dubb_stop -> Handshake error!,%d\n", cmdack_err);
+        DPRINTF("dvrioctl2_dv_dubb_stop -> Handshake error!,%d\n", cmdack_err);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_dv_dubb_stop -> Status error!,%04X\n", cmdack.ack_status_ack);
+            DPRINTF("dvrioctl2_dv_dubb_stop -> Status error!,%04X\n", cmdack.ack_status_ack);
             return -68;
         }
     }
@@ -323,7 +329,7 @@ int dvrioctl2_dv_dubb_rec_start(
     (void)buflen;
 
     cmdack.command = 0x4103;
-    printf("------------------------------ dv dubb rec start!!!\n");
+    DPRINTF("------------------------------ dv dubb rec start!!!\n");
     v8 = 4;
     v9 = (u16 *)((u8 *)arg + 8);
     v10 = &cmdack.input_word[4];
@@ -340,11 +346,11 @@ int dvrioctl2_dv_dubb_rec_start(
     cmdack.input_word_count = 7;
     cmdack_err = DvrdrvExecCmdAck(&cmdack);
     if (cmdack_err) {
-        printf("dvrioctl2_dv_dubb_rec_start -> Handshake error!,%d\n", cmdack_err);
+        DPRINTF("dvrioctl2_dv_dubb_rec_start -> Handshake error!,%d\n", cmdack_err);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_dv_dubb_rec_start -> Status error!,%04X\n", cmdack.ack_status_ack);
+            DPRINTF("dvrioctl2_dv_dubb_rec_start -> Status error!,%04X\n", cmdack.ack_status_ack);
             return -68;
         }
     }
@@ -371,19 +377,19 @@ int dvrioctl2_dv_dubb_rec_stop(
     (void)buf;
     (void)buflen;
 
-    printf("------------------------------ dv dubb rec stop!!!\n");
+    DPRINTF("------------------------------ dv dubb rec stop!!!\n");
     cmdack.command = 0x4104;
     cmdack.input_word_count = 0;
     cmdack.timeout = 5000000;
     cmdack_err = DvrdrvExecCmdAckComp(&cmdack);
     if (cmdack_err) {
-        printf("phase %d\n", cmdack.phase);
-        printf("dvrioctl2_dv_dubb_rec_stop -> Handshake error!,%d\n", cmdack_err);
+        DPRINTF("phase %d\n", cmdack.phase);
+        DPRINTF("dvrioctl2_dv_dubb_rec_stop -> Handshake error!,%d\n", cmdack_err);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("phase %d\n", cmdack.phase);
-            printf("dvrioctl2_dv_dubb_rec_stop -> Status error!,%04X\n", cmdack.ack_status_ack);
+            DPRINTF("phase %d\n", cmdack.phase);
+            DPRINTF("dvrioctl2_dv_dubb_rec_stop -> Status error!,%04X\n", cmdack.ack_status_ack);
             return -68;
         }
     }
@@ -413,12 +419,12 @@ int dvrioctl2_get_dvcam_info(
     cmdack.input_word_count = 0;
     cmdack_err = DvrdrvExecCmdAck(&cmdack);
     if (cmdack_err) {
-        printf("phase %d\n", cmdack.phase);
-        printf("dvrioctl2_get_dvcam_info -> Handshake error!,%d\n", cmdack_err);
+        DPRINTF("phase %d\n", cmdack.phase);
+        DPRINTF("dvrioctl2_get_dvcam_info -> Handshake error!,%d\n", cmdack_err);
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_get_dvcam_info -> Status error!,%04X\n", cmdack.ack_status_ack);
+            DPRINTF("dvrioctl2_get_dvcam_info -> Status error!,%04X\n", cmdack.ack_status_ack);
             return -68;
         } else {
             u16 *v11;
@@ -451,7 +457,7 @@ int dvrioctl2_get_dvcam_name(
     (void)arg;
     (void)arglen;
 
-    printf("dvrioctl2_get_dvcam_name(io=%p, cmd=%d  buf=%p, nbyte=%u)\n", a1, cmd, buf, buflen);
+    DPRINTF("dvrioctl2_get_dvcam_name(io=%p, cmd=%d  buf=%p, nbyte=%u)\n", a1, cmd, buf, buflen);
     cmdack.command = 0x4108;
     cmdack.input_word[0] = 0;
     cmdack.input_word[1] = 0;
@@ -461,11 +467,11 @@ int dvrioctl2_get_dvcam_name(
     cmdack.output_buffer = buf;
     cmdack.timeout = 5000000;
     if (DvrdrvExecCmdAckDmaRecvComp(&cmdack)) {
-        printf("dvrioctl2_get_dvcam_name : IO error (phase %d)\n", cmdack.phase);
+        DPRINTF("dvrioctl2_get_dvcam_name : IO error (phase %d)\n", cmdack.phase);
         return -5;
     } else {
         if (cmdack.comp_status) {
-            printf("dvrioctl2_get_dvcam_name : Complete parameter error (phase %d), %04X\n", cmdack.phase, cmdack.comp_status);
+            DPRINTF("dvrioctl2_get_dvcam_name : Complete parameter error (phase %d), %04X\n", cmdack.phase, cmdack.comp_status);
             return -5;
         }
     }

--- a/iop/dvrp/dvrfile/src/dvrfile.c
+++ b/iop/dvrp/dvrfile/src/dvrfile.c
@@ -18,6 +18,13 @@
 #include "speedregs.h"
 #include "errno.h"
 
+#define MODNAME "DVRFILE"
+#ifdef DEBUG
+#define DPRINTF(x...) printf(MODNAME ": " x)
+#else
+#define DPRINTF(x...)
+#endif
+
 extern int module_start(int argc, char *argv[]);
 extern int module_stop(int argc, char *argv[]);
 extern int dvrf_df_init(iomanX_iop_device_t *f);
@@ -246,8 +253,7 @@ int RBUF[32768];
 int SBUF[32768];
 
 // Based off of DESR / PSX DVR system software version 1.31.
-#define MODNAME "DVRFILE"
-IRX_ID("DVRFILE", 1, 1);
+IRX_ID(MODNAME, 1, 1);
 
 int _start(int argc, char *argv[])
 {
@@ -270,7 +276,7 @@ int module_start(int argc, char *argv[])
     }
 
     if (i == 30000) {
-        printf("IOMAN task of DVRP is not running...\n");
+        DPRINTF("IOMAN task of DVRP is not running...\n");
         return MODULE_NO_RESIDENT_END;
     }
     sema_id = -1;
@@ -288,18 +294,18 @@ int module_start(int argc, char *argv[])
     return MODULE_RESIDENT_END;
 #endif
 setup_fschk:
-    printf("dvrfile.irx : FILE SYSTEM CHECK MODE\n");
+    DPRINTF("dvrfile.irx : FILE SYSTEM CHECK MODE\n");
 
     if (iomanX_AddDrv(&dvrhdck_drv)) {
-        printf("hdck\n");
+        DPRINTF("hdck\n");
         goto fail;
     }
     if (iomanX_AddDrv(&dvrfssk_drv)) {
-        printf("fssk\n");
+        DPRINTF("fssk\n");
         goto fail;
     }
     if (iomanX_AddDrv(&dvrfsck_drv)) {
-        printf("fsck\n");
+        DPRINTF("fsck\n");
         goto fail;
     }
 #if 0
@@ -335,12 +341,12 @@ static int check_cmdack_err(int (*func)(drvdrv_exec_cmd_ack *cmdack), drvdrv_exe
 {
     if (func(cmdack)) {
         *retval = -EIO;
-        printf("%s -> IO error (phase %d)\n", funcname, cmdack->phase);
+        DPRINTF("%s -> IO error (phase %d)\n", funcname, cmdack->phase);
         return 1;
     }
     if (cmdack->comp_status) {
         *retval = -EIO;
-        printf("%s -> Complete parameter error (phase %d), %04X\n", funcname, cmdack->phase, cmdack->comp_status);
+        DPRINTF("%s -> Complete parameter error (phase %d), %04X\n", funcname, cmdack->phase, cmdack->comp_status);
         return 1;
     }
     *retval = (cmdack->return_result_word[0] << 16) + cmdack->return_result_word[1];
@@ -538,7 +544,7 @@ int dvrf_df_dopen(iomanX_iop_file_t *f, const char *path)
         goto finish;
     }
     if (retval < 0) {
-        printf("%s -> fd error (fd=%d)\n", __func__, retval);
+        DPRINTF("%s -> fd error (fd=%d)\n", __func__, retval);
         goto finish;
     }
     f->privdata = (void *)retval;
@@ -841,7 +847,7 @@ int dvrf_df_open(iomanX_iop_file_t *f, const char *name, int flags, int mode)
         goto finish;
     }
     if (retval < 0) {
-        printf("%s -> fd error (fd=%d)\n", __func__, retval);
+        DPRINTF("%s -> fd error (fd=%d)\n", __func__, retval);
         goto finish;
     }
     f->privdata = (void *)retval;

--- a/iop/dvrp/dvrmisc/src/dvrmisc.c
+++ b/iop/dvrp/dvrmisc/src/dvrmisc.c
@@ -19,6 +19,13 @@
 #include "speedregs.h"
 #include "errno.h"
 
+#define MODNAME "DVRMISC"
+#ifdef DEBUG
+#define DPRINTF(x...) printf(MODNAME ": " x)
+#else
+#define DPRINTF(x...)
+#endif
+
 extern int module_start();
 extern int module_stop();
 extern int dvrmisc_df_init(iomanX_iop_device_t *dev);
@@ -127,7 +134,6 @@ char SBUF[16384];
 
 // Based off of DESR / PSX DVR system software version 1.31.
 // Added additional functions from DESR / PSX DVR system software version 2.11.
-#define MODNAME "DVRMISC"
 IRX_ID(MODNAME, 1, 1);
 
 int _start(int argc, char *argv[])
@@ -150,7 +156,7 @@ int module_start()
         DelayThread(1000);
     }
     if (i == 30000) {
-        printf("MISC task of DVRP is not running...\n");
+        DPRINTF("MISC task of DVRP is not running...\n");
         return MODULE_NO_RESIDENT_END;
     } else {
         if (iomanX_AddDrv(&DVRMISC) != 0)
@@ -285,11 +291,11 @@ int dvrioctl2_nop(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen
     cmdack.command = 0x5101;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_nop -> Handshake error!\n");
+        DPRINTF("dvrioctl2_nop -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_nop -> Status error!\n");
+            DPRINTF("dvrioctl2_nop -> Status error!\n");
             return -68;
         }
     }
@@ -315,10 +321,10 @@ int dvrioctl2_version(
     cmdack.command = 0x5102;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_version -> Handshake error!\n");
+        DPRINTF("dvrioctl2_version -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("dvrioctl2_version -> Status error!\n");
+        DPRINTF("dvrioctl2_version -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -347,11 +353,11 @@ int dvrioctl2_led_hdd_rec(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_led_hdd_rec -> Handshake error!\n");
+        DPRINTF("dvrioctl2_led_hdd_rec -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_led_hdd_rec -> Status error!\n");
+            DPRINTF("dvrioctl2_led_hdd_rec -> Status error!\n");
             return -68;
         }
     }
@@ -378,11 +384,11 @@ int dvrioctl2_led_dvd_rec(
     cmdack.input_word_count = 1;
     cmdack.input_word[0] = *(u16 *)arg;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_led_dvd_rec -> Handshake error!\n");
+        DPRINTF("dvrioctl2_led_dvd_rec -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_led_dvd_rec -> Status error!\n");
+            DPRINTF("dvrioctl2_led_dvd_rec -> Status error!\n");
             return -68;
         }
     }
@@ -408,10 +414,10 @@ int dvrioctl2_get_sircs(
     cmdack.command = 0x5107;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_get_sircs -> Handshake error!\n");
+        DPRINTF("dvrioctl2_get_sircs -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("dvrioctl2_get_sircs -> Status error!\n");
+        DPRINTF("dvrioctl2_get_sircs -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -442,10 +448,10 @@ int dvrioctl2_get_time(
     cmdack.command = 0x5108;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_get_time -> Handshake error!\n");
+        DPRINTF("dvrioctl2_get_time -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("dvrioctl2_get_time -> Status error!\n");
+        DPRINTF("dvrioctl2_get_time -> Status error!\n");
         return -68;
     } else {
         *(u8 *)buf = cmdack.output_word[0];
@@ -480,11 +486,11 @@ int dvrioctl2_set_timezone(
     cmdack.input_word_count = 2;
     cmdack.input_word[1] = *((u16 *)arg + 1);
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_set_timezone -> Handshake error!\n");
+        DPRINTF("dvrioctl2_set_timezone -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_set_timezone -> Status error!\n");
+            DPRINTF("dvrioctl2_set_timezone -> Status error!\n");
             return -68;
         }
     }
@@ -512,10 +518,10 @@ int dvrioctl2_save_preset_info(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_save_preset_info -> Handshake error!\n");
+        DPRINTF("dvrioctl2_save_preset_info -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_save_preset_info -> Status error!\n");
+        DPRINTF("dvrioctl2_save_preset_info -> Status error!\n");
         return -68;
     }
     return 0;
@@ -542,10 +548,10 @@ int dvrioctl2_load_preset_info(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_load_preset_info -> Handshake error!\n");
+        DPRINTF("dvrioctl2_load_preset_info -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_load_preset_info -> Status error!\n");
+        DPRINTF("dvrioctl2_load_preset_info -> Status error!\n");
         return -68;
     }
     return 0;
@@ -572,10 +578,10 @@ int dvrioctl2_test_dev_rst(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_test_dev_rst -> Handshake error!\n");
+        DPRINTF("dvrioctl2_test_dev_rst -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_test_dev_rst -> Status error!\n");
+        DPRINTF("dvrioctl2_test_dev_rst -> Status error!\n");
         return -68;
     }
     return 0;
@@ -601,10 +607,10 @@ int dvrioctl2_test_sdram_chk(
     cmdack.input_word_count = 0;
     cmdack.timeout = 20000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_test_sdram_chk -> Handshake error!\n");
+        DPRINTF("dvrioctl2_test_sdram_chk -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_test_sdram_chk -> Status error!\n");
+        DPRINTF("dvrioctl2_test_sdram_chk -> Status error!\n");
         return -68;
     } else {
         *(u32 *)buf = (cmdack.return_result_word[0] << 16) + cmdack.return_result_word[1];
@@ -634,10 +640,10 @@ int dvrioctl2_test_mpe_chk(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_test_mpe_chk -> Handshake error!\n");
+        DPRINTF("dvrioctl2_test_mpe_chk -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_test_mpe_chk -> Status error!\n");
+        DPRINTF("dvrioctl2_test_mpe_chk -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.return_result_word[0];
@@ -665,10 +671,10 @@ int dvrioctl2_test_mpd_chk(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_test_mpd_chk -> Handshake error!\n");
+        DPRINTF("dvrioctl2_test_mpd_chk -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_test_mpd_chk -> Status error!\n");
+        DPRINTF("dvrioctl2_test_mpd_chk -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.return_result_word[0];
@@ -697,10 +703,10 @@ int dvrioctl2_test_vdec_chk(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_test_vdec_chk -> Handshake error!\n");
+        DPRINTF("dvrioctl2_test_vdec_chk -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("dvrioctl2_test_vdec_chk -> Status error!\n");
+        DPRINTF("dvrioctl2_test_vdec_chk -> Status error!\n");
         return -68;
     }
     return 0;
@@ -727,13 +733,13 @@ int dvrioctl2_partition_free(
     v7 = iomanX_devctl((const char *)arg, 0x5002, 0, 0, 0, 0);
     v8 = v7;
     if (v7 < 0) {
-        printf("dvrioctl2_partition_free : Cannot execute PDIOC_ZONEFREE.,%d\n", v7);
+        DPRINTF("dvrioctl2_partition_free : Cannot execute PDIOC_ZONEFREE.,%d\n", v7);
         return -5;
     }
     v9 = iomanX_devctl((const char *)arg, 0x5001, 0, 0, 0, 0);
     v10 = v8 * (s64)v9;
     if (v9 < 0) {
-        printf("dvrioctl2_partition_free : Cannot execute PDIOC_ZONESZ.,%d\n", v9);
+        DPRINTF("dvrioctl2_partition_free : Cannot execute PDIOC_ZONESZ.,%d\n", v9);
         return -5;
     }
     *(u64 *)buf = v10;
@@ -767,11 +773,11 @@ int dvrioctl2_buzzer(
     cmdack.command = 0x5111;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_buzzer -> Handshake error!\n");
+        DPRINTF("dvrioctl2_buzzer -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_buzzer -> Status error!\n");
+            DPRINTF("dvrioctl2_buzzer -> Status error!\n");
             return -68;
         }
     }
@@ -799,11 +805,11 @@ int dvrioctl2_clr_preset_info(
     cmdack.input_word_count = 0;
     cmdack.timeout = 20000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("dvrioctl2_clr_preset_info -> Handshake error!\n");
+        DPRINTF("dvrioctl2_clr_preset_info -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_clr_preset_info -> Status error!\n");
+            DPRINTF("dvrioctl2_clr_preset_info -> Status error!\n");
             return -68;
         }
     }
@@ -829,11 +835,11 @@ int dvrioctl2_get_vbi_err_rate(
     cmdack.command = 0x5113;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_get_vbi_err_rate -> Handshake error!\n");
+        DPRINTF("dvrioctl2_get_vbi_err_rate -> Handshake error!\n");
         return -5;
     } else {
         if (cmdack.ack_status_ack) {
-            printf("dvrioctl2_get_vbi_err_rate -> Status error!\n");
+            DPRINTF("dvrioctl2_get_vbi_err_rate -> Status error!\n");
             return -68;
         } else {
             *(u32 *)buf = (cmdack.output_word[0] << 16) + cmdack.output_word[1];
@@ -881,21 +887,21 @@ int dvrioctl2_update_dvrp_firmware(
     cmdack.input_word_count = 2;
     cmdack.timeout = 10000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("FLASH_DATA_TOTALSIZE -> Handshake error!\n");
+        DPRINTF("FLASH_DATA_TOTALSIZE -> Handshake error!\n");
     LABEL_37:
         retval = -5;
         goto LABEL_38;
     }
     if (cmdack.ack_status_ack) {
-        printf("FLASH_DATA_TOTALSIZE -> Status error!\n");
+        DPRINTF("FLASH_DATA_TOTALSIZE -> Status error!\n");
         goto LABEL_37;
     }
     if (cmdack.comp_status) {
-        printf("FLASH_DATA_TOTALSIZE -> Status error!\n");
+        DPRINTF("FLASH_DATA_TOTALSIZE -> Status error!\n");
         goto LABEL_37;
     }
     if (update_size != (cmdack.return_result_word[0] << 16) + cmdack.return_result_word[1])
-        printf("Size of firmware is not equal to Size of buffer on DVRP memory.\n");
+        DPRINTF("Size of firmware is not equal to Size of buffer on DVRP memory.\n");
     for (i = 0x3FFF;; i = 0x3FFF) {
         char *v13;
         int read_size;
@@ -917,11 +923,11 @@ int dvrioctl2_update_dvrp_firmware(
         cmdack.input_buffer_length = read_size;
         cmdack.timeout = 10000000;
         if (DvrdrvExecCmdAckDmaSendComp(&cmdack)) {
-            printf("MISCCMD_FLASH_DATA_DOWNLOAD -> Handshake error!\n");
+            DPRINTF("MISCCMD_FLASH_DATA_DOWNLOAD -> Handshake error!\n");
             goto LABEL_37;
         }
         if (cmdack.ack_status_ack || (read_offset += read_size, cmdack.comp_status)) {
-            printf("MISCCMD_FLASH_DATA_DOWNLOAD -> Status error!\n");
+            DPRINTF("MISCCMD_FLASH_DATA_DOWNLOAD -> Status error!\n");
             goto LABEL_37;
         }
         for (j = 0; j < read_size; ++j) {
@@ -938,16 +944,16 @@ int dvrioctl2_update_dvrp_firmware(
     cmdack.input_word_count = 6;
     cmdack.timeout = 10000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("MISCCMD_FLASH_DATA_CHECKSUM -> Handshake error!\n");
+        DPRINTF("MISCCMD_FLASH_DATA_CHECKSUM -> Handshake error!\n");
         goto LABEL_37;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_FLASH_DATA_CHECKSUM -> ACK Status error!\n");
+        DPRINTF("MISCCMD_FLASH_DATA_CHECKSUM -> ACK Status error!\n");
     } else {
         if (cmdack.comp_status) {
             retval = -68;
-            printf("MISCCMD_FLASH_DATA_CHECKSUM -> COMP Status error!\n");
-            printf(
+            DPRINTF("MISCCMD_FLASH_DATA_CHECKSUM -> COMP Status error!\n");
+            DPRINTF(
                 "Check sum error! IOP:%08X,DVRP:%08X\n",
                 checksum,
                 (cmdack.return_result_word[0] << 16) | cmdack.return_result_word[1]);
@@ -957,16 +963,16 @@ int dvrioctl2_update_dvrp_firmware(
         cmdack.input_word_count = 0;
         cmdack.timeout = 10000000;
         if (DvrdrvExecCmdAckComp(&cmdack)) {
-            printf("MISCCMD_FLASH_DATA_WRITE -> Handshake error!\n");
+            DPRINTF("MISCCMD_FLASH_DATA_WRITE -> Handshake error!\n");
             goto LABEL_37;
         }
         if (cmdack.ack_status_ack) {
-            printf("MISCCMD_FLASH_DATA_WRITE -> ACK Status error!\n");
+            DPRINTF("MISCCMD_FLASH_DATA_WRITE -> ACK Status error!\n");
         } else {
             retval = 0;
             if (!cmdack.comp_status)
                 goto LABEL_38;
-            printf("MISCCMD_FLASH_DATA_WRITE -> COMP Status error!\n");
+            DPRINTF("MISCCMD_FLASH_DATA_WRITE -> COMP Status error!\n");
         }
     }
     retval = -68;
@@ -994,10 +1000,10 @@ int dvrioctl2_flash_write_status(
     cmdack.command = 0x5118;
     cmdack.input_word_count = 0;
     if (DvrdrvExecCmdAck(&cmdack)) {
-        printf("dvrioctl2_flash_write_status -> Handshake error!\n");
+        DPRINTF("dvrioctl2_flash_write_status -> Handshake error!\n");
         return -5;
     } else if (cmdack.ack_status_ack) {
-        printf("dvrioctl2_flash_write_status -> Status error!\n");
+        DPRINTF("dvrioctl2_flash_write_status -> Status error!\n");
         return -68;
     } else {
         *(u16 *)buf = cmdack.output_word[0];
@@ -1023,7 +1029,7 @@ int dvrioctl2_set_device_key(
     int cmdack_err2;
     drvdrv_exec_cmd_ack cmdack;
 
-    printf(
+    DPRINTF(
         "dvrioctl2_set_device_key (io=%p,cmd=%08X,argp=%p,arglen=%u,bufp=%p,buflen=%u)\n",
         a1,
         cmd,
@@ -1036,23 +1042,23 @@ int dvrioctl2_set_device_key(
     cmdack.input_word[1] = 456;
     cmdack.input_word_count = 2;
     cmdack.timeout = 10000000;
-    printf("dvrcmd.cmd_p[0]:%x\n", 0);
-    printf("dvrcmd.cmd_p[1]:%x\n", 456);
+    DPRINTF("dvrcmd.cmd_p[0]:%x\n", 0);
+    DPRINTF("dvrcmd.cmd_p[1]:%x\n", 456);
     cmdack_err = DvrdrvExecCmdAckComp(&cmdack);
-    printf("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
+    DPRINTF("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
     if (cmdack_err) {
-        printf("DEVKEY_TOTALSIZE -> Handshake error!\n");
+        DPRINTF("DEVKEY_TOTALSIZE -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack || cmdack.comp_status) {
-        printf("DEVKEY_TOTALSIZE -> Status error!\n");
+        DPRINTF("DEVKEY_TOTALSIZE -> Status error!\n");
         return -5;
     }
     bsize = (cmdack.return_result_word[0] << 16) + cmdack.return_result_word[1];
     if (bsize != 456)
-        printf("Size of firmware is not equal to Size of buffer on DVRP memory.\n");
-    printf("FSIZE:%08X\n", 456);
-    printf("BSIZE:%08X\n", bsize);
+        DPRINTF("Size of firmware is not equal to Size of buffer on DVRP memory.\n");
+    DPRINTF("FSIZE:%08X\n", 456);
+    DPRINTF("BSIZE:%08X\n", bsize);
     cmdack.command = 0x511C;
     ((u32 *)SBUF)[0] = *(u32 *)"XESD";
     byteswap_tmp2 = (int *)&SBUF[4];
@@ -1074,34 +1080,34 @@ int dvrioctl2_set_device_key(
     cmdack.input_buffer_length = 456;
     cmdack.timeout = 10000000;
     cmdack_err3 = DvrdrvExecCmdAckDmaSendComp(&cmdack);
-    printf("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
+    DPRINTF("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
     if (cmdack_err3) {
-        printf("MISCCMD_DEVKEY_DOWNLOAD -> Handshake error!\n");
+        DPRINTF("MISCCMD_DEVKEY_DOWNLOAD -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_DEVKEY_DOWNLOAD -> Status error!\n");
+        DPRINTF("MISCCMD_DEVKEY_DOWNLOAD -> Status error!\n");
         return -5;
     }
     if (cmdack.comp_status) {
-        printf("MISCCMD_DEVKEY_DOWNLOAD -> Status error!\n");
+        DPRINTF("MISCCMD_DEVKEY_DOWNLOAD -> Status error!\n");
         return -5;
     }
     cmdack.command = 0x5119;
     cmdack.input_word_count = 0;
     cmdack.timeout = 10000000;
     cmdack_err2 = DvrdrvExecCmdAckComp(&cmdack);
-    printf("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
+    DPRINTF("dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
     if (cmdack_err2) {
-        printf("MISCCMD_SAVE_DEVKEY_INFO -> Handshake error!\n");
+        DPRINTF("MISCCMD_SAVE_DEVKEY_INFO -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_SAVE_DEVKEY_INFO -> Status error!\n");
+        DPRINTF("MISCCMD_SAVE_DEVKEY_INFO -> Status error!\n");
         return -68;
     }
     if (cmdack.comp_status) {
-        printf("MISCCMD_SAVE_DEVKEY_INFO -> Status error!\n");
+        DPRINTF("MISCCMD_SAVE_DEVKEY_INFO -> Status error!\n");
         return -5;
     }
     return 0;
@@ -1133,15 +1139,15 @@ int dvrioctl2_get_device_key(
     cmdack.input_word_count = 2;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("MISCCMD_GET_DEVKEY_INFO -> Handshake error!\n");
+        DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
+        DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
         return -68;
     }
     if (cmdack.comp_status) {
-        printf("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
+        DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
         return -5;
     }
     v6 = 0;
@@ -1190,16 +1196,16 @@ int dvrioctl2_get_device_key(
             cmdack.input_word_count = 2;
             cmdack.timeout = 30000000;
             if (DvrdrvExecCmdAckComp(&cmdack)) {
-                printf("MISCCMD_GET_DEVKEY_INFO -> Handshake error!\n");
+                DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Handshake error!\n");
                 return -5;
             }
             if (cmdack.ack_status_ack) {
-                printf("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
+                DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
                 return -68;
             }
             v22 = 1;
             if (cmdack.comp_status) {
-                printf("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
+                DPRINTF("MISCCMD_GET_DEVKEY_INFO -> Status error!\n");
                 return -5;
             }
             if ((u16)v21 + 1 > 1) {
@@ -1258,15 +1264,15 @@ int dvrioctl2_set_dv_nodeid(
     cmdack.input_word_count = 4;
     cmdack.timeout = 10000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("MISCCMD_SAVE_DV_NODEID -> Handshake error!\n");
+        DPRINTF("MISCCMD_SAVE_DV_NODEID -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_SAVE_DV_NODEID -> Status error!\n");
+        DPRINTF("MISCCMD_SAVE_DV_NODEID -> Status error!\n");
         return -68;
     }
     if (cmdack.comp_status) {
-        printf("MISCCMD_SAVE_DV_NODEID -> Status error!\n");
+        DPRINTF("MISCCMD_SAVE_DV_NODEID -> Status error!\n");
         return -5;
     }
     return 0;
@@ -1292,15 +1298,15 @@ int dvrioctl2_get_dv_nodeid(
     cmdack.input_word_count = 0;
     cmdack.timeout = 15000000;
     if (DvrdrvExecCmdAckComp(&cmdack)) {
-        printf("MISCCMD_GET_DV_NODEID -> Handshake error!\n");
+        DPRINTF("MISCCMD_GET_DV_NODEID -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("MISCCMD_GET_DV_NODEID -> Status error!\n");
+        DPRINTF("MISCCMD_GET_DV_NODEID -> Status error!\n");
         return -68;
     }
     if (cmdack.comp_status) {
-        printf("MISCCMD_GET_DV_NODEID -> Status error!\n");
+        DPRINTF("MISCCMD_GET_DV_NODEID -> Status error!\n");
         return -5;
     }
     bufwalked = 0;
@@ -1324,9 +1330,9 @@ int dvrioctl2_get_dv_nodeid(
     }
     return 0;
 }
-
+#ifdef DEBUG
 int test_count = 0;
-
+#endif
 int dvrioctl2_diag_test(
     iomanX_iop_file_t *a1,
     int cmd,
@@ -1336,7 +1342,9 @@ int dvrioctl2_diag_test(
     unsigned int buflen)
 {
     int cmdack_err;
+#ifdef DEBUG
     int testcnt_tmp;
+#endif
     int outbuf_cnt;
     u16 *outbuf_tmp;
     drvdrv_exec_cmd_ack cmdack;
@@ -1355,44 +1363,46 @@ int dvrioctl2_diag_test(
     cmdack.input_word_count = 5;
     cmdack.timeout = 120000000;
     if (cmdack.input_word[2]) {
-        printf("------------------- > SetTO:%d msec\n", 120000);
+        DPRINTF("------------------- > SetTO:%d msec\n", 120000);
         cmdack.timeout = 10000000 * cmdack.input_word[2];
     }
-    printf("arg :  %4x", cmdack.input_word[0]);
-    printf(" %4x", cmdack.input_word[1]);
-    printf(" %4x ", cmdack.input_word[2]);
-    printf(" SetTimeOutTo : %d usec\n", cmdack.timeout);
+    DPRINTF("arg :  %4x", cmdack.input_word[0]);
+    DPRINTF(" %4x", cmdack.input_word[1]);
+    DPRINTF(" %4x ", cmdack.input_word[2]);
+    DPRINTF(" SetTimeOutTo : %d usec\n", cmdack.timeout);
     cmdack_err = DvrdrvExecCmdAckComp(&cmdack);
+#ifdef DEBUG
     testcnt_tmp = test_count++;
-    printf(
+#endif
+    DPRINTF(
         "cmd ID : %d -------------------- TEST VERSION - diag test -------------------- r %d -- c %d\n",
         31,
         cmdack_err,
         testcnt_tmp);
-    printf("diag_test dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
-    printf("diag_test dvrcmd.phase:%x\n", cmdack.phase);
+    DPRINTF("diag_test dvrcmd.ack_p[0]:%x\n", cmdack.ack_status_ack);
+    DPRINTF("diag_test dvrcmd.phase:%x\n", cmdack.phase);
     if (cmdack_err) {
-        printf("dvrioctl2_diag_test -> Handshake error!\n");
+        DPRINTF("dvrioctl2_diag_test -> Handshake error!\n");
         return -5;
     }
     if (cmdack.ack_status_ack) {
-        printf("dvrioctl2_diag_test -> Status error in ACK! param:%04x\n", cmdack.ack_status_ack);
+        DPRINTF("dvrioctl2_diag_test -> Status error in ACK! param:%04x\n", cmdack.ack_status_ack);
         return -68;
     }
     if (cmdack.comp_status) {
-        printf("dvrioctl2_diag_test -> Status error in COMP! param:%04x\n", cmdack.comp_status);
+        DPRINTF("dvrioctl2_diag_test -> Status error in COMP! param:%04x\n", cmdack.comp_status);
         return -68;
     }
     outbuf_cnt = 0;
-    printf("---------------------------- return buffer\n");
+    DPRINTF("---------------------------- return buffer\n");
     outbuf_tmp = (u16 *)&cmdack.return_result_word[0];
     do {
         outbuf_cnt += 1;
-        printf(" %4x", *outbuf_tmp);
+        DPRINTF(" %4x", *outbuf_tmp);
         *(u16 *)buf = *outbuf_tmp;
         outbuf_tmp += 1;
         buf = (char *)buf + 2;
     } while (outbuf_cnt < 16);
-    printf("\n");
+    DPRINTF("\n");
     return 0;
 }

--- a/iop/fs/netfs/src/debug_printf.h
+++ b/iop/fs/netfs/src/debug_printf.h
@@ -1,0 +1,7 @@
+
+#define PS2NETFS_MODNAME "PS2_TcpFileDriver"
+#ifdef DEBUG
+#define DPRINTF(x...) printf(PS2NETFS_MODNAME ": " x)
+#else
+#define DPRINTF(x...)
+#endif

--- a/iop/fs/netfs/src/devscan.c
+++ b/iop/fs/netfs/src/devscan.c
@@ -27,13 +27,7 @@
 #include <iopmgr.h>
 
 #include "devscan.h"
-
-//#define DEBUG
-#ifdef DEBUG
-#define dbgprintf(args...) printf(args)
-#else
-#define dbgprintf(args...) do { } while(0)
-#endif
+#include "debug_printf.h"
 
 /** Device type structure.
  * @ingroup ps2netfs
@@ -83,7 +77,7 @@ int devscan_setup(int devtype)
   int i;
   int  count = 0;
 
-  dbgprintf("devscan: setup\n");
+  DPRINTF("%s\n", __func__);
   // clear device list
   memset(&dev_info_list,0,sizeof(dev_info_list));
 
@@ -103,7 +97,7 @@ int devscan_setup(int devtype)
           strncpy(dev_info_list[count].name,devinfo_table[i]->name,255);
           dev_info_list[count].name[255] = '\0';
           dev_info_list[count].len = strlen(dev_info_list[count].name);
-          dbgprintf("devscan: ioman '%s'\n",dev_info_list[count].name);
+          DPRINTF("ioman '%s'\n",dev_info_list[count].name);
           count++;
         }
     }
@@ -126,7 +120,7 @@ int devscan_setup(int devtype)
           strncpy(dev_info_list[count].name,devinfo_table[i]->name,255);
           dev_info_list[count].name[255] = '\0';
           dev_info_list[count].len = strlen(dev_info_list[count].name);
-          dbgprintf("devscan: iomanx '%s'\n",dev_info_list[count].name);
+          DPRINTF("iomanx '%s'\n",dev_info_list[count].name);
           count++;
         }
     }
@@ -147,11 +141,11 @@ int devscan_setup(int devtype)
 int devscan_gettype(char *name)
 {
   int count = 0;
-  dbgprintf("devscan: gettype '%s'\n",name);
+  DPRINTF("gettype '%s'\n",name);
   while (dev_info_list[count].name[0] != 0)
   {
     int ret = strncmp(dev_info_list[count].name,name,dev_info_list[count].len );
-    dbgprintf("'%s'",dev_info_list[count].name);
+    DPRINTF("'%s'",dev_info_list[count].name);
     if (!ret)
       return dev_info_list[count].devtype;
     count++;
@@ -171,7 +165,7 @@ int devscan_getdevlist(char *buffer)
   int i;
   char *bufptr = buffer;
 
-  dbgprintf("devscan: getdevlist\n");
+  DPRINTF("getdevlist\n");
   /* rescan for devices, before returning list */
   count = devscan_setup(DEVSCAN_MASK);
 
@@ -179,7 +173,7 @@ int devscan_getdevlist(char *buffer)
   for (i=0;i<count;i++)
   {
     strcpy(bufptr,dev_info_list[i].name);
-    dbgprintf("devscan: '%s'\n",bufptr);
+    DPRINTF("'%s'\n",bufptr);
     bufptr += strlen(bufptr)+1;
   }
   return count;

--- a/iop/fs/netfs/src/ps2netfs.c
+++ b/iop/fs/netfs/src/ps2netfs.c
@@ -24,8 +24,8 @@
 
 #include "ps2_fio.h"
 #include "devscan.h"
+#include "debug_printf.h"
 
-#define PS2NETFS_MODNAME "PS2_TcpFileDriver"
 #define PS2NETFS_VERSION_HIGH 1
 #define PS2NETFS_VERSION_LOW  0
 
@@ -54,21 +54,21 @@ int _start(int argc, char *argv[])
 
   if (!devscan_getmodule(IOPMGR_IOMAN_IDENT))
   {
-    printf("ioman not found\n");
+    DPRINTF("ioman not found\n");
     return MODULE_NO_RESIDENT_END;
   }
   if (!devscan_getmodule(IOPMGR_IOMANX_IDENT))
   {
-    printf("iomanx not found\n");
+    DPRINTF("iomanx not found\n");
     return MODULE_NO_RESIDENT_END;
   }
 
   if (ps2netfs_Init() == 0)
   {
-    printf("\nServer Started\n");
+    DPRINTF("\nServer Started\n");
     return MODULE_RESIDENT_END;
   }
 
-  printf("\nExiting.\n");
+  DPRINTF("\nExiting.\n");
   return MODULE_NO_RESIDENT_END;
 }

--- a/iop/iLink/IEEE1394_disk/src/fat_driver.c
+++ b/iop/iLink/IEEE1394_disk/src/fat_driver.c
@@ -124,7 +124,7 @@ static int fat_getClusterChain12(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector || sectorSpan) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
             lastFatSector = fatSector;
@@ -134,7 +134,7 @@ static int fat_getClusterChain12(fat_driver *fatd, unsigned int cluster, unsigne
                 xbuf[1] = sbuf[fatd->partBpb.sectorSize - 1];
                 ret     = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
+                    XPRINTF("Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
                     return -EIO;
                 }
                 xbuf[2] = sbuf[0];
@@ -182,7 +182,7 @@ static int fat_getClusterChain16(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat16 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
 
@@ -223,7 +223,7 @@ static int fat_getClusterChain32(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat32 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat32 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
 
@@ -280,7 +280,7 @@ static void fat_determineFatType(fat_bpb *partBpb)
     sector -= partBpb->partStart;
     sector       = partBpb->sectorCount - sector;
     clusterCount = sector / partBpb->clusterSize;
-    // XPRINTF("USBHDFSD: Data cluster count = %u \n", clusterCount);
+    // XPRINTF("Data cluster count = %u \n", clusterCount);
 
     if (clusterCount < 4085) {
         partBpb->fatType = FAT12;
@@ -301,7 +301,7 @@ static int fat_getPartitionBootSector(struct SBP2Device *dev, unsigned int secto
 
     ret = READ_SECTOR(dev, sector, sbuf); // read partition boot sector (first sector on partition)
     if (ret < 0) {
-        XPRINTF("USBHDFSD: Read partition boot sector failed sector=%u! \n", sector);
+        XPRINTF("Read partition boot sector failed sector=%u! \n", sector);
         return -EIO;
     }
 
@@ -350,7 +350,7 @@ static int fat_getPartitionBootSector(struct SBP2Device *dev, unsigned int secto
         partBpb->dataStart  = partBpb->rootDirStart;
     }
 
-    printf("USBHDFSD: Fat type %u Id %s \n", partBpb->fatType, partBpb->fatId);
+    printf("Fat type %u Id %s \n", partBpb->fatType, partBpb->fatId);
     return 1;
 }
 
@@ -478,11 +478,11 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
     unsigned char nextChain;
     int chainSize;
 
-    XPRINTF("USBHDFSD: reading cluster chain  \n");
+    XPRINTF("reading cluster chain  \n");
     fileCluster = fatDir->chain[0].cluster;
 
     if (fileCluster < 2) {
-        XPRINTF("USBHDFSD:    early exit... \n");
+        XPRINTF("   early exit... \n");
         return;
     }
 
@@ -503,7 +503,7 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
                 nextChain = 0;
             }
         } else {
-            XPRINTF("USBHDFSD: fat_setFatDirChain(): fat_getClusterChain() failed: %d\n", chainSize);
+            XPRINTF("fat_setFatDirChain(): fat_getClusterChain() failed: %d\n", chainSize);
             return;
         }
 
@@ -523,16 +523,16 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
 
 #ifdef DEBUG_EXTREME // dlanor: I patched this because this bloat hid important stuff
     // debug
-    XPRINTF("USBHDFSD: SEEK CLUSTER CHAIN CACHE fileSize=%u blockSize=%u \n", fatDir->size, blockSize);
+    XPRINTF("SEEK CLUSTER CHAIN CACHE fileSize=%u blockSize=%u \n", fatDir->size, blockSize);
     for (i = 0; i < DIR_CHAIN_SIZE; i++) {
-        XPRINTF("USBHDFSD: index=%u cluster=%u offset= %u - %u start=%u \n",
+        XPRINTF("index=%u cluster=%u offset= %u - %u start=%u \n",
                 fatDir->chain[i].index, fatDir->chain[i].cluster,
                 fatDir->chain[i].index * fatd->partBpb.clusterSize * fatd->partBpb.sectorSize,
                 (fatDir->chain[i].index + 1) * fatd->partBpb.clusterSize * fatd->partBpb.sectorSize,
                 i * blockSize);
     }
 #endif /* debug */
-    XPRINTF("USBHDFSD: read cluster chain  done!\n");
+    XPRINTF("read cluster chain  done!\n");
 }
 
 //---------------------------------------------------------------------------
@@ -542,7 +542,7 @@ static void fat_setFatDir(fat_driver *fatd, fat_dir *fatDir, unsigned int parent
     unsigned int i;
     char *srcName;
 
-    XPRINTF("USBHDFSD: setting fat dir...\n");
+    XPRINTF("setting fat dir...\n");
     srcName = dir->sname;
     if (dir->name[0] != 0) { // long filename not empty
         srcName = dir->name;
@@ -613,12 +613,12 @@ int fat_getDirentrySectorData(fat_driver *fatd, unsigned int *startCluster, unsi
     *startSector = fat_cluster2sector(&fatd->partBpb, *startCluster);
     chainSize    = fat_getClusterChain(fatd, *startCluster, fatd->cbuf, MAX_DIR_CLUSTER, 1);
     if (chainSize >= MAX_DIR_CLUSTER) {
-        XPRINTF("USBHDFSD: Chain too large\n");
+        XPRINTF("Chain too large\n");
         return -EFAULT;
     } else if (chainSize > 0) {
         *dirSector = chainSize * fatd->partBpb.clusterSize;
     } else {
-        XPRINTF("USBHDFSD: Error getting cluster chain! startCluster=%u \n", *startCluster);
+        XPRINTF("Error getting cluster chain! startCluster=%u \n", *startCluster);
         return -EFAULT;
     }
 
@@ -637,7 +637,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
 #endif
 
     cont = 1;
-    XPRINTF("USBHDFSD: getting cluster for dir entry: %s \n", dirName);
+    XPRINTF("getting cluster for dir entry: %s \n", dirName);
     // clear name strings
     dir.sname[0] = 0;
     dir.name[0]  = 0;
@@ -646,7 +646,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
     if (ret < 0)
         return ret;
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -660,10 +660,10 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
 
         ret = READ_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("read directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos = 0;
 
         // go through start of the sector till the end of sector
@@ -674,12 +674,12 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
                 if (!(dir.attr & FAT_ATTR_VOLUME_LABEL)) {                                     // not volume label
                     if ((strEqual(dir.sname, dirName) == 0) ||
                         (strEqual(dir.name, dirName) == 0)) {
-                        XPRINTF("USBHDFSD: found! %s\n", dir.name);
+                        XPRINTF("found! %s\n", dir.name);
                         if (fatDir != NULL) { // fill the directory properties
                             fat_setFatDir(fatd, fatDir, *startCluster, &dir_entry->sfn, &dir, 1);
                         }
                         *startCluster = dir.cluster;
-                        XPRINTF("USBHDFSD: direntry %s found at cluster: %u \n", dirName, dir.cluster);
+                        XPRINTF("direntry %s found at cluster: %u \n", dirName, dir.cluster);
                         return dir.attr; // returns file or directory attr
                     }
                 } // ends "if(!(dir.attr & FAT_ATTR_VOLUME_LABEL))"
@@ -690,7 +690,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
             dirPos += sizeof(fat_direntry);
         } // ends "while"
     }     // ends "for"
-    XPRINTF("USBHDFSD: direntry %s not found! \n", dirName);
+    XPRINTF("direntry %s not found! \n", dirName);
     return -ENOENT;
 }
 
@@ -704,7 +704,7 @@ int fat_getFileStartCluster(fat_driver *fatd, const char *fname, unsigned int *s
     unsigned int i, offset;
     int ret;
 
-    XPRINTF("USBHDFSD: Entering fat_getFileStartCluster\n");
+    XPRINTF("Entering fat_getFileStartCluster\n");
 
     offset = 0;
     i      = 0;
@@ -733,21 +733,21 @@ int fat_getFileStartCluster(fat_driver *fatd, const char *fname, unsigned int *s
     } // ends "for"
     // and the final file
     tmpName[offset] = 0; // terminate string
-    XPRINTF("USBHDFSD: Ready to get cluster for file \"%s\"\n", tmpName);
+    XPRINTF("Ready to get cluster for file \"%s\"\n", tmpName);
     if (fatDir != NULL) {
         // if the last char of the name was slash - the name was already found -exit
         if (offset == 0) {
-            XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with a folder\n");
+            XPRINTF("Exiting from fat_getFileStartCluster with a folder\n");
             return 2;
         }
         ret = fat_getDirentryStartCluster(fatd, tmpName, startCluster, fatDir);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with error %i\n", ret);
+            XPRINTF("Exiting from fat_getFileStartCluster with error %i\n", ret);
             return ret;
         }
-        XPRINTF("USBHDFSD: file's startCluster found. Name=%s, cluster=%u \n", fname, *startCluster);
+        XPRINTF("file's startCluster found. Name=%s, cluster=%u \n", fname, *startCluster);
     }
-    XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with no error.\n");
+    XPRINTF("Exiting from fat_getFileStartCluster with no error.\n");
     return 1;
 }
 
@@ -786,7 +786,7 @@ int fat_readFile(fat_driver *fatd, fat_dir *fatDir, unsigned int filePos, unsign
     dataSkip  = filePos % fatd->partBpb.sectorSize;
     bufferPos = 0;
 
-    XPRINTF("USBHDFSD: fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
+    XPRINTF("fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
             fileCluster, clusterPos, clusterSkip, sectorSkip, dataSkip);
 
     if (fileCluster < 2) {
@@ -831,7 +831,7 @@ int fat_readFile(fat_driver *fatd, fat_dir *fatDir, unsigned int filePos, unsign
 
                 ret = READ_SECTOR(fatd->dev, startSector + j, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read sector failed ! sector=%u\n", startSector + j);
+                    XPRINTF("Read sector failed ! sector=%u\n", startSector + j);
                     return bufferPos;
                 }
 
@@ -842,7 +842,7 @@ int fat_readFile(fat_driver *fatd, fat_dir *fatDir, unsigned int filePos, unsign
                 if (bufSize > mass_device->sectorSize) {
                     bufSize = mass_device->sectorSize;
                 }
-                XPRINTF("USBHDFSD: memcopy dst=%u, src=%u, size=%u  bufSize=%u \n", bufferPos, dataSkip, bufSize - dataSkip, bufSize);
+                XPRINTF("memcopy dst=%u, src=%u, size=%u  bufSize=%u \n", bufferPos, dataSkip, bufSize - dataSkip, bufSize);
                 memcpy(buffer + bufferPos, sbuf + dataSkip, bufSize - dataSkip);
                 size -= (bufSize - dataSkip);
                 bufferPos += (bufSize - dataSkip);
@@ -882,7 +882,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
     if (ret < 0)
         return ret;
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", dirCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", dirCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -900,7 +900,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
         }
         ret = READ_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read directory  sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("Read directory  sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
 
@@ -912,7 +912,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
             if (cont == 1) {                                                                   // when short file name entry detected
                 fat_setFatDir(fatd, fatDir, dirCluster, &dir_entry->sfn, &dir, 0);
 #if 0
-                XPRINTF("USBHDFSD: fat_getNextDirentry %c%c%c%c%c%c %x %s %s\n",
+                XPRINTF("fat_getNextDirentry %c%c%c%c%c%c %x %s %s\n",
                         (dir.attr & FAT_ATTR_VOLUME_LABEL) ? 'v' : '-',
                         (dir.attr & FAT_ATTR_DIRECTORY) ? 'd' : '-',
                         (dir.attr & FAT_ATTR_READONLY) ? 'r' : '-',
@@ -963,7 +963,7 @@ int fat_mount(struct SBP2Device *dev, unsigned int start, unsigned int count)
 
     for (i = 0; i < NUM_DRIVES && fatd == NULL; ++i) {
         if (g_fatd[i] == NULL) {
-            XPRINTF("USBHDFSD: usb fat: allocate fat_driver %d!\n", sizeof(fat_driver));
+            XPRINTF("usb fat: allocate fat_driver %d!\n", sizeof(fat_driver));
             g_fatd[i] = malloc(sizeof(fat_driver));
             if (g_fatd[i] != NULL) {
                 g_fatd[i]->dev = NULL;
@@ -975,12 +975,12 @@ int fat_mount(struct SBP2Device *dev, unsigned int start, unsigned int count)
     }
 
     if (fatd == NULL) {
-        printf("USBHDFSD: usb fat: unable to allocate drive!\n");
+        printf("usb fat: unable to allocate drive!\n");
         return -1;
     }
 
     if (fatd->dev != NULL) {
-        printf("USBHDFSD: usb fat: mount ERROR: alread mounted\n");
+        printf("usb fat: mount ERROR: alread mounted\n");
         fat_forceUnmount(fatd->dev);
     }
 
@@ -1000,7 +1000,7 @@ int fat_mount(struct SBP2Device *dev, unsigned int start, unsigned int count)
 void fat_forceUnmount(struct SBP2Device *dev)
 {
     unsigned int i;
-    XPRINTF("USBHDFSD: usb fat: forceUnmount devId %i \n", dev->nodeID);
+    XPRINTF("usb fat: forceUnmount devId %i \n", dev->nodeID);
 
     for (i = 0; i < NUM_DRIVES; ++i) {
         if (g_fatd[i] != NULL && g_fatd[i]->dev == dev)

--- a/iop/iLink/IEEE1394_disk/src/fat_write.c
+++ b/iop/iLink/IEEE1394_disk/src/fat_write.c
@@ -103,7 +103,7 @@ static int fat_readEmptyClusters12(fat_driver *fatd)
         if (lastFatSector != fatSector || sectorSpan) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
             lastFatSector = fatSector;
@@ -113,7 +113,7 @@ static int fat_readEmptyClusters12(fat_driver *fatd)
                 xbuf[1] = sbuf[fatd->partBpb.sectorSize - 1];
                 ret     = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
+                    XPRINTF("Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
                     return -EIO;
                 }
                 xbuf[2] = sbuf[0];
@@ -173,7 +173,7 @@ static int fat_readEmptyClusters32(fat_driver *fatd)
 
         ret = READ_SECTOR(fatd->dev, fatStartSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat32 sector failed! sector=%u! \n", fatStartSector + i);
+            XPRINTF("Read fat32 sector failed! sector=%u! \n", fatStartSector + i);
             return -EIO;
         }
         for (j = recordSkip; j < indexCount && fatd->clStackIndex < MAX_CLUSTER_STACK; j++) {
@@ -212,7 +212,7 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
     int recordSkip;
 
     oldClStackIndex = fatd->clStackIndex;
-    // XPRINTF("USBHDFSD: #### Read empty clusters16: clStackIndex=%d MAX=%d\n", clStackIndex, MAX_CLUSTER_STACK);
+    // XPRINTF("#### Read empty clusters16: clStackIndex=%d MAX=%d\n", clStackIndex, MAX_CLUSTER_STACK);
 
     // indexCount = numer of cluster indices per sector
     indexCount = fatd->partBpb.sectorSize / 2; // FAT16->2, FAT32->4
@@ -230,7 +230,7 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
 
         ret = READ_SECTOR(fatd->dev, fatStartSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatStartSector + i);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatStartSector + i);
             return -EIO;
         }
         for (j = recordSkip; j < indexCount && fatd->clStackIndex < MAX_CLUSTER_STACK; j++) {
@@ -238,13 +238,13 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
             if (cluster == 0) { // the cluster is free
                 fatd->clStackLast                 = (i * indexCount) + j;
                 fatd->clStack[fatd->clStackIndex] = fatd->clStackLast;
-                XPRINTF("USBHDFSD: %u ", fatd->clStack[fatd->clStackIndex]);
+                XPRINTF("%u ", fatd->clStack[fatd->clStackIndex]);
                 fatd->clStackIndex++;
             }
         }
         recordSkip = 0;
     }
-    XPRINTF("USBHDFSD: \n");
+    XPRINTF("\n");
     // the stack operates as LIFO but we put in the clusters as FIFO
     // we should reverse the cluster order - not necessary
     // but it will retain the natural (increasing) order of
@@ -348,14 +348,14 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         if (!sectorSpan) { // not sector span - the record is copmact and fits in single sector
             fat_setClusterRecord12(sbuf + (recordOffset % fatd->partBpb.sectorSize), value, recordType);
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
         } else { // sector span - the record is broken in 2 pieces - each one on different sector
@@ -364,14 +364,14 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
             // save current sector
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
             // read next sector from the fat
             fatSector++;
             ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
             // modify first byte of the sector buffer
@@ -379,7 +379,7 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
             // save current sector
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
         }
@@ -413,7 +413,7 @@ static int fat_saveClusterRecord16(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         i = currentCluster % indexCount;
@@ -422,7 +422,7 @@ static int fat_saveClusterRecord16(fat_driver *fatd, unsigned int currentCluster
         sbuf[i]   = ((value & 0xFF00) >> 8);
         ret       = WRITE_SECTOR(fatd->dev, fatSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Write fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Write fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
     }
@@ -455,7 +455,7 @@ static int fat_saveClusterRecord32(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat32 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat32 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         i = currentCluster % indexCount;
@@ -467,7 +467,7 @@ static int fat_saveClusterRecord32(fat_driver *fatd, unsigned int currentCluster
 
         ret = WRITE_SECTOR(fatd->dev, fatSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Write fat32 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Write fat32 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
     }
@@ -516,7 +516,7 @@ static int fat_appendClusterChain(fat_driver *fatd, unsigned int currentCluster,
             break;
 
         case FAT16:
-            XPRINTF("USBHDFSD: I: appending cluster chain : current=%u end=%u \n", currentCluster, endCluster);
+            XPRINTF("I: appending cluster chain : current=%u end=%u \n", currentCluster, endCluster);
             ret = fat_saveClusterRecord16(fatd, currentCluster, endCluster);
             if (ret < 0)
                 return ret;
@@ -580,7 +580,7 @@ static int fat_deleteClusterChain(fat_driver *fatd, unsigned int cluster)
     if (cluster < 2) {
         return -EFAULT;
     }
-    XPRINTF("USBHDFSD: I: delete cluster chain starting at cluster=%u\n", cluster);
+    XPRINTF("I: delete cluster chain starting at cluster=%u\n", cluster);
 
     cont = 1;
 
@@ -784,7 +784,7 @@ static void setSfnDate(fat_direntry_sfn *dsfn, int mode)
     tmpClk[3] = (month & 0x08) >> 3;          // month
     tmpClk[3] += ((year - 1980) & 0x7F) << 1; // year
 
-    XPRINTF("USBHDFSD: year=%d, month=%d, day=%d   h=%d m=%d s=%d \n", year, month, day, hour, minute, sec);
+    XPRINTF("year=%d, month=%d, day=%d   h=%d m=%d s=%d \n", year, month, day, hour, minute, sec);
     // set date & time of creation
     if (mode & DATE_CREATE) {
         dsfn->timeCreate[0] = tmpClk[0];
@@ -873,7 +873,7 @@ static int createShortNameMask(char *lname, char *sname)
     // clean short name by putting space
     for (i = 0; i < 11; i++)
         sname[i] = ' ';
-    XPRINTF("USBHDFSD: Clear short name ='%s'\n", sname);
+    XPRINTF("Clear short name ='%s'\n", sname);
 
     // detect number of dots and space characters in the long name
     j = 0;
@@ -886,7 +886,7 @@ static int createShortNameMask(char *lname, char *sname)
     // long name contains no dot or one dot and no space char
     if (j <= 1)
         fit++;
-    // XPRINTF("USBHDFSD: fit1=%d j=%d\n", fit, j);
+    // XPRINTF("fit1=%d j=%d\n", fit, j);
 
     // store name
     for (i = 0; lname[i] != 0 && lname[i] != '.' && i < 8; i++) {
@@ -899,7 +899,7 @@ static int createShortNameMask(char *lname, char *sname)
     if (lname[i] == '.' || lname[i] == 0) {
         fit++;
     }
-    // XPRINTF("USBHDFSD: fit2=%d\n", fit);
+    // XPRINTF("fit2=%d\n", fit);
 
     // find the last dot "." - filename extension
     size = strlen(lname);
@@ -919,12 +919,12 @@ static int createShortNameMask(char *lname, char *sname)
         // no dot detected in the long filename
         fit++;
     }
-    // XPRINTF("USBHDFSD: fit3=%d\n", fit);
-    // XPRINTF("USBHDFSD: Long name=%s  Short name=%s \n", lname, sname);
+    // XPRINTF("fit3=%d\n", fit);
+    // XPRINTF("Long name=%s  Short name=%s \n", lname, sname);
 
     // all 3 checks passed  - the long name fits in the short name without restrictions
     if (fit == 3) {
-        XPRINTF("USBHDFSD: Short name is loseles!\n");
+        XPRINTF("Short name is loseles!\n");
         return 0;
     }
 
@@ -1002,7 +1002,7 @@ static int getShortNameSequence(const char *name, const char *ext, const char *s
         buf[j - i - 1] = name[j];
     buf[j - i - 1] = 0; // terminate
 
-    XPRINTF("USBHDFSD: found short name sequence number='%s' \n", buf);
+    XPRINTF("found short name sequence number='%s' \n", buf);
     return strtol(buf, NULL, 10);
 }
 
@@ -1086,16 +1086,16 @@ static int getDirentryStoreOffset(fat_driver *fatd, int entryCount, int direntry
             } else {
                 slotStart = i;
                 slotSize  = 1;
-                XPRINTF("USBHDFSD: *Start slot at index=%d ", slotStart);
+                XPRINTF("*Start slot at index=%d ", slotStart);
             }
         } else { // occupied entry
             if (tightIndex < 0 && slotSize == direntrySize) {
                 tightIndex = slotStart;
-                XPRINTF("USBHDFSD: !Set tight index= %d\n", tightIndex);
+                XPRINTF("!Set tight index= %d\n", tightIndex);
             }
             if (looseIndex < 0 && slotSize > direntrySize) {
                 looseIndex = slotStart + slotSize - direntrySize;
-                XPRINTF("USBHDFSD: !Set loose index= %d\n", looseIndex);
+                XPRINTF("!Set loose index= %d\n", looseIndex);
             }
             if (tightIndex >= 0 && looseIndex >= 0) {
                 cont = 0;
@@ -1104,7 +1104,7 @@ static int getDirentryStoreOffset(fat_driver *fatd, int entryCount, int direntry
             slotSize  = 0;
         }
     }
-    XPRINTF("USBHDFSD: \n");
+    XPRINTF("\n");
 
     // tight index - smaller fragmentation of space, the larger blocks
     //               are left for larger filenames.
@@ -1177,7 +1177,7 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, char *sname
 
     fat_getDirentrySectorData(fatd, startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -1191,10 +1191,10 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, char *sname
         theSector = startSector + i;
         ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("read directory sector failed ! sector=%u\n", theSector);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos = 0;
 
         // go through start of the sector till the end of sector
@@ -1215,7 +1215,7 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, char *sname
                                     return -ENOTDIR;
                                 return -EISDIR;
                             } // ends "if" clause for mismatched file/folder state
-                            XPRINTF("USBHDFSD: I: entry found! %s, %s = %s\n", dir.name, dir.sname, lname);
+                            XPRINTF("I: entry found! %s, %s = %s\n", dir.name, dir.sname, lname);
                             *retSector               = theSector;
                             *retOffset               = dirPos;
                             *startCluster            = dir.cluster;
@@ -1280,7 +1280,7 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
     unsigned int newCluster;
 
     i = entryIndex + direntrySize;
-    XPRINTF("USBHDFSD: cur=%d ecount=%d \n", i, entryCount);
+    XPRINTF("cur=%d ecount=%d \n", i, entryCount);
     // we don't need to enlarge directory cluster space
     if (i <= entryCount)
         return 0; // direntry fits into current space
@@ -1293,7 +1293,7 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
 
     chainSize = fat_getDirentrySectorData(fatd, &startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: maxSector=%u  dirSector=%u\n", maxSector, dirSector);
+    XPRINTF("maxSector=%u  dirSector=%u\n", maxSector, dirSector);
 
     if ((unsigned int)maxSector <= dirSector)
         return 0;
@@ -1307,11 +1307,11 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
 
     // get last cluster of the cluster chain
     currentCluster = fatd->cbuf[chainSize - 1];
-    XPRINTF("USBHDFSD: current (last) cluster=%u \n", currentCluster);
+    XPRINTF("current (last) cluster=%u \n", currentCluster);
 
     // get 1 cluster from cluster stack and append the chain
     newCluster = fat_getFreeCluster(fatd, currentCluster);
-    XPRINTF("USBHDFSD: new cluster=%u \n", newCluster);
+    XPRINTF("new cluster=%u \n", newCluster);
     fat_invalidateLastChainResult(fatd); // prevent to misuse current (now updated) fatd->cbuf
     // if new cluster cannot be allocated
     if (newCluster == 0) {
@@ -1356,7 +1356,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
     // we create directory space inside one cluster. No need to worry about
     // large dir space spread on multiple clusters
     startSector = fat_cluster2sector(&fatd->partBpb, dirCluster);
-    XPRINTF("USBHDFSD: I: create dir space: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
+    XPRINTF("I: create dir space: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
 
     // go through all sectors of the cluster
     for (i = 0; i < fatd->partBpb.clusterSize; i++) {
@@ -1366,7 +1366,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
 
         ret = ALLOC_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: alloc directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("alloc directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
         memset(sbuf, 0, fatd->partBpb.sectorSize); // clean the sector
@@ -1382,7 +1382,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
         }
         ret = WRITE_SECTOR(fatd->dev, startSector + i);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("write directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
     }
@@ -1439,7 +1439,7 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
 
     fat_getDirentrySectorData(fatd, &startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -1453,10 +1453,10 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
         theSector = startSector + i;
         ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("read directory sector failed ! sector=%u\n", theSector);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos    = 0;
         writeFlag = 0;
         // go through start of the sector till the end of sector
@@ -1486,7 +1486,7 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
         if (writeFlag) {
             ret = WRITE_SECTOR(fatd->dev, theSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+                XPRINTF("write directory sector failed ! sector=%u\n", theSector);
                 return -EIO;
             }
         }
@@ -1553,7 +1553,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     // create short name from long name
     ret = createShortNameMask(lname, sname);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: short name invalid!\n");
+        XPRINTF("E: short name invalid!\n");
         return ret;
     }
     compressShortName = ret;
@@ -1564,7 +1564,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     ret                  = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                                 &parentDirCluster_tmp, retSector, retOffset);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: direntry data invalid!\n");
+        XPRINTF("E: direntry data invalid!\n");
         return ret;
     }
     // ret 0 means that exact filename/directory already exist
@@ -1579,29 +1579,29 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
 
 
     if (ret > DIR_MASK_SIZE) {
-        XPRINTF("USBHDFSD: W: Direntry count is larger than number of records!\n");
+        XPRINTF("W: Direntry count is larger than number of records!\n");
         ret = DIR_MASK_SIZE;
     }
     entryCount = ret;
-    XPRINTF("USBHDFSD: I: direntry count=%d\n", entryCount);
+    XPRINTF("I: direntry count=%d\n", entryCount);
 
     if (compressShortName) {
         setShortNameSequence(fatd, sname);
     }
-    XPRINTF("USBHDFSD: I: new short name='%s' \n", sname);
+    XPRINTF("I: new short name='%s' \n", sname);
 
     // direntry size for long name + 1 additional direntry for short name
     direntrySize = getDirentrySize(lname) + 1;
-    XPRINTF("USBHDFSD: Direntry size=%d\n", direntrySize);
+    XPRINTF("Direntry size=%d\n", direntrySize);
 
     // find the offset (index) of the direntry space where to put this direntry
     entryIndex = getDirentryStoreOffset(fatd, entryCount, direntrySize);
-    XPRINTF("USBHDFSD: I: direntry store offset=%d\n", entryIndex);
+    XPRINTF("I: direntry store offset=%d\n", entryIndex);
 
     // if the direntry offset excede current space of directory clusters
     // we have to add one cluster to directory space
     ret = enlargeDirentryClusterSpace(fatd, *startCluster, entryCount, entryIndex, direntrySize);
-    XPRINTF("USBHDFSD: I: enlarge direntry cluster space ret=%d\n", ret);
+    XPRINTF("I: enlarge direntry cluster space ret=%d\n", ret);
     if (ret < 0) {
         return ret;
     }
@@ -1612,14 +1612,14 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
         if (newCluster == 0) {
             return -ENOSPC;
         }
-        XPRINTF("USBHDFSD: I: new file/dir cluster=%u\n", newCluster);
+        XPRINTF("I: new file/dir cluster=%u\n", newCluster);
     } else {
         newCluster = 0;
     }
 
     // now store direntries into the directory space
     ret = saveDirentry(fatd, *startCluster, lname, sname, directory, newCluster, direntrySize, entryIndex, retSector, retOffset, orig_dsfn);
-    XPRINTF("USBHDFSD: I: save direntry ret=%d\n", ret);
+    XPRINTF("I: save direntry ret=%d\n", ret);
     if (ret < 0) {
         return ret;
     }
@@ -1627,7 +1627,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     // create empty directory structure
     if ((orig_dsfn == NULL) && directory) {
         ret = createDirectorySpace(fatd, newCluster, *startCluster);
-        XPRINTF("USBHDFSD: I: create directory space ret=%d\n", ret);
+        XPRINTF("I: create directory space ret=%d\n", ret);
         if (ret < 0) {
             return ret;
         }
@@ -1656,7 +1656,7 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     unsigned int retSector;
     int retOffset;
 
-    XPRINTF("USBHDFSD: I: checkDirspaceEmpty  directory cluster=%u \n", startCluster);
+    XPRINTF("I: checkDirspaceEmpty  directory cluster=%u \n", startCluster);
     if (startCluster < 2) { // do not check root directory!
         return -EFAULT;
     }
@@ -1667,7 +1667,7 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     ret = fat_fillDirentryInfo(fatd, sname, sname, 1,
                                &startCluster, &retSector, &retOffset);
     if (ret > DIR_MASK_SIZE) {
-        XPRINTF("USBHDFSD: W: Direntry count is larger than number of records! directory space cluster =%u maxRecords=%u\n", startCluster, DIR_MASK_SIZE);
+        XPRINTF("W: Direntry count is larger than number of records! directory space cluster =%u maxRecords=%u\n", startCluster, DIR_MASK_SIZE);
         ret = DIR_MASK_SIZE;
     }
     entryCount = ret;
@@ -1677,11 +1677,11 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     for (i = 1; i < (entryCount / 8); i++) {
         if (fatd->dir_used_mask[i] != 0) {
         non_empty:
-            XPRINTF("USBHDFSD: I: directory not empty!\n");
+            XPRINTF("I: directory not empty!\n");
             return 0;
         } // ends "if"
     }     // ends "for"
-    XPRINTF("USBHDFSD: I: directory is empty.\n");
+    XPRINTF("I: directory is empty.\n");
     return 1;
 }
 
@@ -1700,7 +1700,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
             if (theSector > 0) {
                 ret = WRITE_SECTOR(fatd->dev, theSector);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+                    XPRINTF("write directory sector failed ! sector=%u\n", theSector);
                     ret = -EIO;
                     break;
                 }
@@ -1708,7 +1708,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
             theSector = fatd->deSec[i];
             ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+                XPRINTF("read directory sector failed ! sector=%u\n", theSector);
                 ret = -EIO;
                 break;
             }
@@ -1718,7 +1718,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
     if (theSector > 0) {
         ret = WRITE_SECTOR(fatd->dev, theSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("write directory sector failed ! sector=%u\n", theSector);
             ret = -EIO;
         }
     }
@@ -1753,10 +1753,10 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
     ret = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                startCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found!\n");
+        XPRINTF("E: direntry not found!\n");
         return -ENOENT;
     }
-    XPRINTF("USBHDFSD: clear dir space: dir found at  cluster=%u \n ", *startCluster);
+    XPRINTF("clear dir space: dir found at  cluster=%u \n ", *startCluster);
 
     // Check wether any file or directory exist in te target directory space.
     // We should not delete the directory if files/directories exist
@@ -1775,7 +1775,7 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
         ret = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                    startCluster, &sfnSector, &sfnOffset);
         if (ret != 0) {
-            XPRINTF("USBHDFSD: E: direntry not found!\n");
+            XPRINTF("E: direntry not found!\n");
             return -ENOENT;
         }
     }
@@ -1783,14 +1783,14 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
     // now mark direntries as deleted
     ret = fat_wipeDirEntries(fatd);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: wipe direntries failed!\n");
+        XPRINTF("E: wipe direntries failed!\n");
         return ret;
     }
 
     // now delete whole cluster chain starting at the file's first cluster
     ret = fat_deleteClusterChain(fatd, *startCluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: delete cluster chain failed!\n");
+        XPRINTF("E: delete cluster chain failed!\n");
         return ret;
     }
     return 1;
@@ -1819,20 +1819,20 @@ int fat_truncateFile(fat_driver *fatd, unsigned int cluster, unsigned int sfnSec
     // now delete whole cluster chain starting at the file's first cluster
     ret = fat_deleteClusterChain(fatd, cluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: delete cluster chain failed!\n");
+        XPRINTF("E: delete cluster chain failed!\n");
         return ret;
     }
 
     // terminate cluster
     ret = fat_createClusterChain(fatd, cluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: truncate cluster chain failed!\n");
+        XPRINTF("E: truncate cluster chain failed!\n");
         return ret;
     }
 
     ret = READ_SECTOR(fatd->dev, sfnSector, sbuf);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: read direntry sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("read direntry sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     dsfn          = (fat_direntry_sfn *)(sbuf + sfnOffset);
@@ -1843,7 +1843,7 @@ int fat_truncateFile(fat_driver *fatd, unsigned int cluster, unsigned int sfnSec
 
     ret = WRITE_SECTOR(fatd->dev, sfnSector);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("write directory sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     return 1;
@@ -1871,7 +1871,7 @@ int fat_updateSfn(fat_driver *fatd, int size, unsigned int sfnSector, int sfnOff
 
     ret = READ_SECTOR(fatd->dev, sfnSector, sbuf);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: read direntry sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("read direntry sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     dsfn          = (fat_direntry_sfn *)(sbuf + sfnOffset);
@@ -1884,10 +1884,10 @@ int fat_updateSfn(fat_driver *fatd, int size, unsigned int sfnSector, int sfnOff
 
     ret = WRITE_SECTOR(fatd->dev, sfnSector);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("write directory sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
-    XPRINTF("USBHDFSD: I: sfn updated, file size=%d \n", size);
+    XPRINTF("I: sfn updated, file size=%d \n", size);
     return 1;
 }
 
@@ -1919,25 +1919,25 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: file name not exist or not valid!");
+        XPRINTF("E: file name not exist or not valid!");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_createFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_createFile\n");
     // get start cluster of the last sub-directory of the path
     startCluster = 0;
     ret          = fat_getFileStartCluster(fatd, pathToDirent, &startCluster, &fatdir);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return ret;
     }
 
     if (!(fatdir.attr & FAT_ATTR_DIRECTORY)) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
+    XPRINTF("directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
 
     if (fatdir.attr & FAT_ATTR_READONLY)
         return -EACCES;
@@ -1947,10 +1947,10 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
     directoryCluster = startCluster;
     ret              = fat_modifyDirSpace(fatd, lname, directory, escapeNotExist, &startCluster, sfnSector, sfnOffset, NULL);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: modifyDirSpace failed!\n");
+        XPRINTF("E: modifyDirSpace failed!\n");
         return ret;
     }
-    XPRINTF("USBHDFSD: I: SFN info: sector=%u (%u)  offset=%u (%u) startCluster=%u\n", *sfnSector, *sfnSector * fatd->partBpb.sectorSize, *sfnOffset, *sfnOffset + (*sfnSector * fatd->partBpb.sectorSize), startCluster);
+    XPRINTF("I: SFN info: sector=%u (%u)  offset=%u (%u) startCluster=%u\n", *sfnSector, *sfnSector * fatd->partBpb.sectorSize, *sfnOffset, *sfnOffset + (*sfnSector * fatd->partBpb.sectorSize), startCluster);
     *cluster = startCluster;
     // dlanor: I've repatched the stuff below to improve functionality
     // The simple test below was bugged for the case of creating a folder in root
@@ -1965,7 +1965,7 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
         || ((directoryCluster || !directory)      // OR working in non_root, or making a file
             && (startCluster != directoryCluster) // AND we get an unexpected startCluster
             )) {
-        XPRINTF("USBHDFSD: I: file already exists at cluster=%u\n", startCluster);
+        XPRINTF("I: file already exists at cluster=%u\n", startCluster);
         return 2;
     }
     return 0;
@@ -1987,28 +1987,28 @@ int fat_deleteFile(fat_driver *fatd, const char *fname, char directory)
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: file name not exist or not valid!");
+        XPRINTF("E: file name not exist or not valid!");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_deleteFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_deleteFile\n");
     // get start cluster of the last sub-directory of the path
     startCluster = 0;
     ret          = fat_getFileStartCluster(fatd, pathToDirent, &startCluster, &fatdir);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return ret;
     }
 
     if (!(fatdir.attr & FAT_ATTR_DIRECTORY)) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
+    XPRINTF("directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
 
     if (fatdir.attr & FAT_ATTR_READONLY) {
-        XPRINTF("USBHDFSD: E: directory read only! \n");
+        XPRINTF("E: directory read only! \n");
         return -EACCES;
     }
 
@@ -2016,11 +2016,11 @@ int fat_deleteFile(fat_driver *fatd, const char *fname, char directory)
     directoryCluster = startCluster;
     ret              = fat_clearDirSpace(fatd, lname, directory, &startCluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: cleanDirSpace failed!\n");
+        XPRINTF("E: cleanDirSpace failed!\n");
         return ret;
     }
     if (startCluster != directoryCluster) {
-        XPRINTF("USBHDFSD: I: file/dir removed from cluster=%u\n", startCluster);
+        XPRINTF("I: file/dir removed from cluster=%u\n", startCluster);
     }
     return 0;
 }
@@ -2046,18 +2046,18 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: destination file name not exist or not valid!");
+        XPRINTF("E: destination file name not exist or not valid!");
         return -ENOENT;
     }
 
     // Check if the source file exists, and that the new filename is not in use.
     sDirCluster = fatdir->parentDirCluster;
     dDirCluster = 0;
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_renameFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_renameFile\n");
 
     ret = fat_getFileStartCluster(fatd, pathToDirent, &dDirCluster, NULL);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: destination directory not found! \n");
+        XPRINTF("E: destination directory not found! \n");
         return ret;
     }
     dParentDirCluster = dDirCluster; // Backup dDirCluster, as every call to fat_filleDirentryInfo will update it to point to the scanned file's first cluster.
@@ -2065,22 +2065,22 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     sname[0] = 0;
     ret      = fat_fillDirentryInfo(fatd, lname, sname, -1, &dDirCluster, &new_sfnSector, &new_sfnOffset);
     if (ret == 0) {
-        XPRINTF("USBHDFSD: E: file already exists!\n");
+        XPRINTF("E: file already exists!\n");
         return -EEXIST;
     }
 
     // Get the SFN sector number and offset, so that the SFN record can be read.
     ret = fat_fillDirentryInfo(fatd, fatdir->name, sname, -1, &sDirCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found! %d\n", ret);
+        XPRINTF("E: direntry not found! %d\n", ret);
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: fat_renameFile: dir found at  cluster=%u \n ", sDirCluster);
+    XPRINTF("fat_renameFile: dir found at  cluster=%u \n ", sDirCluster);
 
     // Preserve the original SFN entry.
     if ((ret = READ_SECTOR(fatd->dev, sfnSector, sbuf)) < 0) {
-        XPRINTF("USBHDFSD: E: I/O error! %d\n", ret);
+        XPRINTF("E: I/O error! %d\n", ret);
         return ret;
     }
     memcpy(&OriginalSFN, (fat_direntry_sfn *)(sbuf + sfnOffset), sizeof(fat_direntry_sfn));
@@ -2088,7 +2088,7 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
 
     // Insert a new record.
     if ((ret = fat_modifyDirSpace(fatd, lname, directory, 0, &dDirCluster, &sfnSector, &sfnOffset, &OriginalSFN)) < 0) {
-        XPRINTF("USBHDFSD: E: fat_modifyDirSpace failed! %d\n", ret);
+        XPRINTF("E: fat_modifyDirSpace failed! %d\n", ret);
         return ret;
     }
 
@@ -2097,14 +2097,14 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     sDirCluster = fatdir->parentDirCluster;
     ret         = fat_fillDirentryInfo(fatd, fatdir->name, sname, -1, &sDirCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found! %d\n", ret);
+        XPRINTF("E: direntry not found! %d\n", ret);
         return -ENOENT;
     }
 
     // now mark the original direntries as deleted
     ret = fat_wipeDirEntries(fatd);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: wipe direntries failed!\n");
+        XPRINTF("E: wipe direntries failed!\n");
         return ret;
     }
 
@@ -2160,7 +2160,7 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
             j++;
         }
         lastCluster = fatDir->lastCluster;
-        XPRINTF("USBHDFSD: I: writeFile: last cluster= %u \n", lastCluster);
+        XPRINTF("I: writeFile: last cluster= %u \n", lastCluster);
 
         if (lastCluster == 0)
             return -ENOSPC; // no more free clusters or data invalid
@@ -2173,9 +2173,9 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
         *updateClusterIndices = j;
         fat_invalidateLastChainResult(fatd); // prevent to misuse current (now deleted) fatd->cbuf
 
-        XPRINTF("USBHDFSD: I: writeFile: new clusters allocated = %u new lastCluster=%u \n", j, lastCluster);
+        XPRINTF("I: writeFile: new clusters allocated = %u new lastCluster=%u \n", j, lastCluster);
     }
-    XPRINTF("USBHDFSD: I: write file: filePos=%d  dataSize=%d \n", filePos, size);
+    XPRINTF("I: write file: filePos=%d  dataSize=%d \n", filePos, size);
 
 
     fat_getClusterAtFilePos(fatd, fatDir, filePos, &fileCluster, &clusterPos);
@@ -2186,7 +2186,7 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
     bufferPos = 0;
 
 
-    XPRINTF("USBHDFSD: fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
+    XPRINTF("fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
             fileCluster, clusterPos, clusterSkip, sectorSkip, dataSkip);
 
     if (fileCluster < 2) {
@@ -2241,15 +2241,15 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
                 else
                     ret = ALLOC_SECTOR(fatd->dev, startSector + j, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read sector failed ! sector=%u\n", startSector + j);
+                    XPRINTF("Read sector failed ! sector=%u\n", startSector + j);
                     return bufferPos; // return number of bytes already written
                 }
 
-                XPRINTF("USBHDFSD: memcopy dst=%u, src=%u, size=%u  bufSize=%u \n", dataSkip, bufferPos, bufSize - dataSkip, bufSize);
+                XPRINTF("memcopy dst=%u, src=%u, size=%u  bufSize=%u \n", dataSkip, bufferPos, bufSize - dataSkip, bufSize);
                 memcpy(sbuf + dataSkip, buffer + bufferPos, bufSize - dataSkip);
                 ret = WRITE_SECTOR(fatd->dev, startSector + j);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Write sector failed ! sector=%u\n", startSector + j);
+                    XPRINTF("Write sector failed ! sector=%u\n", startSector + j);
                     return bufferPos; // return number of bytes already written
                 }
 

--- a/iop/iLink/IEEE1394_disk/src/fs_driver.c
+++ b/iop/iLink/IEEE1394_disk/src/fs_driver.c
@@ -235,7 +235,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_open called: %s flags=%X mode=%X \n", name, flags, mode);
+    XPRINTF("fs_open called: %s flags=%X mode=%X \n", name, flags, mode);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -252,7 +252,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
     // find the file
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_open\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_open\n");
     ret = fat_getFileStartCluster(fatd, name, &cluster, &rec->dirent.fatdir);
     if (ret < 0 && ret != -ENOENT) {
         _fs_unlock();
@@ -278,7 +278,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
         escapeNotExist = 1;
         if (flags & O_CREAT) {
-            XPRINTF("USBHDFSD: FAT I: O_CREAT detected!\n");
+            XPRINTF("FAT I: O_CREAT detected!\n");
             escapeNotExist = 0;
         }
 
@@ -291,13 +291,13 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
         }
         // the file already exist but flags is set to truncate
         if (ret == 2 && (flags & O_TRUNC)) {
-            XPRINTF("USBHDFSD: FAT I: O_TRUNC detected!\n");
+            XPRINTF("FAT I: O_TRUNC detected!\n");
             fat_truncateFile(fatd, cluster, rec->sfnSector, rec->sfnOffset);
         }
 
         // find the file
         cluster = 0; // allways start from root
-        XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_open after file creation\n");
+        XPRINTF("Calling fat_getFileStartCluster from fs_open after file creation\n");
         ret = fat_getFileStartCluster(fatd, name, &cluster, &rec->dirent.fatdir);
     }
 
@@ -318,7 +318,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
     rec->sizeChange       = 0;
 
     if ((flags & O_APPEND) && (flags & O_WRONLY)) {
-        XPRINTF("USBHDFSD: FAT I: O_APPEND detected!\n");
+        XPRINTF("FAT I: O_APPEND detected!\n");
         rec->filePos = rec->dirent.fatdir.size;
     }
 
@@ -530,7 +530,7 @@ static int fs_remove(iop_file_t *fd, const char *name)
     }
 
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_remove\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_remove\n");
     result = fat_getFileStartCluster(fatd, name, &cluster, &fatdir);
     if (result < 0) {
         _fs_unlock();
@@ -572,7 +572,7 @@ static int fs_mkdir(iop_file_t *fd, const char *name, int mode)
         return -ENODEV;
     }
 
-    XPRINTF("USBHDFSD: fs_mkdir: name=%s \n", name);
+    XPRINTF("fs_mkdir: name=%s \n", name);
     ret = fat_createFile(fatd, name, 1, 0, &cluster, &sfnSector, &sfnOffset);
 
     // directory of the same name already exist
@@ -614,7 +614,7 @@ static int fs_dopen(iop_file_t *fd, const char *name)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_dopen called: unit %d name %s\n", fd->unit, name);
+    XPRINTF("fs_dopen called: unit %d name %s\n", fd->unit, name);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -653,7 +653,7 @@ static int fs_dclose(iop_file_t *fd)
         return -EBADF;
 
     _fs_lock();
-    XPRINTF("USBHDFSD: fs_dclose called: unit %d\n", fd->unit);
+    XPRINTF("fs_dclose called: unit %d\n", fd->unit);
     if (rec->dirent.file_flag != FS_FILE_FLAG_FOLDER) {
         _fs_unlock();
         return -ENOTDIR;
@@ -677,7 +677,7 @@ static int fs_dread(iop_file_t *fd, iox_dirent_t *buffer)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_dread called: unit %d\n", fd->unit);
+    XPRINTF("fs_dread called: unit %d\n", fd->unit);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -717,7 +717,7 @@ static int fs_getstat(iop_file_t *fd, const char *name, iox_stat_t *stat)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_getstat called: unit %d name %s\n", fd->unit, name);
+    XPRINTF("fs_getstat called: unit %d name %s\n", fd->unit, name);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -725,7 +725,7 @@ static int fs_getstat(iop_file_t *fd, const char *name, iox_stat_t *stat)
         return -ENODEV;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_getstat\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_getstat\n");
     ret = fat_getFileStartCluster(fatd, name, &cluster, &fatdir);
     if (ret < 0) {
         _fs_unlock();
@@ -792,7 +792,7 @@ int fs_rename(iop_file_t *fd, const char *path, const char *newpath)
 
     // find the file
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_rename\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_rename\n");
     ret = fat_getFileStartCluster(fatd, path, &cluster, &fatdir);
     if (ret < 0 && ret != -ENOENT) {
         _fs_unlock();

--- a/iop/iLink/IEEE1394_disk/src/include/mass_debug.h
+++ b/iop/iLink/IEEE1394_disk/src/include/mass_debug.h
@@ -1,9 +1,10 @@
 #ifndef _MASS_DEBUG_H
 #define _MASS_DEBUG_H 1
 
+#define MODNAME "IEEE1394_disk"
 #ifdef DEBUG
-#define XPRINTF(args...)  printf(args)
-#define iXPRINTF(args...) Kprintf(args)
+#define XPRINTF(args...)  printf(MODNAME ": "args)
+#define iXPRINTF(args...) Kprintf(MODNAME ": "args)
 #else
 #define XPRINTF(args...) \
     do {                 \

--- a/iop/iLink/IEEE1394_disk/src/main.c
+++ b/iop/iLink/IEEE1394_disk/src/main.c
@@ -5,8 +5,7 @@
 
 #include "sbp2_disk.h"
 #include "fat_driver.h"
-
-#define MODNAME "IEEE1394_disk"
+#include "mass_debug.h"
 IRX_ID(MODNAME, 0x01, 0x07);
 
 int InitFS(void);

--- a/iop/iLink/IEEE1394_disk/src/part_driver.c
+++ b/iop/iLink/IEEE1394_disk/src/part_driver.c
@@ -58,11 +58,11 @@ int part_getPartitionTable(struct SBP2Device *dev, part_table *part)
 
     ret = READ_SECTOR(dev, 0, sbuf); // read sector 0 - Disk MBR or boot sector
     if (ret < 0) {
-        printf("USBHDFSD: part_getPartitionTable read failed %d!\n", ret);
+        XPRINTF("part_getPartitionTable read failed %d!\n", ret);
         return -1;
     }
 
-    printf("USBHDFSD: boot signature %X %X\n", sbuf[0x1FE], sbuf[0x1FF]);
+    XPRINTF("boot signature %X %X\n", sbuf[0x1FE], sbuf[0x1FF]);
     if (sbuf[0x1FE] == 0x55 && sbuf[0x1FF] == 0xAA) {
         for (i = 0; i < 4; i++) {
             part_raw_record *part_raw;
@@ -86,7 +86,7 @@ int part_connect(struct SBP2Device *dev)
     part_table partTable;
     int count = 0;
     int i;
-    XPRINTF("USBHDFSD: part_connect devId %i \n", dev->nodeID);
+    XPRINTF("part_connect devId %i \n", dev->nodeID);
 
     if (part_getPartitionTable(dev, &partTable) < 0)
         return -1;
@@ -100,7 +100,7 @@ int part_connect(struct SBP2Device *dev)
             partTable.record[i].sid == 0x0C || // fat 32
             partTable.record[i].sid == 0x0E)   // fat 16 LBA
         {
-            XPRINTF("USBHDFSD: mount partition %d\n", i);
+            XPRINTF("mount partition %d\n", i);
             if (fat_mount(dev, partTable.record[i].start, partTable.record[i].count) >= 0)
                 count++;
         }
@@ -108,7 +108,7 @@ int part_connect(struct SBP2Device *dev)
 
     if (count == 0) { // no partition table detected
         // try to use "floppy" option
-        printf("USBHDFSD: mount drive\n");
+        XPRINTF("mount drive\n");
         if (fat_mount(dev, 0, dev->maxLBA) < 0)
             return -1;
     }
@@ -119,7 +119,7 @@ int part_connect(struct SBP2Device *dev)
 //---------------------------------------------------------------------------
 void part_disconnect(struct SBP2Device *dev)
 {
-    printf("USBHDFSD: part_disconnect devId %i \n", dev->nodeID);
+    XPRINTF("part_disconnect devId %i \n", dev->nodeID);
     fat_forceUnmount(dev);
 }
 

--- a/iop/iLink/IEEE1394_disk/src/scsi.c
+++ b/iop/iLink/IEEE1394_disk/src/scsi.c
@@ -26,7 +26,7 @@ static int scsiTestUnitReady(struct SBP2Device *dev)
 {
     struct CommandDescriptorBlock cdb;
 
-    XPRINTF("IEEE1394_disk: scsiTestUnitReady.\n");
+    XPRINTF("scsiTestUnitReady.\n");
 
     cdb.misc = (u32)(ORB_NOTIFY | ORB_REQUEST_FORMAT(0) | CDB_MAX_PAYLOAD(dev->max_payload) | CDB_DIRECTION(WRITE_TRANSACTION) | CDB_SPEED(dev->speed));
 
@@ -59,7 +59,7 @@ static int scsiRequestSense(struct SBP2Device *dev, void *buffer, int size)
     int ret;
     struct CommandDescriptorBlock cdb;
 
-    XPRINTF("IEEE1394_disk: scsiRequestSense.\n");
+    XPRINTF("scsiRequestSense.\n");
 
     cdb.misc = (ORB_NOTIFY | ORB_REQUEST_FORMAT(0) | CDB_MAX_PAYLOAD(dev->max_payload) | CDB_DIRECTION(WRITE_TRANSACTION) | CDB_SPEED(dev->speed) | CDB_DATA_SIZE(size));
 
@@ -88,7 +88,7 @@ static int scsiRequestSense(struct SBP2Device *dev, void *buffer, int size)
     ret = ieee1394_Sync();
 
     if (ret != 0) {
-        XPRINTF("IEEE1394_disk: scsiRequestSense error: %d\n", ret);
+        XPRINTF("scsiRequestSense error: %d\n", ret);
     }
 
     return ret;
@@ -99,7 +99,7 @@ static int scsiInquiry(struct SBP2Device *dev, void *buffer, int size)
     int ret;
     struct CommandDescriptorBlock cdb;
 
-    XPRINTF("IEEE1394_disk: scsiInquiry. buffer: %p\n", buffer);
+    XPRINTF("scsiInquiry. buffer: %p\n", buffer);
 
     cdb.misc = (ORB_NOTIFY | ORB_REQUEST_FORMAT(0) | CDB_MAX_PAYLOAD(dev->max_payload) | CDB_DIRECTION(WRITE_TRANSACTION) | CDB_SPEED(dev->speed) | CDB_DATA_SIZE(size));
 
@@ -128,7 +128,7 @@ static int scsiInquiry(struct SBP2Device *dev, void *buffer, int size)
     ret = ieee1394_Sync();
 
     if (ret != 0) {
-        XPRINTF("IEEE1394_disk: scsiInquiry error %d\n", ret);
+        XPRINTF("scsiInquiry error %d\n", ret);
     } else {
         unsigned int i;
 
@@ -143,7 +143,7 @@ static int scsiStartStopUnit(struct SBP2Device *dev)
 {
     struct CommandDescriptorBlock cdb;
 
-    XPRINTF("IEEE1394_disk: scsiStartStopUnit.\n");
+    XPRINTF("scsiStartStopUnit.\n");
 
     cdb.misc = (ORB_NOTIFY | ORB_REQUEST_FORMAT(0) | CDB_MAX_PAYLOAD(dev->max_payload) | CDB_DIRECTION(WRITE_TRANSACTION) | CDB_SPEED(dev->speed));
 
@@ -175,7 +175,7 @@ static int scsiReadCapacity(struct SBP2Device *dev, void *buffer, int size)
 {
     struct CommandDescriptorBlock cdb;
 
-    XPRINTF("IEEE1394_disk: scsiReadCapacity.\n");
+    XPRINTF("scsiReadCapacity.\n");
 
     cdb.misc = (ORB_NOTIFY | ORB_REQUEST_FORMAT(0) | CDB_MAX_PAYLOAD(dev->max_payload) | CDB_DIRECTION(WRITE_TRANSACTION) | CDB_SPEED(dev->speed) | CDB_DATA_SIZE(size));
 
@@ -215,7 +215,7 @@ int scsiReadSector(struct SBP2Device *dev, unsigned long int lba, void *buffer, 
     void *bufferPtr, *PreviousReqBufferPtr;
     int result;
 
-    XPRINTF("IEEE1394_disk: scsiReadSector. buffer: %p, lba: 0x%08lx, numsectors: %d.\n", buffer, lba, sectorCount);
+    XPRINTF("scsiReadSector. buffer: %p, lba: 0x%08lx, numsectors: %d.\n", buffer, lba, sectorCount);
     SectorsPerBlock = XFER_BLOCK_SIZE / dev->sectorSize;
     OrbsRemaining   = sectorCount / SectorsPerBlock;
     if ((sectorCount % SectorsPerBlock) != 0)
@@ -288,7 +288,7 @@ int scsiReadSector(struct SBP2Device *dev, unsigned long int lba, void *buffer, 
     for (i = 0; i < sectorsToRead << 7; i++)
         ((unsigned int *)PreviousReqBufferPtr)[i] = BSWAP32(((unsigned int *)PreviousReqBufferPtr)[i]);
 
-    XPRINTF("IEEE1394_disk: scsiReadSector done.\n");
+    XPRINTF("scsiReadSector done.\n");
 
     return result;
 }
@@ -300,7 +300,7 @@ int scsiWriteSector(struct SBP2Device *dev, unsigned long int lba, void *buffer,
     void *bufferPtr;
     int result, max_payload;
 
-    XPRINTF("IEEE1394_disk: scsiWriteSector.\n");
+    XPRINTF("scsiWriteSector.\n");
     SectorsPerBlock = XFER_BLOCK_SIZE / dev->sectorSize;
     OrbsRemaining   = sectorCount / SectorsPerBlock;
     if ((sectorCount % SectorsPerBlock) != 0)
@@ -367,43 +367,43 @@ static inline int InitializeSCSIDevice(struct SBP2Device *dev)
     read_capacity_data rcd;
     int stat;
 
-    XPRINTF("IEEE1394_disk: InitializeSCSIDevice.\n");
+    XPRINTF("InitializeSCSIDevice.\n");
 
     memset(&id, 0, sizeof(inquiry_data));
     if ((stat = scsiInquiry(dev, &id, sizeof(inquiry_data))) < 0) {
-        XPRINTF("IEEE1394_disk: Error - scsiInquiry returned %d.\n", stat);
+        XPRINTF("Error - scsiInquiry returned %d.\n", stat);
         return -1;
     }
 
-    printf("IEEE1394_disk: Vendor: %.8s\n", id.vendor);
-    printf("IEEE1394_disk: Product: %.16s\n", id.product);
-    printf("IEEE1394_disk: Revision: %.4s\n", id.revision);
+    printf("Vendor: %.8s\n", id.vendor);
+    printf("Product: %.16s\n", id.product);
+    printf("Revision: %.4s\n", id.revision);
 
     if ((stat = scsiReadCapacity(dev, &rcd, sizeof(read_capacity_data))) != 0) {
-        XPRINTF("IEEE1394_disk: Error - scsiReadCapacity %d\n", stat);
+        XPRINTF("Error - scsiReadCapacity %d\n", stat);
         return -1;
     }
 
     dev->sectorSize = rcd.block_length;
     dev->maxLBA     = rcd.last_lba;
 
-    printf("IEEE1394_disk: sectorSize %lu maxLBA %lu\n", dev->sectorSize, dev->maxLBA);
+    printf("sectorSize %lu maxLBA %lu\n", dev->sectorSize, dev->maxLBA);
 
     while ((stat = scsiTestUnitReady(dev)) != 0) {
-        XPRINTF("IEEE1394_disk: Error - scsiTestUnitReady %d\n", stat);
+        XPRINTF("Error - scsiTestUnitReady %d\n", stat);
 
         stat = scsiRequestSense(dev, &sd, sizeof(sense_data));
         if (stat != 0) {
-            XPRINTF("IEEE1394_disk: Error - scsiRequestSense %d\n", stat);
+            XPRINTF("Error - scsiRequestSense %d\n", stat);
         }
 
         if ((sd.error_code == 0x70) && (sd.sense_key != 0x00)) {
-            XPRINTF("IEEE1394_disk: Sense Data key: %02X code: %02X qual: %02X\n", sd.sense_key, sd.add_sense_code, sd.add_sense_qual);
+            XPRINTF("Sense Data key: %02X code: %02X qual: %02X\n", sd.sense_key, sd.add_sense_code, sd.add_sense_qual);
 
             if ((sd.sense_key == 0x02) && (sd.add_sense_code == 0x04) && (sd.add_sense_qual == 0x02)) {
-                XPRINTF("IEEE1394_disk: Error - Additional initalization is required for this device!\n");
+                XPRINTF("Error - Additional initalization is required for this device!\n");
                 if ((stat = scsiStartStopUnit(dev)) != 0) {
-                    XPRINTF("IEEE1394_disk: Error - scsiStartStopUnit %d\n", stat);
+                    XPRINTF("Error - scsiStartStopUnit %d\n", stat);
                     return -1;
                 }
             }
@@ -424,12 +424,12 @@ int ConfigureSBP2Device(struct SBP2Device *dev)
     int ret;
 
     if ((ret = InitializeSCSIDevice(dev)) < 0) {
-        XPRINTF("IEEE1394_disk: Error - failed to warmup device 0x%08x\n", dev->nodeID);
+        XPRINTF("Error - failed to warmup device 0x%08x\n", dev->nodeID);
         return ret;
     }
 
     if ((dev->cache = scache_init(dev, dev->sectorSize)) == NULL) {
-        XPRINTF("IEEE1394_disk: Error - scache_init failed \n");
+        XPRINTF("Error - scache_init failed \n");
         return ret;
     }
 

--- a/iop/iLink/iLinkman/src/include/iLink_internal.h
+++ b/iop/iLink/iLinkman/src/include/iLink_internal.h
@@ -1,8 +1,8 @@
 // #define DEBUG_TTY_FEEDBACK /* Comment out to disable generation of debug TTY messages */
 
 #ifdef DEBUG_TTY_FEEDBACK
-#define DEBUG_PRINTF(args...)  printf(args)
-#define iDEBUG_PRINTF(args...) Kprintf(args)
+#define DEBUG_PRINTF(args...)  printf("ILINKMAN: "args)
+#define iDEBUG_PRINTF(args...) Kprintf("ILINKMAN: "args)
 #else
 #define DEBUG_PRINTF(args...) \
     do {                      \

--- a/iop/network/smap/src/include/main.h
+++ b/iop/network/smap/src/include/main.h
@@ -15,7 +15,7 @@
 #endif
 
 // In the SONY original, all the calls to DEBUG_PRINTF() were to sceInetPrintf().
-#define DEBUG_PRINTF(args...) printf(args)
+#define DEBUG_PRINTF(args...) printf("SMAP: "args)
 
 // This struct needs to be the exact same layout as struct NetManEthRuntimeStats!
 struct RuntimeStats

--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -292,14 +292,14 @@ int _start(int argc, char *argv[])
 
 #ifdef BUILDING_SMAP_NETMAN
     if (RegisterLibraryEntries(&_exp_smap) != 0) {
-        DEBUG_PRINTF("smap: module already loaded\n");
+        DEBUG_PRINTF("module already loaded\n");
         return MODULE_NO_RESIDENT_END;
     }
 #endif
 
 #ifdef BUILDING_SMAP_MODULAR
     if (RegisterLibraryEntries(&_exp_smapmodu) != 0) {
-        DEBUG_PRINTF("smap: module already loaded\n");
+        DEBUG_PRINTF("module already loaded\n");
         return MODULE_NO_RESIDENT_END;
     }
 #endif
@@ -310,25 +310,25 @@ int _start(int argc, char *argv[])
     // It may be necessary to prevent SMAP from linking with an old DEV9 module.
 
     /* if ((ModuleID = SearchModuleByName("dev9")) < 0) {
-        sceInetPrintf("smap: dev9 module not found\n");
+        sceInetPrintf("dev9 module not found\n");
         return MODULE_NO_RESIDENT_END;
     }
     if (ReferModuleStatus(ModuleID, &ModStatus) < 0) {
-        sceInetPrintf("smap: can't get dev9 module status\n");
+        sceInetPrintf("can't get dev9 module status\n");
         return MODULE_NO_RESIDENT_END;
     }
 
     if (ModStatus.version < 0x204) {
-        sceInetPrintf("smap: dev9 module version must be 2.4 or later\n");
+        sceInetPrintf("dev9 module version must be 2.4 or later\n");
         return MODULE_NO_RESIDENT_END;
     } */
 
 #ifdef BUILDING_SMAP_PS2IP
     // Parse IP args.
-    DEBUG_PRINTF("SMAP: argc %d\n", argc);
+    DEBUG_PRINTF("argc %d\n", argc);
 
     if (argc >= 4) {
-        DEBUG_PRINTF("SMAP: %s %s %s\n", argv[1], argv[2], argv[3]);
+        DEBUG_PRINTF("%s %s %s\n", argv[1], argv[2], argv[3]);
         IP.addr = inet_addr(argv[1]);
         NM.addr = inet_addr(argv[2]);
         GW.addr = inet_addr(argv[3]);
@@ -349,7 +349,7 @@ int _start(int argc, char *argv[])
 
 #ifdef BUILDING_SMAP_NETMAN
     if ((result = smap_init(argc, argv)) < 0) {
-        DEBUG_PRINTF("smap: smap_init -> %d\n", result);
+        DEBUG_PRINTF("smap_init -> %d\n", result);
         ReleaseLibraryEntries(&_exp_smap);
         return MODULE_NO_RESIDENT_END;
     }
@@ -362,7 +362,7 @@ int _start(int argc, char *argv[])
         return MODULE_NO_RESIDENT_END;
     }
 
-    printf("SMap: Initialized OK, IP: ");
+    printf("Initialized OK, IP: ");
     PrintIP(&IP);
     printf(", NM: ");
     PrintIP(&NM);

--- a/iop/network/smap/src/smap.c
+++ b/iop/network/smap/src/smap.c
@@ -117,7 +117,7 @@ static u16 _smap_read_phy(volatile u8 *emac3_regbase, unsigned int address)
     } while (i < 100);
 
     if (i >= 100)
-        printf("smap: %s: > %u ms\n", "_smap_read_phy", i);
+        printf("SMAP: %s: > %u ms\n", "_smap_read_phy", i);
 
     return result;
 }
@@ -140,7 +140,7 @@ static int DisplayHelpMessage(void)
 static inline void RestartAutoNegotiation(volatile u8 *emac3_regbase, u16 bmsr)
 {
     if (EnableVerboseOutput)
-        DEBUG_PRINTF("smap: restarting auto nego (BMCR=0x%x, BMSR=0x%x)\n", _smap_read_phy(emac3_regbase, SMAP_DsPHYTER_BMCR), bmsr);
+        DEBUG_PRINTF("restarting auto nego (BMCR=0x%x, BMSR=0x%x)\n", _smap_read_phy(emac3_regbase, SMAP_DsPHYTER_BMCR), bmsr);
     _smap_write_phy(emac3_regbase, SMAP_DsPHYTER_BMCR, SMAP_PHY_BMCR_ANEN | SMAP_PHY_BMCR_RSAN);
 }
 
@@ -154,12 +154,12 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
 
     LinkSpeed100M = 0;
     if (EnableVerboseOutput != 0)
-        DEBUG_PRINTF("smap: Resetting PHY\n");
+        DEBUG_PRINTF("Resetting PHY\n");
 
     _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, SMAP_PHY_BMCR_RST);
     for (i = 0; _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR) & SMAP_PHY_BMCR_RST; i++) {
         if (i <= 0) {
-            DEBUG_PRINTF("smap: PHY reset error\n");
+            DEBUG_PRINTF("PHY reset error\n");
             return -1;
         }
         if (SmapDrivPrivData->NetDevStopFlag)
@@ -170,7 +170,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
 
     if (!EnableAutoNegotiation) {
         if (EnableVerboseOutput != 0)
-            DEBUG_PRINTF("smap: no auto mode (conf=0x%x)\n", SmapConfiguration);
+            DEBUG_PRINTF("no auto mode (conf=0x%x)\n", SmapConfiguration);
 
         LinkSpeed100M = 0 < (SmapConfiguration & 0x180); /* Toggles between SMAP_PHY_BMCR_10M and SMAP_PHY_BMCR_100M. */
         value         = LinkSpeed100M << 13;
@@ -179,7 +179,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
         _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, value);
 
     WaitLink:
-        DEBUG_PRINTF("smap: Waiting Valid Link for %dMbps\n", LinkSpeed100M ? 100 : 10);
+        DEBUG_PRINTF("Waiting Valid Link for %dMbps\n", LinkSpeed100M ? 100 : 10);
 
         i = 0;
         while (1) {
@@ -207,11 +207,11 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
             if (!(value & 0x0800))
                 SmapConfiguration = SmapConfiguration & 0xFFFFFFDF; /* 10Base-TX HDX */
 
-            DEBUG_PRINTF("smap: no strap mode (conf=0x%x, bmsr=0x%x)\n", SmapConfiguration, value);
+            DEBUG_PRINTF("no strap mode (conf=0x%x, bmsr=0x%x)\n", SmapConfiguration, value);
 
             value = _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_ANAR);
             value = (SmapConfiguration & 0x5E0) | (value & 0x1F);
-            DEBUG_PRINTF("smap: anar=0x%x\n", value);
+            DEBUG_PRINTF("anar=0x%x\n", value);
             _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_ANAR, value);
             _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, SMAP_PHY_BMCR_ANEN | SMAP_PHY_BMCR_RSAN);
         } else {
@@ -220,7 +220,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
             }
         }
 
-        DEBUG_PRINTF("smap: auto mode (BMCR=0x%x ANAR=0x%x)\n", _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR), _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_ANAR));
+        DEBUG_PRINTF("auto mode (BMCR=0x%x ANAR=0x%x)\n", _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR), _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_ANAR));
 
     RepeatAutoNegoProcess:
         for (AutoNegoRetries = 0; AutoNegoRetries < 3; AutoNegoRetries++) {
@@ -254,7 +254,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
         /* If automatic negotiation fails, manually figure out which speed and duplex mode to use. */
         if (AutoNegoRetries >= 3) {
             if (EnableVerboseOutput)
-                DEBUG_PRINTF("smap: waiting valid link for 100Mbps Half-Duplex\n");
+                DEBUG_PRINTF("waiting valid link for 100Mbps Half-Duplex\n");
 
             _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, SMAP_PHY_BMCR_100M);
             DelayThread(1000000);
@@ -271,7 +271,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
 
             if (i >= 30) {
                 if (EnableVerboseOutput)
-                    DEBUG_PRINTF("smap: waiting valid link for 10Mbps Half-Duplex\n");
+                    DEBUG_PRINTF("waiting valid link for 10Mbps Half-Duplex\n");
 
                 _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, SMAP_PHY_BMCR_10M);
                 DelayThread(1000000);
@@ -299,7 +299,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
         RegDump[i] = _smap_read_phy(SmapDrivPrivData->emac3_regbase, i);
 
     if (EnableVerboseOutput)
-        DEBUG_PRINTF("smap: PHY: %04x %04x %04x %04x %04x %04x\n", RegDump[SMAP_DsPHYTER_BMCR], RegDump[SMAP_DsPHYTER_BMSR], RegDump[SMAP_DsPHYTER_PHYIDR1], RegDump[SMAP_DsPHYTER_PHYIDR2], RegDump[SMAP_DsPHYTER_ANAR], RegDump[SMAP_DsPHYTER_ANLPAR]);
+        DEBUG_PRINTF("PHY: %04x %04x %04x %04x %04x %04x\n", RegDump[SMAP_DsPHYTER_BMCR], RegDump[SMAP_DsPHYTER_BMSR], RegDump[SMAP_DsPHYTER_PHYIDR1], RegDump[SMAP_DsPHYTER_PHYIDR2], RegDump[SMAP_DsPHYTER_ANAR], RegDump[SMAP_DsPHYTER_ANLPAR]);
 
     /* Special initialization for the National Semiconductor DP83846A PHY. */
     if (RegDump[SMAP_DsPHYTER_PHYIDR1] == SMAP_PHY_IDR1_VAL && (RegDump[SMAP_DsPHYTER_PHYIDR2] & SMAP_PHY_IDR2_MSK) == SMAP_PHY_IDR2_VAL) {
@@ -311,13 +311,13 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
             value2 = _smap_read_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_RECR);
             if ((value2 != 0) || (value >= 0x11)) {
                 if (EnableVerboseOutput)
-                    DEBUG_PRINTF("smap: FCSCR=%d RECR=%d\n", value, value2);
+                    DEBUG_PRINTF("FCSCR=%d RECR=%d\n", value, value2);
                 _smap_write_phy(SmapDrivPrivData->emac3_regbase, SMAP_DsPHYTER_BMCR, 0);
                 goto WaitLink;
             }
         }
 
-        DEBUG_PRINTF("smap: PHY chip: DP83846A%d\n", (RegDump[SMAP_DsPHYTER_PHYIDR2] & SMAP_PHY_IDR2_REV_MSK) + 1);
+        DEBUG_PRINTF("PHY chip: DP83846A%d\n", (RegDump[SMAP_DsPHYTER_PHYIDR2] & SMAP_PHY_IDR2_REV_MSK) + 1);
 
         /* If operating in 10Mbit mode, disable the 10Mb/s Loopback mode. */
         if (!EnableAutoNegotiation) {
@@ -361,7 +361,7 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
     if (FlowControlEnabled)
         SmapDrivPrivData->LinkMode |= 0x40;
 
-    DEBUG_PRINTF("smap: %s %s Duplex Mode %s Flow Control\n", LinkSpeed100M ? "100BaseTX" : "10BaseT", LinkFDX ? "Full" : "Half", FlowControlEnabled ? "with" : "without");
+    DEBUG_PRINTF("%s %s Duplex Mode %s Flow Control\n", LinkSpeed100M ? "100BaseTX" : "10BaseT", LinkFDX ? "Full" : "Half", FlowControlEnabled ? "with" : "without");
 
     emac3_regbase = SmapDrivPrivData->emac3_regbase;
     emac3_value   = SMAP_EMAC3_GET32(SMAP_R_EMAC3_MODE1) & 0x67FFFFFF;
@@ -456,7 +456,7 @@ static void IntrHandlerThread(struct SmapDriverData *SmapDrivPrivData)
         int result;
 
         if ((result = WaitEventFlag(SmapDrivPrivData->Dev9IntrEventFlag, SMAP_EVENT_START | SMAP_EVENT_STOP | SMAP_EVENT_INTR | SMAP_EVENT_XMIT | SMAP_EVENT_LINK_CHECK, WEF_OR | WEF_CLEAR, &EFBits)) != 0) {
-            DEBUG_PRINTF("smap: WaitEventFlag -> %d\n", result);
+            DEBUG_PRINTF("WaitEventFlag -> %d\n", result);
             break;
         }
 
@@ -895,14 +895,14 @@ void SMAPOutputDebugInformation(void)
     int i;
     char bdidx;
 
-    DEBUG_PRINTF("smap: SMAP_R_RXFIFO_CTRL:       0x%x\n", SMAP_REG8(SMAP_R_RXFIFO_CTRL));
-    DEBUG_PRINTF("smap: SMAP_R_RXFIFO_RD_PTR:     0x%x\n", SMAP_REG16(SMAP_R_RXFIFO_RD_PTR));
-    DEBUG_PRINTF("smap: SMAP_R_RXFIFO_SIZE:       %d\n", SMAP_REG16(SMAP_R_RXFIFO_SIZE));
-    DEBUG_PRINTF("smap: SMAP_R_RXFIFO_FRAME_CNT:  %d\n", SMAP_REG8(SMAP_R_RXFIFO_FRAME_CNT));
-    DEBUG_PRINTF("smap: SMAP_R_RXFIFO_FRAME_DEC:  %d\n", SMAP_REG8(SMAP_R_RXFIFO_FRAME_DEC));
-    DEBUG_PRINTF("smap: SMAP_R_EMAC3_RxMODE:      0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_RxMODE));
-    DEBUG_PRINTF("smap: SMAP_R_EMAC3_INTR_STAT:   0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_INTR_STAT));
-    DEBUG_PRINTF("smap: SMAP_R_EMAC3_INTR_ENABLE: 0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_INTR_ENABLE));
+    DEBUG_PRINTF("SMAP_R_RXFIFO_CTRL:       0x%x\n", SMAP_REG8(SMAP_R_RXFIFO_CTRL));
+    DEBUG_PRINTF("SMAP_R_RXFIFO_RD_PTR:     0x%x\n", SMAP_REG16(SMAP_R_RXFIFO_RD_PTR));
+    DEBUG_PRINTF("SMAP_R_RXFIFO_SIZE:       %d\n", SMAP_REG16(SMAP_R_RXFIFO_SIZE));
+    DEBUG_PRINTF("SMAP_R_RXFIFO_FRAME_CNT:  %d\n", SMAP_REG8(SMAP_R_RXFIFO_FRAME_CNT));
+    DEBUG_PRINTF("SMAP_R_RXFIFO_FRAME_DEC:  %d\n", SMAP_REG8(SMAP_R_RXFIFO_FRAME_DEC));
+    DEBUG_PRINTF("SMAP_R_EMAC3_RxMODE:      0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_RxMODE));
+    DEBUG_PRINTF("SMAP_R_EMAC3_INTR_STAT:   0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_INTR_STAT));
+    DEBUG_PRINTF("SMAP_R_EMAC3_INTR_ENABLE: 0x%x\n", (unsigned int)SMAP_EMAC3_GET32(SMAP_R_EMAC3_INTR_ENABLE));
     bdidx = SmapDriverData.RxBDIndex % SMAP_BD_MAX_ENTRY;
     for (i = 0; i < SMAP_BD_MAX_ENTRY; i += 1) {
         if (rx_bd[i].ctrl_stat != SMAP_BD_RX_EMPTY ||
@@ -919,19 +919,19 @@ void SMAPOutputDebugInformation(void)
         }
     }
 
-    DEBUG_PRINTF("smap: RxDroppedFrameCount:      %d\n", (int)SmapDriverData.RuntimeStats.RxDroppedFrameCount);
-    DEBUG_PRINTF("smap: RxErrorCount:             %d\n", (int)SmapDriverData.RuntimeStats.RxErrorCount);
-    DEBUG_PRINTF("smap: RxFrameOverrunCount:      %d\n", SmapDriverData.RuntimeStats.RxFrameOverrunCount);
-    DEBUG_PRINTF("smap: RxFrameBadLengthCount:    %d\n", SmapDriverData.RuntimeStats.RxFrameBadLengthCount);
-    DEBUG_PRINTF("smap: RxFrameBadFCSCount:       %d\n", SmapDriverData.RuntimeStats.RxFrameBadFCSCount);
-    DEBUG_PRINTF("smap: RxFrameBadAlignmentCount: %d\n", SmapDriverData.RuntimeStats.RxFrameBadAlignmentCount);
-    DEBUG_PRINTF("smap: TxDroppedFrameCount:      %d\n", (int)SmapDriverData.RuntimeStats.TxDroppedFrameCount);
-    DEBUG_PRINTF("smap: TxErrorCount:             %d\n", (int)SmapDriverData.RuntimeStats.TxErrorCount);
-    DEBUG_PRINTF("smap: TxFrameLOSSCRCount:       %d\n", SmapDriverData.RuntimeStats.TxFrameLOSSCRCount);
-    DEBUG_PRINTF("smap: TxFrameEDEFERCount:       %d\n", SmapDriverData.RuntimeStats.TxFrameEDEFERCount);
-    DEBUG_PRINTF("smap: TxFrameCollisionCount:    %d\n", SmapDriverData.RuntimeStats.TxFrameCollisionCount);
-    DEBUG_PRINTF("smap: TxFrameUnderrunCount:     %d\n", SmapDriverData.RuntimeStats.TxFrameUnderrunCount);
-    DEBUG_PRINTF("smap: RxAllocFail:              %d\n", SmapDriverData.RuntimeStats.RxAllocFail);
+    DEBUG_PRINTF("RxDroppedFrameCount:      %d\n", (int)SmapDriverData.RuntimeStats.RxDroppedFrameCount);
+    DEBUG_PRINTF("RxErrorCount:             %d\n", (int)SmapDriverData.RuntimeStats.RxErrorCount);
+    DEBUG_PRINTF("RxFrameOverrunCount:      %d\n", SmapDriverData.RuntimeStats.RxFrameOverrunCount);
+    DEBUG_PRINTF("RxFrameBadLengthCount:    %d\n", SmapDriverData.RuntimeStats.RxFrameBadLengthCount);
+    DEBUG_PRINTF("RxFrameBadFCSCount:       %d\n", SmapDriverData.RuntimeStats.RxFrameBadFCSCount);
+    DEBUG_PRINTF("RxFrameBadAlignmentCount: %d\n", SmapDriverData.RuntimeStats.RxFrameBadAlignmentCount);
+    DEBUG_PRINTF("TxDroppedFrameCount:      %d\n", (int)SmapDriverData.RuntimeStats.TxDroppedFrameCount);
+    DEBUG_PRINTF("TxErrorCount:             %d\n", (int)SmapDriverData.RuntimeStats.TxErrorCount);
+    DEBUG_PRINTF("TxFrameLOSSCRCount:       %d\n", SmapDriverData.RuntimeStats.TxFrameLOSSCRCount);
+    DEBUG_PRINTF("TxFrameEDEFERCount:       %d\n", SmapDriverData.RuntimeStats.TxFrameEDEFERCount);
+    DEBUG_PRINTF("TxFrameCollisionCount:    %d\n", SmapDriverData.RuntimeStats.TxFrameCollisionCount);
+    DEBUG_PRINTF("TxFrameUnderrunCount:     %d\n", SmapDriverData.RuntimeStats.TxFrameUnderrunCount);
+    DEBUG_PRINTF("RxAllocFail:              %d\n", SmapDriverData.RuntimeStats.RxAllocFail);
 #endif
 }
 
@@ -991,7 +991,7 @@ static inline int SetupNetDev(void)
     EventFlagData.bits   = 0;
 
     if ((result = SmapDriverData.Dev9IntrEventFlag = CreateEventFlag(&EventFlagData)) < 0) {
-        DEBUG_PRINTF("smap: CreateEventFlag -> %d\n", result);
+        DEBUG_PRINTF("CreateEventFlag -> %d\n", result);
         return -6;
     }
 
@@ -1001,7 +1001,7 @@ static inline int SetupNetDev(void)
     ThreadData.priority  = ThreadPriority;
     ThreadData.stacksize = ThreadStackSize;
     if ((result = SmapDriverData.IntrHandlerThreadID = CreateThread(&ThreadData)) < 0) {
-        DEBUG_PRINTF("smap: CreateThread -> %d\n", result);
+        DEBUG_PRINTF("CreateThread -> %d\n", result);
         DeleteEventFlag(SmapDriverData.Dev9IntrEventFlag);
         return result;
     }

--- a/iop/network/smbman/src/debug.h
+++ b/iop/network/smbman/src/debug.h
@@ -7,7 +7,7 @@
 #define __DEBUG_H__
 
 #ifdef DEBUG
-#define DPRINTF(args...) printf(args)
+#define DPRINTF(args...) printf("SMBMAN: "args)
 #else
 #define DPRINTF(args...) \
     do {                 \

--- a/iop/network/smbman/src/smbman.c
+++ b/iop/network/smbman/src/smbman.c
@@ -27,7 +27,7 @@ int _start(int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    DPRINTF("%s version 0x%01x%02x start!\n", MODNAME, VER_MAJOR, VER_MINOR);
+    printf("%s version 0x%01x%02x start!\n", MODNAME, VER_MAJOR, VER_MINOR);
 
     smb_initdev();
 

--- a/iop/security/secrman/src/main.h
+++ b/iop/security/secrman/src/main.h
@@ -6,13 +6,13 @@
   */
 
 #ifdef DEBUG
-#define _printf(args...) printf(args)
-#define _printf2(args...) printf(args)
-#define _printf3(args...) printf(args)
-#define _printf4(args...) printf(args)
+#define _printf(args...) printf("SECRMAN: "args)
+#define _printf2(args...) printf("SECRMAN: "args)
+#define _printf3(args...) printf("SECRMAN: "args)
+#define _printf4(args...) printf("SECRMAN: "args)
 #else
-#define _printf(args...)  // printf(args)
-#define _printf2(args...) // printf(args)
-#define _printf3(args...) // printf(args)
-#define _printf4(args...) // printf(args)
+#define _printf(args...)
+#define _printf2(args...)
+#define _printf3(args...)
+#define _printf4(args...)
 #endif

--- a/iop/security/secrsif/src/secrsif.c
+++ b/iop/security/secrsif/src/secrsif.c
@@ -12,6 +12,12 @@
 #define MODNAME "secrsif"
 IRX_ID(MODNAME, 1, 2);
 
+#ifdef DEBUG
+#define DPRINTF(x...) printf("SECRSIF: " x)
+#else
+#define DPRINTF(x...)
+#endif
+
 extern struct irx_export_table _exp_secrsif;
 
 static SifRpcDataQueue_t SifSecrDownloadHeaderQD;
@@ -99,7 +105,7 @@ static void *SifSecrDiskBootBlockHandler(int function, void *buffer, int nbytes)
     (void)nbytes;
 
     ((struct SecrSifDiskBootBlockParams *)buffer)->result = SecrDiskBootBlock(((struct SecrSifDiskBootBlockParams *)buffer)->source, ((struct SecrSifDiskBootBlockParams *)buffer)->destination, ((struct SecrSifDiskBootBlockParams *)buffer)->size);
-    printf("sif_disk_boot_block %p %ld\n", ((struct SecrSifDiskBootBlockParams *)buffer)->source, ((struct SecrSifDiskBootBlockParams *)buffer)->result);
+    DPRINTF("sif_disk_boot_block %p %ld\n", ((struct SecrSifDiskBootBlockParams *)buffer)->source, ((struct SecrSifDiskBootBlockParams *)buffer)->result);
 
     return buffer;
 }
@@ -109,7 +115,7 @@ static void SifSecrDownloadHeaderThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -124,7 +130,7 @@ static void SifSecrDownloadBlockThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -139,7 +145,7 @@ static void SifSecrDownloadGetKbitThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -154,7 +160,7 @@ static void SifSecrDownloadGetKcThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -169,7 +175,7 @@ static void SifSecrDownloadGetICVPS2Thread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -184,7 +190,7 @@ static void SifSecrDiskBootHeaderThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 
@@ -199,7 +205,7 @@ static void SifSecrDiskBootBlockThread(void *parameters)
     (void)parameters;
 
     if (!sceSifCheckInit()) {
-        printf("yet sif hasn't been init\n");
+        DPRINTF("yet sif hasn't been init\n");
         sceSifInit();
     }
 

--- a/iop/sound/audsrv/src/adpcm.c
+++ b/iop/sound/audsrv/src/adpcm.c
@@ -26,6 +26,7 @@
 #include "common.h"
 #include "rpc_server.h"
 #include "spu.h"
+#include "debug_printf.h"
 
 typedef struct adpcm_list_t
 {

--- a/iop/sound/audsrv/src/audsrv.c
+++ b/iop/sound/audsrv/src/audsrv.c
@@ -30,6 +30,7 @@
 #include "upsamplers.h"
 #include "hw.h"
 #include "spu.h"
+#include "debug_printf.h"
 
 #define MODNAME "audsrv"
 #define VERSION "0.93"
@@ -206,7 +207,7 @@ int audsrv_set_format(int freq, int bits, int channels)
 	writepos = 0;
 	readpos = (feed_size * 5) & ~3;
 
-	printf("audsrv: freq %d bits %d channels %d ringbuf_sz %d feed_size %d shift %d\n", freq, bits, channels, ringbuf_size, feed_size, core1_sample_shift);
+	DPRINTF("freq %d bits %d channels %d ringbuf_sz %d feed_size %d shift %d\n", freq, bits, channels, ringbuf_size, feed_size, core1_sample_shift);
 
 	format_changed = 1;
 	return AUDSRV_ERR_NOERROR;
@@ -225,7 +226,7 @@ int audsrv_init()
 	/* initialize libsd */
 	if (sceSdInit(SD_INIT_COLD) < 0)
 	{
-		printf("audsrv: failed to initialize libsd\n");
+		DPRINTF("failed to initialize libsd\n");
 		return -1;
 	}
 
@@ -259,9 +260,9 @@ int audsrv_init()
 	audsrv_set_format(48000, 16, 2);
 
 	play_tid = create_thread(play_thread, 39, 0);
-	printf("audsrv: playing thread 0x%x started\n", play_tid);
+	DPRINTF("playing thread 0x%x started\n", play_tid);
 
-	printf("audsrv: kickstarted\n");
+	DPRINTF("kickstarted\n");
 
 	initialized = 1;
 	return AUDSRV_ERR_NOERROR;
@@ -356,7 +357,7 @@ int audsrv_play_audio(const char *buf, int buflen)
 		update_volume();
 	}
 
-	//printf("play audio %d bytes, readpos %d, writepos %d avail %d\n", buflen, readpos, writepos, audsrv_available());
+	//DPRINTF("play audio %d bytes, readpos %d, writepos %d avail %d\n", buflen, readpos, writepos, audsrv_available());
 
 	/* limit to what's available, no crossing possible */
 	buflen = MIN(buflen, audsrv_available());
@@ -410,7 +411,7 @@ int audsrv_set_threshold(int amount)
 		return AUDSRV_ERR_ARGS;
 	}
 
-	printf("audsrv: callback threshold: %d\n", amount);
+	DPRINTF("callback threshold: %d\n", amount);
 	fillbuf_threshold = amount;
 	return 0;
 }
@@ -434,7 +435,7 @@ static void play_thread(void *arg)
 
 	(void)arg;
 
-	printf("starting play thread\n");
+	DPRINTF("starting play thread\n");
 	while (1)
 	{
 		int block;
@@ -501,7 +502,7 @@ static void play_thread(void *arg)
 			call_client_callback(AUDSRV_FILLBUF_CALLBACK);
 		}
 
-		//printf("avaiable: %d, queued: %d\n", available, ringbuf_size - available);
+		//DPRINTF("avaiable: %d, queued: %d\n", available, ringbuf_size - available);
 	}
 }
 
@@ -562,12 +563,12 @@ int _start(int argc, char *argv[])
 	FlushDcache();
 	CpuEnableIntr(0);
 
-	printf("audsrv: greetings from version " VERSION " !\n");
+	printf("greetings from version " VERSION " !\n");
 
 	err = RegisterLibraryEntries(&_exp_audsrv);
 	if (err != 0)
 	{
-		printf("audsrv: couldn't register library entries. Error %d\n", err);
+		DPRINTF("couldn't register library entries. Error %d\n", err);
 		return MODULE_NO_RESIDENT_END;
 	}
 

--- a/iop/sound/audsrv/src/cdrom.c
+++ b/iop/sound/audsrv/src/cdrom.c
@@ -31,6 +31,7 @@
 #include "upsamplers.h"
 #include "spu.h"
 #include "hw.h"
+#include "debug_printf.h"
 
 /* cdda */
 /** initialization status */
@@ -149,7 +150,7 @@ static int process_toc()
 	toc.tracks[toc.num_tracks].second = btoi(raw_toc[35]);
 	toc.tracks[toc.num_tracks].sector = btoi(raw_toc[36]);
 
-	printf("audsrv: found %d tracks\n", toc.num_tracks);
+	DPRINTF("found %d tracks\n", toc.num_tracks);
 	return 0;
 }
 
@@ -182,19 +183,19 @@ static int initialize_cdda()
 	sceCdSync(0);
 
 	type = audsrv_get_cd_type();
-	printf("audsrv: disc type: %d\n", type);
+	DPRINTF("disc type: %d\n", type);
 
 	if (type != 0x11 && type != 0x13 && type != 0xfd)
 	{
 		/* not a cdda disc, or a ps1/ps2 with cdda tracks */
-		printf("audsrv: not a cdda disc!\n");
+		DPRINTF("not a cdda disc!\n");
 		return -AUDSRV_ERR_ARGS;
 	}
 
 	process_toc();
 
 	cdda_initialized = 1;
-	printf("audsrv: cdda initialization completed successfully\n");
+	DPRINTF("cdda initialization completed successfully\n");
 	return 0;
 }
 
@@ -470,11 +471,11 @@ int audsrv_get_trackpos()
  */
 int audsrv_cd_play_sectors(int start, int end)
 {
-	printf("audsrv: cd_play_sectors: %d %d\n", start, end);
+	DPRINTF("cd_play_sectors: %d %d\n", start, end);
 
 	if (initialize_cdda() < 0)
 	{
-		printf("audsrv: initialized cdda failed\n");
+		DPRINTF("initialized cdda failed\n");
 		return AUDSRV_ERR_NOT_INITIALIZED; //FIXME
 	}
 
@@ -485,7 +486,7 @@ int audsrv_cd_play_sectors(int start, int end)
 	cdda_play_end = end;
 	cdda_pos = start;
 
-	printf("audsrv: creating cdda feed thread\n");
+	DPRINTF("creating cdda feed thread\n");
 
 	/* .. and start a new one! */
 	cdda_play_tid = create_thread(cdda_procedure, 48, 0);
@@ -514,7 +515,7 @@ int audsrv_play_cd(int track)
 
 	if (initialize_cdda() < 0)
 	{
-		printf("audsrv: initialized cdda failed\n");
+		DPRINTF("initialized cdda failed\n");
 		return AUDSRV_ERR_NOT_INITIALIZED; //FIXME
 	}
 
@@ -528,7 +529,7 @@ int audsrv_play_cd(int track)
 	if (track == 1 && (type == 11 || type == 0x13))
 	{
 		/* first track is data */
-		printf("audsrv: request to play data track\n");
+		DPRINTF("request to play data track\n");
 		return AUDSRV_ERR_ARGS;
 	}
 
@@ -537,7 +538,7 @@ int audsrv_play_cd(int track)
 
 	if (start < 0 || end < 0 || end < start)
 	{
-		printf("audsrv: invalid track offsets %d, %d\n", start, end);
+		DPRINTF("invalid track offsets %d, %d\n", start, end);
 		return AUDSRV_ERR_ARGS; //FIXME:
 	}
 

--- a/iop/sound/audsrv/src/debug_printf.h
+++ b/iop/sound/audsrv/src/debug_printf.h
@@ -1,0 +1,5 @@
+#ifdef DEBUG
+#define DPRINTF(x...) printf("AUDSRV: " x)
+#else
+#define DPRINTF(x...)
+#endif

--- a/iop/sound/audsrv/src/rpc_server.c
+++ b/iop/sound/audsrv/src/rpc_server.c
@@ -24,6 +24,7 @@
 #include "audsrv_internal.h"
 #include "common.h"
 #include "rpc_client.h"
+#include "debug_printf.h"
 
 /* rpc server variables */
 /** buffer for RPC DMA */
@@ -49,7 +50,7 @@ static void *rpc_command(int func, unsigned *data, int size)
 
 	(void)size;
 
-	/* printf("audsrv: rpc command %d\n", func); */
+	/* DPRINTF("rpc command %d\n", func); */
 	switch(func)
 	{
 		case AUDSRV_INIT:
@@ -184,7 +185,7 @@ static void rpc_server_thread(void *arg)
 
 	SifInitRpc(0);
 
-	printf("audsrv: creating rpc server\n");
+	DPRINTF("creating rpc server\n");
 
 	SifSetRpcQueue(&qd, GetThreadId());
 	SifRegisterRpc(&sd0, AUDSRV_IRX, (void *)rpc_command, rpc_buffer, NULL, NULL, &qd);
@@ -193,9 +194,7 @@ static void rpc_server_thread(void *arg)
 
 int initialize_rpc_thread()
 {
-	int rpc_tid;
-
-	rpc_tid = create_thread(rpc_server_thread, 40, 0);
-	printf("audsrv: rpc server thread 0x%x started\n", rpc_tid);
-	return 0;
+	int rpc_tid = create_thread(rpc_server_thread, 40, 0);
+	DPRINTF("rpc server thread 0x%x started\n", rpc_tid);
+	return (rpc_tid > 0);
 }

--- a/iop/system/rmman/src/rmman.c
+++ b/iop/system/rmman/src/rmman.c
@@ -13,6 +13,12 @@
 
 IRX_ID("rmman", 1, 16);
 
+#ifdef DEBUG
+#define DPRINTF(x...) printf("RMMAN: "x)
+#else
+#define DPRINTF(x...)
+#endif
+
 #define RM_EF_EXIT_THREAD		1
 #define RM_EF_EXIT_THREAD_DONE		2
 #define RM_EF_CLOSE_PORT		4
@@ -526,7 +532,7 @@ static void *RpcHandler(int fno, void *buffer, int len)
 			retBuff = RmmanRpc_version((struct rmRpcPacket *)buffer);
 			break;
 		default:
-			printf("invalid function code (%03x)\n", (unsigned int)((struct rmRpcPacket *)buffer)->cmd.command);
+			DPRINTF("invalid function code (%03x)\n", (unsigned int)((struct rmRpcPacket *)buffer)->cmd.command);
 			retBuff = buffer;
 	}
 
@@ -539,7 +545,7 @@ static void RpcThread(void *arg)
 
 	if(!sceSifCheckInit())
 	{
-		printf("yet sif hasn't been init\n");
+		DPRINTF("yet sif hasn't been init\n");
 		sceSifInit();
 	}
 

--- a/iop/system/sio2man/src/log.c
+++ b/iop/system/sio2man/src/log.c
@@ -22,7 +22,7 @@
 
 #include "log.h"
 
-#define DPRINTF(format, args...) printf("%s: " format, __FUNCTION__ , ## args)
+#define DPRINTF(format, args...) printf("SIO2MAN: (%s): " format, __FUNCTION__ , ## args)
 
 #define FLUSH_COUNT_MAX	4
 #define DMA_MAX		1024

--- a/iop/tcpip/tcpip-base/include/ps2ip_internal.h
+++ b/iop/tcpip/tcpip-base/include/ps2ip_internal.h
@@ -15,7 +15,7 @@
 #include "lwip/sockets.h"
 
 #ifdef DEBUG
-#define	dbgprintf(args...)	printf(args)
+#define	dbgprintf(args...)	printf("PS2IP: "args)
 #else
 #define	dbgprintf(args...)
 #endif

--- a/iop/usb/usbd/src/usbd.c
+++ b/iop/usb/usbd/src/usbd.c
@@ -23,8 +23,7 @@
 #include "sysclib.h"
 #include "thsemap.h"
 #include "loadcore.h"
-
-IRX_ID("usbd", 1, 1);
+IRX_ID(MODNAME, 1, 1);
 
 #define WELCOME_STR "FreeUsbd v.0.1.2\n"
 

--- a/iop/usb/usbd/src/usbdpriv.h
+++ b/iop/usb/usbd/src/usbdpriv.h
@@ -21,8 +21,9 @@
 
 #define OHCI_REG_BASE 0xBF801600
 
+#define MODNAME "usbd"
 #ifdef DEBUG
-#define dbg_printf printf
+#define dbg_printf(a...) printf(MODNAME ": " a)
 #else
 #define dbg_printf(a...) (void)0
 #endif

--- a/iop/usb/usbhdfsd/src/fat_driver.c
+++ b/iop/usb/usbhdfsd/src/fat_driver.c
@@ -127,7 +127,7 @@ static int fat_getClusterChain12(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector || sectorSpan) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
             lastFatSector = fatSector;
@@ -137,7 +137,7 @@ static int fat_getClusterChain12(fat_driver *fatd, unsigned int cluster, unsigne
                 xbuf[1] = sbuf[fatd->partBpb.sectorSize - 1];
                 ret     = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
+                    XPRINTF("Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
                     return -EIO;
                 }
                 xbuf[2] = sbuf[0];
@@ -185,7 +185,7 @@ static int fat_getClusterChain16(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat16 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
 
@@ -226,7 +226,7 @@ static int fat_getClusterChain32(fat_driver *fatd, unsigned int cluster, unsigne
         if (lastFatSector != fatSector) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat32 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat32 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
 
@@ -313,7 +313,7 @@ static void fat_determineFatType(fat_bpb *partBpb)
     sector -= partBpb->partStart;
     sector       = partBpb->sectorCount - sector;
     clusterCount = sector / partBpb->clusterSize;
-    // XPRINTF("USBHDFSD: Data cluster count = %u \n", clusterCount);
+    // XPRINTF("Data cluster count = %u \n", clusterCount);
 
     if (clusterCount < 4085) {
         partBpb->fatType = FAT12;
@@ -334,7 +334,7 @@ static int fat_getPartitionBootSector(mass_dev *dev, unsigned int sector, fat_bp
 
     ret = READ_SECTOR(dev, sector, sbuf); // read partition boot sector (first sector on partition)
     if (ret < 0) {
-        XPRINTF("USBHDFSD: Read partition boot sector failed sector=%u! \n", sector);
+        XPRINTF("Read partition boot sector failed sector=%u! \n", sector);
         return -EIO;
     }
 
@@ -511,11 +511,11 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
     unsigned char nextChain;
     int chainSize;
 
-    XPRINTF("USBHDFSD: reading cluster chain  \n");
+    XPRINTF("reading cluster chain  \n");
     fileCluster = fatDir->chain[0].cluster;
 
     if (fileCluster < 2) {
-        XPRINTF("USBHDFSD:    early exit... \n");
+        XPRINTF("   early exit... \n");
         return;
     }
 
@@ -536,7 +536,7 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
                 nextChain = 0;
             }
         } else {
-            XPRINTF("USBHDFSD: fat_setFatDirChain(): fat_getClusterChain() failed: %d\n", chainSize);
+            XPRINTF("fat_setFatDirChain(): fat_getClusterChain() failed: %d\n", chainSize);
             return;
         }
 
@@ -556,16 +556,16 @@ void fat_setFatDirChain(fat_driver *fatd, fat_dir *fatDir)
 
 #ifdef DEBUG_EXTREME // dlanor: I patched this because this bloat hid important stuff
     // debug
-    XPRINTF("USBHDFSD: SEEK CLUSTER CHAIN CACHE fileSize=%u blockSize=%u \n", fatDir->size, blockSize);
+    XPRINTF("SEEK CLUSTER CHAIN CACHE fileSize=%u blockSize=%u \n", fatDir->size, blockSize);
     for (i = 0; i < DIR_CHAIN_SIZE; i++) {
-        XPRINTF("USBHDFSD: index=%u cluster=%u offset= %u - %u start=%u \n",
+        XPRINTF("index=%u cluster=%u offset= %u - %u start=%u \n",
                 fatDir->chain[i].index, fatDir->chain[i].cluster,
                 fatDir->chain[i].index * fatd->partBpb.clusterSize * fatd->partBpb.sectorSize,
                 (fatDir->chain[i].index + 1) * fatd->partBpb.clusterSize * fatd->partBpb.sectorSize,
                 i * blockSize);
     }
 #endif /* debug */
-    XPRINTF("USBHDFSD: read cluster chain  done!\n");
+    XPRINTF("read cluster chain  done!\n");
 }
 
 //---------------------------------------------------------------------------
@@ -575,7 +575,7 @@ static void fat_setFatDir(fat_driver *fatd, fat_dir *fatDir, unsigned int parent
     unsigned int i;
     char *srcName;
 
-    XPRINTF("USBHDFSD: setting fat dir...\n");
+    XPRINTF("setting fat dir...\n");
     srcName = dir->sname;
     if (dir->name[0] != 0) { // long filename not empty
         srcName = dir->name;
@@ -646,12 +646,12 @@ int fat_getDirentrySectorData(fat_driver *fatd, unsigned int *startCluster, unsi
     *startSector = fat_cluster2sector(&fatd->partBpb, *startCluster);
     chainSize    = fat_getClusterChain(fatd, *startCluster, fatd->cbuf, MAX_DIR_CLUSTER, 1);
     if (chainSize >= MAX_DIR_CLUSTER) {
-        XPRINTF("USBHDFSD: Chain too large\n");
+        XPRINTF("Chain too large\n");
         return -EFAULT;
     } else if (chainSize > 0) {
         *dirSector = chainSize * fatd->partBpb.clusterSize;
     } else {
-        XPRINTF("USBHDFSD: Error getting cluster chain! startCluster=%u \n", *startCluster);
+        XPRINTF("Error getting cluster chain! startCluster=%u \n", *startCluster);
         return -EFAULT;
     }
 
@@ -670,7 +670,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
 #endif
 
     cont = 1;
-    XPRINTF("USBHDFSD: getting cluster for dir entry: %s \n", dirName);
+    XPRINTF("getting cluster for dir entry: %s \n", dirName);
     // clear name strings
     dir.sname[0] = 0;
     dir.name[0]  = 0;
@@ -679,7 +679,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
     if (ret < 0)
         return ret;
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -693,10 +693,10 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
 
         ret = READ_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("read directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos = 0;
 
         // go through start of the sector till the end of sector
@@ -707,12 +707,12 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
                 if (!(dir.attr & FAT_ATTR_VOLUME_LABEL)) {                                     // not volume label
                     if ((strEqual(dir.sname, dirName) == 0) ||
                         (strEqual(dir.name, dirName) == 0)) {
-                        XPRINTF("USBHDFSD: found! %s\n", dir.name);
+                        XPRINTF("found! %s\n", dir.name);
                         if (fatDir != NULL) { // fill the directory properties
                             fat_setFatDir(fatd, fatDir, *startCluster, &dir_entry->sfn, &dir, 1);
                         }
                         *startCluster = dir.cluster;
-                        XPRINTF("USBHDFSD: direntry %s found at cluster: %u \n", dirName, dir.cluster);
+                        XPRINTF("direntry %s found at cluster: %u \n", dirName, dir.cluster);
                         return dir.attr; // returns file or directory attr
                     }
                 } // ends "if(!(dir.attr & FAT_ATTR_VOLUME_LABEL))"
@@ -723,7 +723,7 @@ static int fat_getDirentryStartCluster(fat_driver *fatd, char *dirName, unsigned
             dirPos += sizeof(fat_direntry);
         } // ends "while"
     }     // ends "for"
-    XPRINTF("USBHDFSD: direntry %s not found! \n", dirName);
+    XPRINTF("direntry %s not found! \n", dirName);
     return -ENOENT;
 }
 
@@ -737,7 +737,7 @@ int fat_getFileStartCluster(fat_driver *fatd, const char *fname, unsigned int *s
     unsigned int i, offset;
     int ret;
 
-    XPRINTF("USBHDFSD: Entering fat_getFileStartCluster\n");
+    XPRINTF("Entering fat_getFileStartCluster\n");
 
     offset = 0;
     i      = 0;
@@ -766,21 +766,21 @@ int fat_getFileStartCluster(fat_driver *fatd, const char *fname, unsigned int *s
     } // ends "for"
     // and the final file
     tmpName[offset] = 0; // terminate string
-    XPRINTF("USBHDFSD: Ready to get cluster for file \"%s\"\n", tmpName);
+    XPRINTF("Ready to get cluster for file \"%s\"\n", tmpName);
     if (fatDir != NULL) {
         // if the last char of the name was slash - the name was already found -exit
         if (offset == 0) {
-            XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with a folder\n");
+            XPRINTF("Exiting from fat_getFileStartCluster with a folder\n");
             return 2;
         }
         ret = fat_getDirentryStartCluster(fatd, tmpName, startCluster, fatDir);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with error %i\n", ret);
+            XPRINTF("Exiting from fat_getFileStartCluster with error %i\n", ret);
             return ret;
         }
-        XPRINTF("USBHDFSD: file's startCluster found. Name=%s, cluster=%u \n", fname, *startCluster);
+        XPRINTF("file's startCluster found. Name=%s, cluster=%u \n", fname, *startCluster);
     }
-    XPRINTF("USBHDFSD: Exiting from fat_getFileStartCluster with no error.\n");
+    XPRINTF("Exiting from fat_getFileStartCluster with no error.\n");
     return 1;
 }
 
@@ -810,7 +810,7 @@ static int fat_readSingleSector(mass_dev *dev, unsigned int sector, void *buffer
 
     ret = READ_SECTOR(dev, sector, sbuf);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: Read sector failed ! sector=%u\n", sector);
+        XPRINTF("Read sector failed ! sector=%u\n", sector);
         return 0;
     }
 
@@ -835,7 +835,7 @@ int fat_readFile(fat_driver *fatd, fat_dir *fatDir, unsigned int filePos, unsign
     dataSkip  = filePos % fatd->partBpb.sectorSize;
     bufferPos = 0;
 
-    XPRINTF("USBHDFSD: fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
+    XPRINTF("fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
             fileCluster, clusterPos, clusterSkip, sectorSkip, dataSkip);
 
     if (fileCluster < 2) {
@@ -922,7 +922,7 @@ int fat_readFile(fat_driver *fatd, fat_dir *fatDir, unsigned int filePos, unsign
                 INVALIDATE_SECTORS(fatd->dev, startSector, toRead);
                 ret = READ_SECTORS_RAW(fatd->dev, startSector, toRead, buffer + bufferPos);
                 if (ret != 0) {
-                    XPRINTF("USBHDFSD: Read sectors failed ! sector=%u (%u)\n", startSector, toRead);
+                    XPRINTF("Read sectors failed ! sector=%u (%u)\n", startSector, toRead);
                     return bufferPos;
                 }
 
@@ -977,7 +977,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
     if (ret < 0)
         return ret;
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", dirCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", dirCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -995,7 +995,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
         }
         ret = READ_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read directory  sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("Read directory  sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
 
@@ -1007,7 +1007,7 @@ int fat_getNextDirentry(fat_driver *fatd, fat_dir_list *fatdlist, fat_dir *fatDi
             if (cont == 1) {                                                                   // when short file name entry detected
                 fat_setFatDir(fatd, fatDir, dirCluster, &dir_entry->sfn, &dir, 0);
 #if 0
-                XPRINTF("USBHDFSD: fat_getNextDirentry %c%c%c%c%c%c %x %s %s\n",
+                XPRINTF("fat_getNextDirentry %c%c%c%c%c%c %x %s %s\n",
                         (dir.attr & FAT_ATTR_VOLUME_LABEL) ? 'v' : '-',
                         (dir.attr & FAT_ATTR_DIRECTORY) ? 'd' : '-',
                         (dir.attr & FAT_ATTR_READONLY) ? 'r' : '-',
@@ -1058,7 +1058,7 @@ int fat_mount(mass_dev *dev, unsigned int start, unsigned int count)
 
     for (i = 0; i < NUM_DRIVES && fatd == NULL; ++i) {
         if (g_fatd[i] == NULL) {
-            XPRINTF("USBHDFSD: usb fat: allocate fat_driver %d!\n", sizeof(fat_driver));
+            XPRINTF("usb fat: allocate fat_driver %d!\n", sizeof(fat_driver));
             g_fatd[i] = malloc(sizeof(fat_driver));
             if (g_fatd[i] != NULL) {
                 g_fatd[i]->dev = NULL;
@@ -1095,7 +1095,7 @@ int fat_mount(mass_dev *dev, unsigned int start, unsigned int count)
 void fat_forceUnmount(mass_dev *dev)
 {
     unsigned int i;
-    XPRINTF("USBHDFSD: usb fat: forceUnmount devId %i \n", dev->devId);
+    XPRINTF("usb fat: forceUnmount devId %i \n", dev->devId);
 
     for (i = 0; i < NUM_DRIVES; ++i) {
         if (g_fatd[i] != NULL && g_fatd[i]->dev == dev)

--- a/iop/usb/usbhdfsd/src/fat_write.c
+++ b/iop/usb/usbhdfsd/src/fat_write.c
@@ -105,7 +105,7 @@ static int fat_readEmptyClusters12(fat_driver *fatd)
         if (lastFatSector != fatSector || sectorSpan) {
             ret = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
+                XPRINTF("Read fat12 sector failed! sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector);
                 return -EIO;
             }
             lastFatSector = fatSector;
@@ -115,7 +115,7 @@ static int fat_readEmptyClusters12(fat_driver *fatd)
                 xbuf[1] = sbuf[fatd->partBpb.sectorSize - 1];
                 ret     = READ_SECTOR(fatd->dev, fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1, sbuf);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
+                    XPRINTF("Read fat12 sector failed sector=%u! \n", fatd->partBpb.partStart + fatd->partBpb.resSectors + fatSector + 1);
                     return -EIO;
                 }
                 xbuf[2] = sbuf[0];
@@ -175,7 +175,7 @@ static int fat_readEmptyClusters32(fat_driver *fatd)
 
         ret = READ_SECTOR(fatd->dev, fatStartSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat32 sector failed! sector=%u! \n", fatStartSector + i);
+            XPRINTF("Read fat32 sector failed! sector=%u! \n", fatStartSector + i);
             return -EIO;
         }
         for (j = recordSkip; j < indexCount && fatd->clStackIndex < MAX_CLUSTER_STACK; j++) {
@@ -214,7 +214,7 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
     int recordSkip;
 
     oldClStackIndex = fatd->clStackIndex;
-    // XPRINTF("USBHDFSD: #### Read empty clusters16: clStackIndex=%d MAX=%d\n", clStackIndex, MAX_CLUSTER_STACK);
+    // XPRINTF("#### Read empty clusters16: clStackIndex=%d MAX=%d\n", clStackIndex, MAX_CLUSTER_STACK);
 
     // indexCount = numer of cluster indices per sector
     indexCount = fatd->partBpb.sectorSize / 2; // FAT16->2, FAT32->4
@@ -232,7 +232,7 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
 
         ret = READ_SECTOR(fatd->dev, fatStartSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatStartSector + i);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatStartSector + i);
             return -EIO;
         }
         for (j = recordSkip; j < indexCount && fatd->clStackIndex < MAX_CLUSTER_STACK; j++) {
@@ -240,13 +240,13 @@ static int fat_readEmptyClusters16(fat_driver *fatd)
             if (cluster == 0) { // the cluster is free
                 fatd->clStackLast                 = (i * indexCount) + j;
                 fatd->clStack[fatd->clStackIndex] = fatd->clStackLast;
-                XPRINTF("USBHDFSD: %u ", fatd->clStack[fatd->clStackIndex]);
+                XPRINTF("%u ", fatd->clStack[fatd->clStackIndex]);
                 fatd->clStackIndex++;
             }
         }
         recordSkip = 0;
     }
-    XPRINTF("USBHDFSD: \n");
+    XPRINTF("\n");
     // the stack operates as LIFO but we put in the clusters as FIFO
     // we should reverse the cluster order - not necessary
     // but it will retain the natural (increasing) order of
@@ -350,14 +350,14 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         if (!sectorSpan) { // not sector span - the record is copmact and fits in single sector
             fat_setClusterRecord12(sbuf + (recordOffset % fatd->partBpb.sectorSize), value, recordType);
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
         } else { // sector span - the record is broken in 2 pieces - each one on different sector
@@ -366,14 +366,14 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
             // save current sector
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
             // read next sector from the fat
             fatSector++;
             ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
             // modify first byte of the sector buffer
@@ -381,7 +381,7 @@ static int fat_saveClusterRecord12(fat_driver *fatd, unsigned int currentCluster
             // save current sector
             ret = WRITE_SECTOR(fatd->dev, fatSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: Write fat12 sector failed! sector=%u! \n", fatSector);
+                XPRINTF("Write fat12 sector failed! sector=%u! \n", fatSector);
                 return -EIO;
             }
         }
@@ -415,7 +415,7 @@ static int fat_saveClusterRecord16(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         i = currentCluster % indexCount;
@@ -424,7 +424,7 @@ static int fat_saveClusterRecord16(fat_driver *fatd, unsigned int currentCluster
         sbuf[i]   = ((value & 0xFF00) >> 8);
         ret       = WRITE_SECTOR(fatd->dev, fatSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Write fat16 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Write fat16 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
     }
@@ -457,7 +457,7 @@ static int fat_saveClusterRecord32(fat_driver *fatd, unsigned int currentCluster
 
         ret = READ_SECTOR(fatd->dev, fatSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read fat32 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Read fat32 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
         i = currentCluster % indexCount;
@@ -469,7 +469,7 @@ static int fat_saveClusterRecord32(fat_driver *fatd, unsigned int currentCluster
 
         ret = WRITE_SECTOR(fatd->dev, fatSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Write fat32 sector failed! sector=%u! \n", fatSector);
+            XPRINTF("Write fat32 sector failed! sector=%u! \n", fatSector);
             return -EIO;
         }
     }
@@ -518,7 +518,7 @@ static int fat_appendClusterChain(fat_driver *fatd, unsigned int currentCluster,
             break;
 
         case FAT16:
-            XPRINTF("USBHDFSD: I: appending cluster chain : current=%u end=%u \n", currentCluster, endCluster);
+            XPRINTF("I: appending cluster chain : current=%u end=%u \n", currentCluster, endCluster);
             ret = fat_saveClusterRecord16(fatd, currentCluster, endCluster);
             if (ret < 0)
                 return ret;
@@ -582,7 +582,7 @@ static int fat_deleteClusterChain(fat_driver *fatd, unsigned int cluster)
     if (cluster < 2) {
         return -EFAULT;
     }
-    XPRINTF("USBHDFSD: I: delete cluster chain starting at cluster=%u\n", cluster);
+    XPRINTF("I: delete cluster chain starting at cluster=%u\n", cluster);
 
     cont = 1;
 
@@ -786,7 +786,7 @@ static void setSfnDate(fat_direntry_sfn *dsfn, int mode)
     tmpClk[3] = (month & 0x08) >> 3;          // month
     tmpClk[3] += ((year - 1980) & 0x7F) << 1; // year
 
-    XPRINTF("USBHDFSD: year=%d, month=%d, day=%d   h=%d m=%d s=%d \n", year, month, day, hour, minute, sec);
+    XPRINTF("year=%d, month=%d, day=%d   h=%d m=%d s=%d \n", year, month, day, hour, minute, sec);
     // set date & time of creation
     if (mode & DATE_CREATE) {
         dsfn->timeCreate[0] = tmpClk[0];
@@ -875,7 +875,7 @@ static int createShortNameMask(char *lname, char *sname)
     // clean short name by putting space
     for (i = 0; i < 11; i++)
         sname[i] = ' ';
-    XPRINTF("USBHDFSD: Clear short name ='%s'\n", sname);
+    XPRINTF("Clear short name ='%s'\n", sname);
 
     // detect number of dots and space characters in the long name
     j = 0;
@@ -888,7 +888,7 @@ static int createShortNameMask(char *lname, char *sname)
     // long name contains no dot or one dot and no space char
     if (j <= 1)
         fit++;
-    // XPRINTF("USBHDFSD: fit1=%d j=%d\n", fit, j);
+    // XPRINTF("fit1=%d j=%d\n", fit, j);
 
     // store name
     for (i = 0; lname[i] != 0 && lname[i] != '.' && i < 8; i++) {
@@ -901,7 +901,7 @@ static int createShortNameMask(char *lname, char *sname)
     if (lname[i] == '.' || lname[i] == 0) {
         fit++;
     }
-    // XPRINTF("USBHDFSD: fit2=%d\n", fit);
+    // XPRINTF("fit2=%d\n", fit);
 
     // find the last dot "." - filename extension
     size = strlen(lname);
@@ -921,12 +921,12 @@ static int createShortNameMask(char *lname, char *sname)
         // no dot detected in the long filename
         fit++;
     }
-    // XPRINTF("USBHDFSD: fit3=%d\n", fit);
-    // XPRINTF("USBHDFSD: Long name=%s  Short name=%s \n", lname, sname);
+    // XPRINTF("fit3=%d\n", fit);
+    // XPRINTF("Long name=%s  Short name=%s \n", lname, sname);
 
     // all 3 checks passed  - the long name fits in the short name without restrictions
     if (fit == 3) {
-        XPRINTF("USBHDFSD: Short name is loseles!\n");
+        XPRINTF("Short name is loseles!\n");
         return 0;
     }
 
@@ -1003,7 +1003,7 @@ static int getShortNameSequence(const char *name, const char *ext, const char *s
         buf[j - i - 1] = name[j];
     buf[j - i - 1] = 0; // terminate
 
-    XPRINTF("USBHDFSD: found short name sequence number='%s' \n", buf);
+    XPRINTF("found short name sequence number='%s' \n", buf);
     return strtol(buf, NULL, 10);
 }
 
@@ -1087,16 +1087,16 @@ static int getDirentryStoreOffset(fat_driver *fatd, int entryCount, int direntry
             } else {
                 slotStart = i;
                 slotSize  = 1;
-                XPRINTF("USBHDFSD: *Start slot at index=%d ", slotStart);
+                XPRINTF("*Start slot at index=%d ", slotStart);
             }
         } else { // occupied entry
             if (tightIndex < 0 && slotSize == direntrySize) {
                 tightIndex = slotStart;
-                XPRINTF("USBHDFSD: !Set tight index= %d\n", tightIndex);
+                XPRINTF("!Set tight index= %d\n", tightIndex);
             }
             if (looseIndex < 0 && slotSize > direntrySize) {
                 looseIndex = slotStart + slotSize - direntrySize;
-                XPRINTF("USBHDFSD: !Set loose index= %d\n", looseIndex);
+                XPRINTF("!Set loose index= %d\n", looseIndex);
             }
             if (tightIndex >= 0 && looseIndex >= 0) {
                 cont = 0;
@@ -1105,7 +1105,7 @@ static int getDirentryStoreOffset(fat_driver *fatd, int entryCount, int direntry
             slotSize  = 0;
         }
     }
-    XPRINTF("USBHDFSD: \n");
+    XPRINTF("\n");
 
     // tight index - smaller fragmentation of space, the larger blocks
     //               are left for larger filenames.
@@ -1179,7 +1179,7 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, const char 
 
     fat_getDirentrySectorData(fatd, startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", *startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -1193,10 +1193,10 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, const char 
         theSector = startSector + i;
         ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("read directory sector failed ! sector=%u\n", theSector);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos = 0;
 
         // go through start of the sector till the end of sector
@@ -1217,7 +1217,7 @@ static int fat_fillDirentryInfo(fat_driver *fatd, const char *lname, const char 
                                     return -ENOTDIR;
                                 return -EISDIR;
                             } // ends "if" clause for mismatched file/folder state
-                            XPRINTF("USBHDFSD: I: entry found! %s, %s = %s\n", dir.name, dir.sname, lname);
+                            XPRINTF("I: entry found! %s, %s = %s\n", dir.name, dir.sname, lname);
                             *retSector               = theSector;
                             *retOffset               = dirPos;
                             *startCluster            = dir.cluster;
@@ -1282,7 +1282,7 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
     unsigned int newCluster;
 
     i = entryIndex + direntrySize;
-    XPRINTF("USBHDFSD: cur=%d ecount=%d \n", i, entryCount);
+    XPRINTF("cur=%d ecount=%d \n", i, entryCount);
     // we don't need to enlarge directory cluster space
     if (i <= entryCount)
         return 0; // direntry fits into current space
@@ -1295,7 +1295,7 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
 
     chainSize = fat_getDirentrySectorData(fatd, &startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: maxSector=%u  dirSector=%u\n", maxSector, dirSector);
+    XPRINTF("maxSector=%u  dirSector=%u\n", maxSector, dirSector);
 
     if ((unsigned int)maxSector <= dirSector)
         return 0;
@@ -1309,11 +1309,11 @@ static int enlargeDirentryClusterSpace(fat_driver *fatd, unsigned int startClust
 
     // get last cluster of the cluster chain
     currentCluster = fatd->cbuf[chainSize - 1];
-    XPRINTF("USBHDFSD: current (last) cluster=%u \n", currentCluster);
+    XPRINTF("current (last) cluster=%u \n", currentCluster);
 
     // get 1 cluster from cluster stack and append the chain
     newCluster = fat_getFreeCluster(fatd, currentCluster);
-    XPRINTF("USBHDFSD: new cluster=%u \n", newCluster);
+    XPRINTF("new cluster=%u \n", newCluster);
     fat_invalidateLastChainResult(fatd); // prevent to misuse current (now updated) fatd->cbuf
     // if new cluster cannot be allocated
     if (newCluster == 0) {
@@ -1358,7 +1358,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
     // we create directory space inside one cluster. No need to worry about
     // large dir space spread on multiple clusters
     startSector = fat_cluster2sector(&fatd->partBpb, dirCluster);
-    XPRINTF("USBHDFSD: I: create dir space: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
+    XPRINTF("I: create dir space: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
 
     // go through all sectors of the cluster
     for (i = 0; i < fatd->partBpb.clusterSize; i++) {
@@ -1368,7 +1368,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
 
         ret = ALLOC_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: alloc directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("alloc directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
         memset(sbuf, 0, fatd->partBpb.sectorSize); // clean the sector
@@ -1384,7 +1384,7 @@ static int createDirectorySpace(fat_driver *fatd, unsigned int dirCluster, unsig
         }
         ret = WRITE_SECTOR(fatd->dev, startSector + i);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("write directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
     }
@@ -1408,7 +1408,7 @@ static int updateDirectoryParent(fat_driver *fatd, unsigned int dirCluster, unsi
     // The basic directory space should be within one cluster. No need to worry about
     // large dir space spread on multiple clusters
     startSector = fat_cluster2sector(&fatd->partBpb, dirCluster);
-    XPRINTF("USBHDFSD: I: update dir parent: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
+    XPRINTF("I: update dir parent: cluster=%u sector=%u (%u) \n", dirCluster, startSector, startSector * fatd->partBpb.sectorSize);
 
     // go through all sectors of the cluster
     for (i = 0; i < fatd->partBpb.clusterSize; i++) {
@@ -1418,7 +1418,7 @@ static int updateDirectoryParent(fat_driver *fatd, unsigned int dirCluster, unsi
 
         ret = READ_SECTOR(fatd->dev, startSector + i, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", startSector + i);
+            XPRINTF("read directory sector failed ! sector=%u\n", startSector + i);
             return -EIO;
         }
         fat_direntry_sfn *dsfn = (fat_direntry_sfn *)sbuf;
@@ -1431,7 +1431,7 @@ static int updateDirectoryParent(fat_driver *fatd, unsigned int dirCluster, unsi
 
                 ret = WRITE_SECTOR(fatd->dev, startSector + i);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", startSector + i);
+                    XPRINTF("write directory sector failed ! sector=%u\n", startSector + i);
                     return -EIO;
                 }
 
@@ -1493,7 +1493,7 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
 
     fat_getDirentrySectorData(fatd, &startCluster, &startSector, &dirSector);
 
-    XPRINTF("USBHDFSD: dirCluster=%u startSector=%u (%u) dirSector=%u \n", startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
+    XPRINTF("dirCluster=%u startSector=%u (%u) dirSector=%u \n", startCluster, startSector, startSector * mass_device->sectorSize, dirSector);
 
     // go through first directory sector till the max number of directory sectors
     // or stop when no more direntries detected
@@ -1507,10 +1507,10 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
         theSector = startSector + i;
         ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("read directory sector failed ! sector=%u\n", theSector);
             return -EIO;
         }
-        XPRINTF("USBHDFSD: read sector ok, scanning sector for direntries...\n");
+        XPRINTF("read sector ok, scanning sector for direntries...\n");
         dirPos    = 0;
         writeFlag = 0;
         // go through start of the sector till the end of sector
@@ -1540,7 +1540,7 @@ static int saveDirentry(fat_driver *fatd, unsigned int startCluster,
         if (writeFlag) {
             ret = WRITE_SECTOR(fatd->dev, theSector);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+                XPRINTF("write directory sector failed ! sector=%u\n", theSector);
                 return -EIO;
             }
         }
@@ -1608,7 +1608,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     // create short name from long name
     ret = createShortNameMask(lname, sname);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: short name invalid!\n");
+        XPRINTF("E: short name invalid!\n");
         return ret;
     }
     compressShortName = ret;
@@ -1619,7 +1619,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     ret              = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                             startCluster, retSector, retOffset);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: direntry data invalid!\n");
+        XPRINTF("E: direntry data invalid!\n");
         return ret;
     }
     // ret 0 means that exact filename/directory already exist
@@ -1633,29 +1633,29 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     }
 
     if (ret > DIR_MASK_SIZE) {
-        XPRINTF("USBHDFSD: W: Direntry count is larger than number of records!\n");
+        XPRINTF("W: Direntry count is larger than number of records!\n");
         ret = DIR_MASK_SIZE;
     }
     entryCount = ret;
-    XPRINTF("USBHDFSD: I: direntry count=%d\n", entryCount);
+    XPRINTF("I: direntry count=%d\n", entryCount);
 
     if (compressShortName) {
         setShortNameSequence(fatd, sname);
     }
-    XPRINTF("USBHDFSD: I: new short name='%s' \n", sname);
+    XPRINTF("I: new short name='%s' \n", sname);
 
     // direntry size for long name + 1 additional direntry for short name
     direntrySize = getDirentrySize(lname) + 1;
-    XPRINTF("USBHDFSD: Direntry size=%d\n", direntrySize);
+    XPRINTF("Direntry size=%d\n", direntrySize);
 
     // find the offset (index) of the direntry space where to put this direntry
     entryIndex = getDirentryStoreOffset(fatd, entryCount, direntrySize);
-    XPRINTF("USBHDFSD: I: direntry store offset=%d\n", entryIndex);
+    XPRINTF("I: direntry store offset=%d\n", entryIndex);
 
     // if the direntry offset excede current space of directory clusters
     // we have to add one cluster to directory space
     ret = enlargeDirentryClusterSpace(fatd, parentDirCluster, entryCount, entryIndex, direntrySize);
-    XPRINTF("USBHDFSD: I: enlarge direntry cluster space ret=%d\n", ret);
+    XPRINTF("I: enlarge direntry cluster space ret=%d\n", ret);
     if (ret < 0) {
         return ret;
     }
@@ -1666,7 +1666,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
         if (newCluster == 0) {
             return -ENOSPC;
         }
-        XPRINTF("USBHDFSD: I: new file/dir cluster=%u\n", newCluster);
+        XPRINTF("I: new file/dir cluster=%u\n", newCluster);
         *startCluster = newCluster;
     } else {
         *startCluster = (fatd->partBpb.fatType == FAT32) ? getUI32_2(orig_dsfn->clusterL, orig_dsfn->clusterH) : getUI16(orig_dsfn->clusterL);
@@ -1675,7 +1675,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
 
     // now store direntries into the directory space
     ret = saveDirentry(fatd, parentDirCluster, lname, sname, directory, newCluster, direntrySize, entryIndex, retSector, retOffset, orig_dsfn);
-    XPRINTF("USBHDFSD: I: save direntry ret=%d\n", ret);
+    XPRINTF("I: save direntry ret=%d\n", ret);
     if (ret < 0) {
         return ret;
     }
@@ -1683,7 +1683,7 @@ static int fat_modifyDirSpace(fat_driver *fatd, char *lname, char directory, cha
     // create empty directory structure
     if ((orig_dsfn == NULL) && directory) {
         ret = createDirectorySpace(fatd, newCluster, parentDirCluster);
-        XPRINTF("USBHDFSD: I: create directory space ret=%d\n", ret);
+        XPRINTF("I: create directory space ret=%d\n", ret);
         if (ret < 0) {
             return ret;
         }
@@ -1712,7 +1712,7 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     unsigned int retSector;
     int retOffset;
 
-    XPRINTF("USBHDFSD: I: checkDirspaceEmpty  directory cluster=%u \n", startCluster);
+    XPRINTF("I: checkDirspaceEmpty  directory cluster=%u \n", startCluster);
     if (startCluster < 2) { // do not check root directory!
         return -EFAULT;
     }
@@ -1723,7 +1723,7 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     ret = fat_fillDirentryInfo(fatd, sname, sname, 1,
                                &startCluster, &retSector, &retOffset);
     if (ret > DIR_MASK_SIZE) {
-        XPRINTF("USBHDFSD: W: Direntry count is larger than number of records! directory space cluster =%u maxRecords=%u\n", startCluster, DIR_MASK_SIZE);
+        XPRINTF("W: Direntry count is larger than number of records! directory space cluster =%u maxRecords=%u\n", startCluster, DIR_MASK_SIZE);
         ret = DIR_MASK_SIZE;
     }
     entryCount = ret;
@@ -1733,11 +1733,11 @@ static int checkDirspaceEmpty(fat_driver *fatd, unsigned int startCluster)
     for (i = 1; i < (entryCount / 8); i++) {
         if (fatd->dir_used_mask[i] != 0) {
         non_empty:
-            XPRINTF("USBHDFSD: I: directory not empty!\n");
+            XPRINTF("I: directory not empty!\n");
             return 0;
         } // ends "if"
     }     // ends "for"
-    XPRINTF("USBHDFSD: I: directory is empty.\n");
+    XPRINTF("I: directory is empty.\n");
     return 1;
 }
 
@@ -1756,7 +1756,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
             if (theSector > 0) {
                 ret = WRITE_SECTOR(fatd->dev, theSector);
                 if (ret < 0) {
-                    XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+                    XPRINTF("write directory sector failed ! sector=%u\n", theSector);
                     ret = -EIO;
                     break;
                 }
@@ -1764,7 +1764,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
             theSector = fatd->deSec[i];
             ret       = READ_SECTOR(fatd->dev, theSector, sbuf);
             if (ret < 0) {
-                XPRINTF("USBHDFSD: read directory sector failed ! sector=%u\n", theSector);
+                XPRINTF("read directory sector failed ! sector=%u\n", theSector);
                 ret = -EIO;
                 break;
             }
@@ -1774,7 +1774,7 @@ static int fat_wipeDirEntries(fat_driver *fatd)
     if (theSector > 0) {
         ret = WRITE_SECTOR(fatd->dev, theSector);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", theSector);
+            XPRINTF("write directory sector failed ! sector=%u\n", theSector);
             ret = -EIO;
         }
     }
@@ -1809,10 +1809,10 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
     ret = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                startCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found!\n");
+        XPRINTF("E: direntry not found!\n");
         return -ENOENT;
     }
-    XPRINTF("USBHDFSD: clear dir space: dir found at  cluster=%u \n ", *startCluster);
+    XPRINTF("clear dir space: dir found at  cluster=%u \n ", *startCluster);
 
     // Check wether any file or directory exist in te target directory space.
     // We should not delete the directory if files/directories exist
@@ -1831,7 +1831,7 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
         ret = fat_fillDirentryInfo(fatd, lname, sname, directory,
                                    startCluster, &sfnSector, &sfnOffset);
         if (ret != 0) {
-            XPRINTF("USBHDFSD: E: direntry not found!\n");
+            XPRINTF("E: direntry not found!\n");
             return -ENOENT;
         }
     }
@@ -1839,14 +1839,14 @@ static int fat_clearDirSpace(fat_driver *fatd, char *lname, char directory, unsi
     // now mark direntries as deleted
     ret = fat_wipeDirEntries(fatd);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: wipe direntries failed!\n");
+        XPRINTF("E: wipe direntries failed!\n");
         return ret;
     }
 
     // now delete whole cluster chain starting at the file's first cluster
     ret = fat_deleteClusterChain(fatd, *startCluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: delete cluster chain failed!\n");
+        XPRINTF("E: delete cluster chain failed!\n");
         return ret;
     }
     return 1;
@@ -1874,20 +1874,20 @@ int fat_truncateFile(fat_driver *fatd, unsigned int cluster, unsigned int sfnSec
     // now delete whole cluster chain starting at the file's first cluster
     ret = fat_deleteClusterChain(fatd, cluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: delete cluster chain failed!\n");
+        XPRINTF("E: delete cluster chain failed!\n");
         return ret;
     }
 
     // terminate cluster
     ret = fat_createClusterChain(fatd, cluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: truncate cluster chain failed!\n");
+        XPRINTF("E: truncate cluster chain failed!\n");
         return ret;
     }
 
     ret = READ_SECTOR(fatd->dev, sfnSector, sbuf);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: read direntry sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("read direntry sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     dsfn          = (fat_direntry_sfn *)(sbuf + sfnOffset);
@@ -1898,7 +1898,7 @@ int fat_truncateFile(fat_driver *fatd, unsigned int cluster, unsigned int sfnSec
 
     ret = WRITE_SECTOR(fatd->dev, sfnSector);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("write directory sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     return 1;
@@ -1926,7 +1926,7 @@ int fat_updateSfn(fat_driver *fatd, int size, unsigned int sfnSector, int sfnOff
 
     ret = READ_SECTOR(fatd->dev, sfnSector, sbuf);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: read direntry sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("read direntry sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
     dsfn          = (fat_direntry_sfn *)(sbuf + sfnOffset);
@@ -1939,10 +1939,10 @@ int fat_updateSfn(fat_driver *fatd, int size, unsigned int sfnSector, int sfnOff
 
     ret = WRITE_SECTOR(fatd->dev, sfnSector);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: write directory sector failed ! sector=%u\n", sfnSector);
+        XPRINTF("write directory sector failed ! sector=%u\n", sfnSector);
         return -EIO;
     }
-    XPRINTF("USBHDFSD: I: sfn updated, file size=%d \n", size);
+    XPRINTF("I: sfn updated, file size=%d \n", size);
     return 1;
 }
 
@@ -1974,25 +1974,25 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: file name not exist or not valid!");
+        XPRINTF("E: file name not exist or not valid!");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_createFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_createFile\n");
     // get start cluster of the last sub-directory of the path
     startCluster = 0;
     ret          = fat_getFileStartCluster(fatd, pathToDirent, &startCluster, &fatdir);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return ret;
     }
 
     if (!(fatdir.attr & FAT_ATTR_DIRECTORY)) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
+    XPRINTF("directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
 
     if (fatdir.attr & FAT_ATTR_READONLY)
         return -EACCES;
@@ -2002,10 +2002,10 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
     directoryCluster = startCluster;
     ret              = fat_modifyDirSpace(fatd, lname, directory, escapeNotExist, &startCluster, sfnSector, sfnOffset, NULL);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: modifyDirSpace failed!\n");
+        XPRINTF("E: modifyDirSpace failed!\n");
         return ret;
     }
-    XPRINTF("USBHDFSD: I: SFN info: sector=%u (%u)  offset=%u (%u) startCluster=%u\n", *sfnSector, *sfnSector * fatd->partBpb.sectorSize, *sfnOffset, *sfnOffset + (*sfnSector * fatd->partBpb.sectorSize), startCluster);
+    XPRINTF("I: SFN info: sector=%u (%u)  offset=%u (%u) startCluster=%u\n", *sfnSector, *sfnSector * fatd->partBpb.sectorSize, *sfnOffset, *sfnOffset + (*sfnSector * fatd->partBpb.sectorSize), startCluster);
     *cluster = startCluster;
     // dlanor: I've repatched the stuff below to improve functionality
     // The simple test below was bugged for the case of creating a folder in root
@@ -2020,7 +2020,7 @@ int fat_createFile(fat_driver *fatd, const char *fname, char directory, char esc
         || ((directoryCluster || !directory)      // OR working in non_root, or making a file
             && (startCluster != directoryCluster) // AND we get an unexpected startCluster
             )) {
-        XPRINTF("USBHDFSD: I: file already exists at cluster=%u\n", startCluster);
+        XPRINTF("I: file already exists at cluster=%u\n", startCluster);
         return EEXIST;
     }
     return 0;
@@ -2042,28 +2042,28 @@ int fat_deleteFile(fat_driver *fatd, const char *fname, char directory)
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: file name not exist or not valid!");
+        XPRINTF("E: file name not exist or not valid!");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_deleteFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_deleteFile\n");
     // get start cluster of the last sub-directory of the path
     startCluster = 0;
     ret          = fat_getFileStartCluster(fatd, pathToDirent, &startCluster, &fatdir);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return ret;
     }
 
     if (!(fatdir.attr & FAT_ATTR_DIRECTORY)) {
-        XPRINTF("USBHDFSD: E: directory not found! \n");
+        XPRINTF("E: directory not found! \n");
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
+    XPRINTF("directory=%s name=%s cluster=%u \n", pathToDirent, lname, startCluster);
 
     if (fatdir.attr & FAT_ATTR_READONLY) {
-        XPRINTF("USBHDFSD: E: directory read only! \n");
+        XPRINTF("E: directory read only! \n");
         return -EACCES;
     }
 
@@ -2071,11 +2071,11 @@ int fat_deleteFile(fat_driver *fatd, const char *fname, char directory)
     directoryCluster = startCluster;
     ret              = fat_clearDirSpace(fatd, lname, directory, &startCluster);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: cleanDirSpace failed!\n");
+        XPRINTF("E: cleanDirSpace failed!\n");
         return ret;
     }
     if (startCluster != directoryCluster) {
-        XPRINTF("USBHDFSD: I: file/dir removed from cluster=%u\n", startCluster);
+        XPRINTF("I: file/dir removed from cluster=%u\n", startCluster);
     }
     return 0;
 }
@@ -2102,18 +2102,18 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
             || ((lname[0] == '.') && ((lname[1] == 0)                          // or name is single period
                                       || ((lname[1] == '.') && (lname[2] == 0) // or name is two periods
                                           ))))) {
-        XPRINTF("USBHDFSD: E: destination file name not exist or not valid!");
+        XPRINTF("E: destination file name not exist or not valid!");
         return -ENOENT;
     }
 
     // Check if the source file exists, and that the new filename is not in use.
     sDirCluster = fatdir->parentDirCluster;
     dDirCluster = 0;
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fat_renameFile\n");
+    XPRINTF("Calling fat_getFileStartCluster from fat_renameFile\n");
 
     ret = fat_getFileStartCluster(fatd, pathToDirent, &dDirCluster, NULL);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: destination directory not found! \n");
+        XPRINTF("E: destination directory not found! \n");
         return ret;
     }
     dParentDirCluster = dDirCluster; // Backup dDirCluster, as every call to fat_filleDirentryInfo will update it to point to the scanned file's first cluster.
@@ -2122,15 +2122,15 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     sname[0] = 0;
     ret      = fat_fillDirentryInfo(fatd, fatdir->name, sname, -1, &sDirCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found! %d\n", ret);
+        XPRINTF("E: direntry not found! %d\n", ret);
         return -ENOENT;
     }
 
-    XPRINTF("USBHDFSD: fat_renameFile: dir found at  cluster=%u \n ", sDirCluster);
+    XPRINTF("fat_renameFile: dir found at  cluster=%u \n ", sDirCluster);
 
     // Preserve the original SFN entry.
     if ((ret = READ_SECTOR(fatd->dev, sfnSector, sbuf)) < 0) {
-        XPRINTF("USBHDFSD: E: I/O error! %d\n", ret);
+        XPRINTF("E: I/O error! %d\n", ret);
         return ret;
     }
     memcpy(&OriginalSFN, (fat_direntry_sfn *)(sbuf + sfnOffset), sizeof(fat_direntry_sfn));
@@ -2153,7 +2153,7 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     // Insert a new record.
     startCluster = dParentDirCluster;
     if ((ret = fat_modifyDirSpace(fatd, lname, srcIsDirectory, 0, &startCluster, &sfnSector, &sfnOffset, &OriginalSFN)) < 0) {
-        XPRINTF("USBHDFSD: E: fat_modifyDirSpace failed! %d\n", ret);
+        XPRINTF("E: fat_modifyDirSpace failed! %d\n", ret);
         return ret;
     }
 
@@ -2161,7 +2161,7 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     if (srcIsDirectory) {
         dDirCluster = (fatd->partBpb.fatType == FAT32) ? getUI32_2(OriginalSFN.clusterL, OriginalSFN.clusterH) : getUI16(OriginalSFN.clusterL);
         if ((ret = updateDirectoryParent(fatd, dDirCluster, dParentDirCluster)) != 0) {
-            XPRINTF("USBHDFSD: E: could not update \"..\" entry! %d\n", ret);
+            XPRINTF("E: could not update \"..\" entry! %d\n", ret);
             return ret;
         }
     }
@@ -2171,14 +2171,14 @@ int fat_renameFile(fat_driver *fatd, fat_dir *fatdir, const char *fname)
     sDirCluster = fatdir->parentDirCluster;
     ret         = fat_fillDirentryInfo(fatd, fatdir->name, sname, -1, &sDirCluster, &sfnSector, &sfnOffset);
     if (ret != 0) {
-        XPRINTF("USBHDFSD: E: direntry not found! %d\n", ret);
+        XPRINTF("E: direntry not found! %d\n", ret);
         return -ENOENT;
     }
 
     // now mark the original direntries as deleted
     ret = fat_wipeDirEntries(fatd);
     if (ret < 0) {
-        XPRINTF("USBHDFSD: E: wipe direntries failed!\n");
+        XPRINTF("E: wipe direntries failed!\n");
         return ret;
     }
 
@@ -2198,7 +2198,7 @@ static int fat_writeSingleSector(mass_dev *dev, unsigned int sector, const void 
         // Handle the partially-filled sector.
         ret = READ_SECTOR(dev, sector, sbuf);
         if (ret < 0) {
-            XPRINTF("USBHDFSD: Read sector failed ! sector=%u\n", sector);
+            XPRINTF("Read sector failed ! sector=%u\n", sector);
             return 0;
         }
 
@@ -2215,7 +2215,7 @@ static int fat_writeSingleSector(mass_dev *dev, unsigned int sector, const void 
 
         ret = WRITE_SECTORS_RAW(dev, sector, 1, buffer);
         if (ret != 0) {
-            XPRINTF("USBHDFSD: Write sector failed ! sector=%u\n", sector);
+            XPRINTF("Write sector failed ! sector=%u\n", sector);
             return 0;
         }
     }
@@ -2269,7 +2269,7 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
             j++;
         }
         lastCluster = fatDir->lastCluster;
-        XPRINTF("USBHDFSD: I: writeFile: last cluster= %u \n", lastCluster);
+        XPRINTF("I: writeFile: last cluster= %u \n", lastCluster);
 
         if (lastCluster == 0)
             return -ENOSPC; // no more free clusters or data invalid
@@ -2282,9 +2282,9 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
         *updateClusterIndices = j;
         fat_invalidateLastChainResult(fatd); // prevent to misuse current (now deleted) fatd->cbuf
 
-        XPRINTF("USBHDFSD: I: writeFile: new clusters allocated = %u new lastCluster=%u \n", j, lastCluster);
+        XPRINTF("I: writeFile: new clusters allocated = %u new lastCluster=%u \n", j, lastCluster);
     }
-    XPRINTF("USBHDFSD: I: write file: filePos=%d  dataSize=%d \n", filePos, size);
+    XPRINTF("I: write file: filePos=%d  dataSize=%d \n", filePos, size);
 
 
     fat_getClusterAtFilePos(fatd, fatDir, filePos, &fileCluster, &clusterPos);
@@ -2295,7 +2295,7 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
     bufferPos = 0;
 
 
-    XPRINTF("USBHDFSD: fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
+    XPRINTF("fileCluster = %u,  clusterPos= %u clusterSkip=%u, sectorSkip=%u dataSkip=%u \n",
             fileCluster, clusterPos, clusterSkip, sectorSkip, dataSkip);
 
     if (fileCluster < 2) {
@@ -2386,7 +2386,7 @@ int fat_writeFile(fat_driver *fatd, fat_dir *fatDir, int *updateClusterIndices, 
                     INVALIDATE_SECTORS(fatd->dev, startSector, toWrite);
                     ret = WRITE_SECTORS_RAW(fatd->dev, startSector, toWrite, buffer + bufferPos);
                     if (ret != 0) {
-                        XPRINTF("USBHDFSD: Write sectors failed ! sector=%u (%u)\n", startSector, toWrite);
+                        XPRINTF("Write sectors failed ! sector=%u (%u)\n", startSector, toWrite);
                         return bufferPos; // return number of bytes already written
                     }
 

--- a/iop/usb/usbhdfsd/src/fs_driver.c
+++ b/iop/usb/usbhdfsd/src/fs_driver.c
@@ -235,7 +235,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_open called: %s flags=%X mode=%X \n", name, flags, mode);
+    XPRINTF("fs_open called: %s flags=%X mode=%X \n", name, flags, mode);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -252,7 +252,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
     // find the file
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_open\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_open\n");
     ret = fat_getFileStartCluster(fatd, name, &cluster, &rec->dirent.fatdir);
     if (ret < 0 && ret != -ENOENT) {
         _fs_unlock();
@@ -278,7 +278,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
         escapeNotExist = 1;
         if (flags & O_CREAT) {
-            XPRINTF("USBHDFSD: FAT I: O_CREAT detected!\n");
+            XPRINTF("FAT I: O_CREAT detected!\n");
             escapeNotExist = 0;
         }
 
@@ -292,11 +292,11 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
         }
         // the file already exist but flags is set to truncate
         if (ret == EEXIST && (flags & O_TRUNC)) {
-            XPRINTF("USBHDFSD: FAT I: O_TRUNC detected!\n");
+            XPRINTF("FAT I: O_TRUNC detected!\n");
             ret = fat_truncateFile(fatd, cluster, rec->sfnSector, rec->sfnOffset);
             if (ret < 0) {
                 FLUSH_SECTORS(fatd);
-                XPRINTF("USBHDFSD: FAT E: failed to truncate!\n");
+                XPRINTF("FAT E: failed to truncate!\n");
                 _fs_unlock();
                 return ret;
             }
@@ -304,7 +304,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 
         // find the file
         cluster = 0; // allways start from root
-        XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_open after file creation\n");
+        XPRINTF("Calling fat_getFileStartCluster from fs_open after file creation\n");
         ret = fat_getFileStartCluster(fatd, name, &cluster, &rec->dirent.fatdir);
     }
 
@@ -325,7 +325,7 @@ static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
     rec->sizeChange       = 0;
 
     if ((flags & O_APPEND) && (flags & O_WRONLY)) {
-        XPRINTF("USBHDFSD: FAT I: O_APPEND detected!\n");
+        XPRINTF("FAT I: O_APPEND detected!\n");
         rec->filePos = rec->dirent.fatdir.size;
     }
 
@@ -537,7 +537,7 @@ static int fs_remove(iop_file_t *fd, const char *name)
     }
 
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_remove\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_remove\n");
     result = fat_getFileStartCluster(fatd, name, &cluster, &fatdir);
     if (result < 0) {
         _fs_unlock();
@@ -579,7 +579,7 @@ static int fs_mkdir(iop_file_t *fd, const char *name, int mode)
         return -ENODEV;
     }
 
-    XPRINTF("USBHDFSD: fs_mkdir: name=%s \n", name);
+    XPRINTF("fs_mkdir: name=%s \n", name);
     ret = fat_createFile(fatd, name, 1, 0, &cluster, &sfnSector, &sfnOffset);
 
     // directory of the same name already exist
@@ -621,7 +621,7 @@ static int fs_dopen(iop_file_t *fd, const char *name)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_dopen called: unit %d name %s\n", fd->unit, name);
+    XPRINTF("fs_dopen called: unit %d name %s\n", fd->unit, name);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -660,7 +660,7 @@ static int fs_dclose(iop_file_t *fd)
         return -EBADF;
 
     _fs_lock();
-    XPRINTF("USBHDFSD: fs_dclose called: unit %d\n", fd->unit);
+    XPRINTF("fs_dclose called: unit %d\n", fd->unit);
     if (rec->dirent.file_flag != FS_FILE_FLAG_FOLDER) {
         _fs_unlock();
         return -ENOTDIR;
@@ -684,7 +684,7 @@ static int fs_dread(iop_file_t *fd, iox_dirent_t *buffer)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_dread called: unit %d\n", fd->unit);
+    XPRINTF("fs_dread called: unit %d\n", fd->unit);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -724,7 +724,7 @@ static int fs_getstat(iop_file_t *fd, const char *name, iox_stat_t *stat)
 
     _fs_lock();
 
-    XPRINTF("USBHDFSD: fs_getstat called: unit %d name %s\n", fd->unit, name);
+    XPRINTF("fs_getstat called: unit %d name %s\n", fd->unit, name);
 
     fatd = fat_getData(fd->unit);
     if (fatd == NULL) {
@@ -732,7 +732,7 @@ static int fs_getstat(iop_file_t *fd, const char *name, iox_stat_t *stat)
         return -ENODEV;
     }
 
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_getstat\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_getstat\n");
     ret = fat_getFileStartCluster(fatd, name, &cluster, &fatdir);
     if (ret < 0) {
         _fs_unlock();
@@ -808,7 +808,7 @@ int fs_rename(iop_file_t *fd, const char *path, const char *newpath)
 
     // find the file
     cluster = 0; // allways start from root
-    XPRINTF("USBHDFSD: Calling fat_getFileStartCluster from fs_rename\n");
+    XPRINTF("Calling fat_getFileStartCluster from fs_rename\n");
     ret = fat_getFileStartCluster(fatd, path, &cluster, &fatdir);
     if (ret < 0 && ret != -ENOENT) {
         _fs_unlock();

--- a/iop/usb/usbhdfsd/src/include/mass_debug.h
+++ b/iop/usb/usbhdfsd/src/include/mass_debug.h
@@ -1,8 +1,9 @@
 #ifndef _MASS_DEBUG_H
 #define _MASS_DEBUG_H 1
 
+#define MODNAME "usbhdfsd"
 #ifdef DEBUG
-#define XPRINTF(args...) printf(args)
+#define XPRINTF(args...) printf(MODNAME ": " args)
 #else
 #define XPRINTF(args...) \
     do {                 \

--- a/iop/usb/usbhdfsd/src/part_driver.c
+++ b/iop/usb/usbhdfsd/src/part_driver.c
@@ -72,7 +72,7 @@ static int part_getPartitionTable(mass_dev *dev, part_table *part)
 
     ret = READ_SECTOR(dev, 0, sbuf); // read sector 0 - Disk MBR or boot sector
     if (ret < 0) {
-        XPRINTF("USBHDFSD: part_getPartitionTable read failed %d!\n", ret);
+        XPRINTF("part_getPartitionTable read failed %d!\n", ret);
         return -EIO;
     }
 
@@ -108,7 +108,7 @@ int part_connect(mass_dev *dev)
 {
     part_table partTable;
     int parts;
-    XPRINTF("USBHDFSD: part_connect devId %i \n", dev->devId);
+    XPRINTF("part_connect devId %i \n", dev->devId);
 
     if ((parts = part_getPartitionTable(dev, &partTable)) < 0)
         return -1;
@@ -124,7 +124,7 @@ int part_connect(mass_dev *dev)
                 partTable.record[i].sid == 0x0C || // fat 32
                 partTable.record[i].sid == 0x0E)   // fat 16 LBA
             {
-                XPRINTF("USBHDFSD: mount partition %d id %02x\n", i, partTable.record[i].sid);
+                XPRINTF("mount partition %d id %02x\n", i, partTable.record[i].sid);
                 if (fat_mount(dev, partTable.record[i].start, partTable.record[i].count) >= 0)
                     count++;
             }

--- a/iop/usb/usbhdfsd/src/usb_driver.c
+++ b/iop/usb/usbhdfsd/src/usb_driver.c
@@ -133,7 +133,7 @@ static void usb_callback(int resultCode, int bytes, void *arg)
     usb_callback_data *data = (usb_callback_data *)arg;
     data->returnCode        = resultCode;
     data->returnSize        = bytes;
-    XPRINTF("USBHDFSD: callback: res %d, bytes %d, arg %p \n", resultCode, bytes, arg);
+    XPRINTF("callback: res %d, bytes %d, arg %p \n", resultCode, bytes, arg);
     SignalSema(data->sema);
 }
 
@@ -181,7 +181,7 @@ static int usb_set_configuration(mass_dev *dev, int configNumber)
 
     cb_data.sema = dev->ioSema;
 
-    XPRINTF("USBHDFSD: setting configuration controlEp=%i, confNum=%i \n", dev->controlEp, configNumber);
+    XPRINTF("setting configuration controlEp=%i, confNum=%i \n", dev->controlEp, configNumber);
     ret = sceUsbdSetConfiguration(dev->controlEp, configNumber, usb_callback, (void *)&cb_data);
 
     if (ret == USB_RC_OK) {
@@ -199,7 +199,7 @@ static int usb_set_interface(mass_dev *dev, int interface, int altSetting)
 
     cb_data.sema = dev->ioSema;
 
-    XPRINTF("USBHDFSD: setting interface controlEp=%i, interface=%i altSetting=%i\n", dev->controlEp, interface, altSetting);
+    XPRINTF("setting interface controlEp=%i, interface=%i altSetting=%i\n", dev->controlEp, interface, altSetting);
     ret = sceUsbdSetInterface(dev->controlEp, interface, altSetting, usb_callback, (void *)&cb_data);
 
     if (ret == USB_RC_OK) {
@@ -301,7 +301,7 @@ static int usb_bulk_status(mass_dev *dev, csw_packet *csw, unsigned int tag)
             printf("USBHDFSD: bulk csw.status returnSize: %i != 13\n", cb_data.returnSize);
         if (csw->dataResidue != 0)
             printf("USBHDFSD: bulk csw.status residue: %u\n", csw->dataResidue);
-        XPRINTF("USBHDFSD: bulk csw result: %d, csw.status: %u\n", ret, csw->status);
+        XPRINTF("bulk csw result: %d, csw.status: %u\n", ret, csw->status);
     }
 
     return ret;
@@ -320,7 +320,7 @@ static int usb_bulk_manage_status(mass_dev *dev, unsigned int tag)
     int ret;
     csw_packet csw;
 
-    // XPRINTF("USBHDFSD: usb_bulk_manage_status 1 ...\n");
+    // XPRINTF("usb_bulk_manage_status 1 ...\n");
     ret = usb_bulk_status(dev, &csw, tag);       /* Attempt to read CSW from bulk in endpoint */
     if (ret != USB_RC_OK) {                      /* STALL bulk in  -OR- Bulk error */
         usb_bulk_clear_halt(dev, USB_BLK_EP_IN); /* clear the stall condition for bulk in */
@@ -458,7 +458,7 @@ static int cbw_scsi_test_unit_ready(mass_dev *dev)
             0,    // reserved
         }};
 
-    XPRINTF("USBHDFSD: cbw_scsi_test_unit_ready\n");
+    XPRINTF("cbw_scsi_test_unit_ready\n");
 
     for (result = -EIO, retries = USB_XFER_MAX_RETRIES; retries > 0; retries--) {
         if (usb_bulk_command(dev, &cbw) == USB_RC_OK) {
@@ -500,7 +500,7 @@ static int cbw_scsi_request_sense(mass_dev *dev, void *buffer, int size)
     cbw.dataTransferLength = size;
     cbw.comData[4]         = size;
 
-    XPRINTF("USBHDFSD: cbw_scsi_request_sense\n");
+    XPRINTF("cbw_scsi_request_sense\n");
 
     for (retries = USB_XFER_MAX_RETRIES; retries > 0; retries--) {
         if (usb_bulk_command(dev, &cbw) == USB_RC_OK) {
@@ -542,7 +542,7 @@ static int cbw_scsi_inquiry(mass_dev *dev, void *buffer, int size)
             0,    // reserved
         }};
 
-    XPRINTF("USBHDFSD: cbw_scsi_inquiry\n");
+    XPRINTF("cbw_scsi_inquiry\n");
 
     cbw.dataTransferLength = size; // INQUIRY_REPLY_LENGTH
     cbw.comData[4]         = size; // inquiry reply length
@@ -587,7 +587,7 @@ static int cbw_scsi_start_stop_unit(mass_dev *dev, u8 param)
             0,    // reserved
         }};
 
-    XPRINTF("USBHDFSD: cbw_scsi_start_stop_unit. param: %02x\n", param);
+    XPRINTF("cbw_scsi_start_stop_unit. param: %02x\n", param);
 
     cbw.comData[4] = param;
 
@@ -630,7 +630,7 @@ static int cbw_scsi_read_capacity(mass_dev *dev, void *buffer, int size)
 
     cbw.dataTransferLength = size;
 
-    XPRINTF("USBHDFSD: cbw_scsi_read_capacity\n");
+    XPRINTF("cbw_scsi_read_capacity\n");
 
     for (retries = USB_XFER_MAX_RETRIES; retries > 0; retries--) {
         if (usb_bulk_command(dev, &cbw) == USB_RC_OK) {
@@ -671,7 +671,7 @@ static int cbw_scsi_read_sector(mass_dev *dev, unsigned int lba, void *buffer, u
             0,    // reserved
             0,    // reserved
         }};
-    XPRINTF("USBHDFSD: cbw_scsi_read_sector - 0x%08x %p 0x%04x\n", lba, buffer, sectorCount);
+    XPRINTF("cbw_scsi_read_sector - 0x%08x %p 0x%04x\n", lba, buffer, sectorCount);
 
     cbw.dataTransferLength = dev->sectorSize * sectorCount;
 
@@ -723,7 +723,7 @@ static int cbw_scsi_write_sector(mass_dev *dev, unsigned int lba, const void *bu
             0,    // reserved
             0,    // reserved
         }};
-    XPRINTF("USBHDFSD: cbw_scsi_write_sector - 0x%08x %p 0x%04x\n", lba, buffer, sectorCount);
+    XPRINTF("cbw_scsi_write_sector - 0x%08x %p 0x%04x\n", lba, buffer, sectorCount);
 
     cbw.dataTransferLength = dev->sectorSize * sectorCount;
 
@@ -753,10 +753,10 @@ static mass_dev *mass_stor_findDevice(int devId, int create)
 {
     mass_dev *dev = NULL;
     int i;
-    XPRINTF("USBHDFSD: mass_stor_findDevice devId %i\n", devId);
+    XPRINTF("mass_stor_findDevice devId %i\n", devId);
     for (i = 0; i < NUM_DEVICES; ++i) {
         if (g_mass_device[i].devId == devId) {
-            XPRINTF("USBHDFSD: mass_stor_findDevice exists %i\n", i);
+            XPRINTF("mass_stor_findDevice exists %i\n", i);
             dev = &g_mass_device[i];
             break;
         } else if (create && dev == NULL && g_mass_device[i].devId == -1) {
@@ -800,7 +800,7 @@ static void usb_bulk_probeEndpoint(int devId, mass_dev *dev, UsbEndpointDescript
             /* When sceUsbdOpenPipe() is used to work around the hardware errata that occurs when an unaligned memory address is specified,
                some USB devices become incompatible. Hence it is preferable to do alignment correction in software instead. */
             dev->bulkEpO = sceUsbdOpenPipeAligned(devId, endpoint);
-            XPRINTF("USBHDFSD: register Output endpoint id =%i addr=%02X packetSize=%i\n", dev->bulkEpO, endpoint->bEndpointAddress, (unsigned short int)endpoint->wMaxPacketSizeHB << 8 | endpoint->wMaxPacketSizeLB);
+            XPRINTF("register Output endpoint id =%i addr=%02X packetSize=%i\n", dev->bulkEpO, endpoint->bEndpointAddress, (unsigned short int)endpoint->wMaxPacketSizeHB << 8 | endpoint->wMaxPacketSizeLB);
         } else
             /* in transfer */
             if ((endpoint->bEndpointAddress & USB_ENDPOINT_DIR_MASK) == USB_DIR_IN && dev->bulkEpI < 0) {
@@ -809,7 +809,7 @@ static void usb_bulk_probeEndpoint(int devId, mass_dev *dev, UsbEndpointDescript
                    there is always an alignment check if the pipe is opened with the sceUsbdOpenPipeAligned(),
                    even when there is never any correction for the bulk out pipe. */
                 dev->bulkEpI = sceUsbdOpenPipe(devId, endpoint);
-                XPRINTF("USBHDFSD: register Input endpoint id =%i addr=%02X packetSize=%i\n", dev->bulkEpI, endpoint->bEndpointAddress, (unsigned short int)endpoint->wMaxPacketSizeHB << 8 | endpoint->wMaxPacketSizeLB);
+                XPRINTF("register Input endpoint id =%i addr=%02X packetSize=%i\n", dev->bulkEpI, endpoint->bEndpointAddress, (unsigned short int)endpoint->wMaxPacketSizeHB << 8 | endpoint->wMaxPacketSizeLB);
             }
     }
 }
@@ -820,7 +820,7 @@ int mass_stor_probe(int devId)
     UsbConfigDescriptor *config  = NULL;
     UsbInterfaceDescriptor *intf = NULL;
 
-    XPRINTF("USBHDFSD: probe: devId=%i\n", devId);
+    XPRINTF("probe: devId=%i\n", devId);
 
     mass_dev *mass_device = mass_stor_findDevice(devId, 0);
 
@@ -849,7 +849,7 @@ int mass_stor_probe(int devId)
         return 0;
     }
     /* check that at least one interface exists */
-    XPRINTF("USBHDFSD: bNumInterfaces %d\n", config->bNumInterfaces);
+    XPRINTF("bNumInterfaces %d\n", config->bNumInterfaces);
     if ((config->bNumInterfaces < 1) ||
         (config->wTotalLength < (sizeof(UsbConfigDescriptor) + sizeof(UsbInterfaceDescriptor)))) {
         printf("USBHDFSD: Error - No interfaces available\n");
@@ -857,7 +857,7 @@ int mass_stor_probe(int devId)
     }
     /* get interface */
     intf = (UsbInterfaceDescriptor *)((char *)config + config->bLength); /* Get first interface */
-    XPRINTF("USBHDFSD: bInterfaceClass %X bInterfaceSubClass %X bInterfaceProtocol %X\n",
+    XPRINTF("bInterfaceClass %X bInterfaceSubClass %X bInterfaceProtocol %X\n",
             intf->bInterfaceClass, intf->bInterfaceSubClass, intf->bInterfaceProtocol);
 
     if ((intf->bInterfaceClass != USB_CLASS_MASS_STORAGE) ||
@@ -944,7 +944,7 @@ int mass_stor_connect(int devId)
     dev->devId    = devId;
     dev->configId = config->bConfigurationValue;
     dev->status   = USBMASS_DEV_STAT_CONN;
-    XPRINTF("USBHDFSD: connect ok: epI=%i, epO=%i \n", dev->bulkEpI, dev->bulkEpO);
+    XPRINTF("connect ok: epI=%i, epO=%i \n", dev->bulkEpI, dev->bulkEpO);
 
     if (dev->callback != NULL)
         dev->callback(USBMASS_DEV_EV_CONN);
@@ -1003,7 +1003,7 @@ static int mass_stor_warmup(mass_dev *dev)
     read_capacity_data rcd;
     int stat;
 
-    XPRINTF("USBHDFSD: mass_stor_warmup\n");
+    XPRINTF("mass_stor_warmup\n");
 
     if (!(dev->status & USBMASS_DEV_STAT_CONN)) {
         printf("USBHDFSD: Error - no mass storage device found!\n");
@@ -1083,7 +1083,7 @@ int mass_stor_configureNextDevice(void)
 {
     int i;
 
-    XPRINTF("USBHDFSD: configuring devices... \n");
+    XPRINTF("configuring devices... \n");
 
     for (i = 0; i < NUM_DEVICES; ++i) {
         mass_dev *dev = &g_mass_device[i];
@@ -1134,7 +1134,7 @@ int InitUSB(void)
     driver.disconnect = mass_stor_disconnect;
 
     ret = sceUsbdRegisterLdd(&driver);
-    XPRINTF("USBHDFSD: registerDriver=%i \n", ret);
+    XPRINTF("registerDriver=%i \n", ret);
     if (ret < 0) {
         printf("USBHDFSD: register driver failed! ret=%d\n", ret);
         return (-1);

--- a/iop/usb/usbhdfsd/src/usbhdfsd.c
+++ b/iop/usb/usbhdfsd/src/usbhdfsd.c
@@ -12,8 +12,8 @@
 #include <usbhdfsd.h>
 
 #include <irx.h>
-
-IRX_ID("usbhdfsd", MAJOR_VER, MINOR_VER);
+#include "mass_debug.h"
+IRX_ID(MODNAME, MAJOR_VER, MINOR_VER);
 
 extern int InitFAT();
 extern int InitFS();

--- a/iop/usb/usbmass_bd/src/include/module_debug.h
+++ b/iop/usb/usbmass_bd/src/include/module_debug.h
@@ -1,8 +1,9 @@
 #ifndef _MODULE_DEBUG_H
 #define _MODULE_DEBUG_H
 
+#define MODNAME   "usbmass_bd"
 #ifndef MINI_DRIVER
-#define M_PRINTF(format, args...) printf("USBMASS: " format, ##args)
+#define M_PRINTF(format, args...) printf(MODNAME ": " format, ##args)
 #else
 #define M_PRINTF(format, args...) \
     do {                          \

--- a/iop/usb/usbmass_bd/src/main.c
+++ b/iop/usb/usbmass_bd/src/main.c
@@ -1,6 +1,5 @@
 #define MAJOR_VER 1
 #define MINOR_VER 1
-#define MODNAME   "usbmass_bd"
 
 #include "scsi.h"
 #include <irx.h>


### PR DESCRIPTION
- enforce modname as a prefix on printf's of some modules
- encase some printf inside macros, so they're not added when building non debug (left all those "Welcome" printf intact
- unify printf macros into single header for certain modules