### PR TITLE
[EE Makefile]: imitate IOP Makefiles

### DIFF
--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -50,6 +50,8 @@ endif
 
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
 
+EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
+
 # These macros can be used to simplify certain build rules.
 EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
 EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
@@ -57,23 +59,31 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 # Command for ensuring the output directory for the rule exists.
 DIR_GUARD = @$(MKDIR) -p $(@D)
 
-%.o: %.c
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c
 	$(DIR_GUARD)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o: %.cc
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cc
 	$(DIR_GUARD)
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o: %.cpp
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cpp
 	$(DIR_GUARD)
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o: %.S
+$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.S
 	$(DIR_GUARD)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-%.o: %.s
+$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.s
+	$(DIR_GUARD)
+	$(EE_AS) $(EE_ASFLAGS) $< -o $@
+
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.S
+	$(DIR_GUARD)
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.s
 	$(DIR_GUARD)
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 


### PR DESCRIPTION
Allow developers to change source files location and object files output location without copy pasting recipes. just declaring the `EE_*_DIR` variables