### PR TITLE
FatFS: Mount immediately so we can return ok/error

### DIFF
--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -157,7 +157,7 @@ static FRESULT fatfs_fs_driver_mount_bd(int mount_info_index, struct block_devic
     mount_point[2] = '\x00';
 
     fs_driver_mount_info[mount_info_index].mounted_bd = bd;
-    ret = f_mount(&(fs_driver_mount_info[mount_info_index].fatfs), mount_point, 0);
+    ret = f_mount(&(fs_driver_mount_info[mount_info_index].fatfs), mount_point, 1);
     if (ret != FR_OK) {
         fs_driver_mount_info[mount_info_index].mounted_bd = NULL;
     }


### PR DESCRIPTION
The description of this changed parameter:
`Mount option: 0=Do not mount (delayed mount), 1=Mount immediately`

Setting this to 0 will always return succes, even if the filesystem is not supported. We need to "mount immediately" so we can report back to BDM if this is a supported filesystem, or not.

This also solves an issue in OPL when you have 2 partitions:
- the first being an usupported partition (like ntfs, ext4, etc...) - that would falsely be mounted as "mass0"
- the second being the partition with games - that would not show up

@grimdoomer do you agree on this PR, or do you have other things in the works that solve the same issue?