### PR TITLE
Be sure we restore pointer glue I/O functions when deinit flieXio

### DIFF
--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -36,6 +36,28 @@ static int fileXioInited = 0;
 static int fileXioBlockMode;
 static int fileXioCompletionSema = -1;
 
+/* Backup pointer functions to restore after exit fileXio */
+static int (*_backup_ps2sdk_close)(int);
+static int (*_backup_ps2sdk_open)(const char*, int, ...);
+static int (*_backup_ps2sdk_read)(int, void*, int);
+static int (*_backup_ps2sdk_lseek)(int, int, int);
+static int64_t (*_backup_ps2sdk_lseek64)(int, int64_t, int);
+static int (*_backup_ps2sdk_write)(int, const void*, int);
+static int (*_backup_ps2sdk_ioctl)(int, int, void*);
+static int (*_backup_ps2sdk_remove)(const char*);
+static int (*_backup_ps2sdk_rename)(const char*, const char*);
+static int (*_backup_ps2sdk_mkdir)(const char*, int);
+static int (*_backup_ps2sdk_rmdir)(const char*);
+
+static int (*_backup_ps2sdk_stat)(const char *path, struct stat *buf);
+static int (*_backup_ps2sdk_readlink)(const char *path, char *buf, size_t bufsiz);
+static int (*_backup_ps2sdk_symlink)(const char *target, const char *linkpath);
+
+static DIR * (*_backup_ps2sdk_opendir)(const char *path);
+static struct dirent * (*_backup_ps2sdk_readdir)(DIR *dir);
+static void (*_backup_ps2sdk_rewinddir)(DIR *dir);
+static int (*_backup_ps2sdk_closedir)(DIR *dir);
+
 static void _fxio_intr(void)
 {
 	iSignalSema(fileXioCompletionSema);
@@ -216,25 +238,43 @@ static int fileXioInitHelper(int overrideNewlibMethods)
 
 	if (overrideNewlibMethods) 
 	{
+		_backup_ps2sdk_close = _ps2sdk_close;
 		_ps2sdk_close = fileXioClose;
+		_backup_ps2sdk_open = _ps2sdk_open;
 		_ps2sdk_open = fileXioOpen;
+		_backup_ps2sdk_read = _ps2sdk_read;
 		_ps2sdk_read = fileXioRead;
+		_backup_ps2sdk_lseek = _ps2sdk_lseek;
 		_ps2sdk_lseek = fileXioLseek;
+		_backup_ps2sdk_lseek64 = _ps2sdk_lseek64;
 		_ps2sdk_lseek64 = fileXioLseek64;
+		_backup_ps2sdk_write = _ps2sdk_write;
 		_ps2sdk_write = fileXioWrite;
+		_backup_ps2sdk_ioctl = _ps2sdk_ioctl;
 		_ps2sdk_ioctl = fileXioIoctl;
+		_backup_ps2sdk_remove = _ps2sdk_remove;
 		_ps2sdk_remove= fileXioRemove;
+		_backup_ps2sdk_rename = _ps2sdk_rename;
 		_ps2sdk_rename= fileXioRename;
+		_backup_ps2sdk_mkdir = _ps2sdk_mkdir;
 		_ps2sdk_mkdir = fileXioMkdir;
+		_backup_ps2sdk_rmdir = _ps2sdk_rmdir;
 		_ps2sdk_rmdir = fileXioRmdir;
+		_backup_ps2sdk_readlink = _ps2sdk_readlink;
 		_ps2sdk_readlink = fileXioReadlink;
+		_backup_ps2sdk_symlink = _ps2sdk_symlink;
 		_ps2sdk_symlink = fileXioSymlink;
 
+		_backup_ps2sdk_stat = _ps2sdk_stat;
 		_ps2sdk_stat = fileXioGetstatHelper;
 
+		_backup_ps2sdk_opendir = _ps2sdk_opendir;
 		_ps2sdk_opendir = fileXioOpendirHelper;
+		_backup_ps2sdk_readdir = _ps2sdk_readdir;
 		_ps2sdk_readdir = fileXioReaddirHelper;
+		_backup_ps2sdk_rewinddir = _ps2sdk_rewinddir;
 		_ps2sdk_rewinddir = fileXioRewinddirHelper;
+		_backup_ps2sdk_closedir = _ps2sdk_closedir;
 		_ps2sdk_closedir = fileXioClosedirHelper;
 	}
 
@@ -261,6 +301,81 @@ void fileXioExit(void)
 		memset(&cd0, 0, sizeof(cd0));
 
 		fileXioInited = 0;
+	}
+
+	if (_backup_ps2sdk_close) {
+		_ps2sdk_close = _backup_ps2sdk_close;
+		_backup_ps2sdk_close = NULL;	
+	} 
+	if (_backup_ps2sdk_open) {
+		_ps2sdk_open = _backup_ps2sdk_open;
+		_backup_ps2sdk_open = NULL;	
+	} 
+	if (_backup_ps2sdk_read) {
+		_ps2sdk_read = _backup_ps2sdk_read;
+		_backup_ps2sdk_read = NULL;	
+	} 
+	if (_backup_ps2sdk_lseek) {
+		_ps2sdk_lseek = _backup_ps2sdk_lseek;
+		_backup_ps2sdk_lseek = NULL;	
+	} 
+	if (_backup_ps2sdk_lseek64) {
+		_ps2sdk_lseek64 = _backup_ps2sdk_lseek64;
+		_backup_ps2sdk_lseek64 = NULL;	
+	} 
+	if (_backup_ps2sdk_write) {
+		_ps2sdk_write = _backup_ps2sdk_write;
+		_backup_ps2sdk_write = NULL;	
+	} 
+	if (_backup_ps2sdk_ioctl) {
+		_ps2sdk_ioctl = _backup_ps2sdk_ioctl;
+		_backup_ps2sdk_ioctl = NULL;	
+	} 
+	if (_backup_ps2sdk_remove) {
+		_ps2sdk_remove = _backup_ps2sdk_remove;
+		_backup_ps2sdk_remove = NULL;	
+	} 
+	if (_backup_ps2sdk_rename) {
+		_ps2sdk_rename = _backup_ps2sdk_rename;
+		_backup_ps2sdk_rename = NULL;	
+	} 
+	if (_backup_ps2sdk_mkdir) {
+		_ps2sdk_mkdir = _backup_ps2sdk_mkdir;
+		_backup_ps2sdk_mkdir = NULL;	
+	} 
+	if (_backup_ps2sdk_rmdir) {
+		_ps2sdk_rmdir = _backup_ps2sdk_rmdir;
+		_backup_ps2sdk_rmdir = NULL;	
+	} 
+	if (_backup_ps2sdk_readlink) {
+		_ps2sdk_readlink = _backup_ps2sdk_readlink;
+		_backup_ps2sdk_readlink = NULL;	
+	} 
+	if (_backup_ps2sdk_symlink) {
+		_ps2sdk_symlink = _backup_ps2sdk_symlink;
+		_backup_ps2sdk_symlink = NULL;	
+	} 
+
+	if (_backup_ps2sdk_stat) {
+		_ps2sdk_stat = _backup_ps2sdk_stat;
+		_backup_ps2sdk_stat = NULL;
+	}
+
+	if (_backup_ps2sdk_opendir) {
+		_ps2sdk_opendir = _backup_ps2sdk_opendir;
+		_backup_ps2sdk_opendir = NULL;
+	}
+	if (_backup_ps2sdk_readdir) {
+		_ps2sdk_readdir = _backup_ps2sdk_readdir;
+		_backup_ps2sdk_readdir = NULL;
+	}
+	if (_backup_ps2sdk_rewinddir) {
+		_ps2sdk_rewinddir = _backup_ps2sdk_rewinddir;
+		_backup_ps2sdk_rewinddir = NULL;
+	}
+	if (_backup_ps2sdk_closedir) {
+		_ps2sdk_closedir = _backup_ps2sdk_closedir;
+		_backup_ps2sdk_closedir = NULL;
 	}
 }
 


### PR DESCRIPTION
This PRs has been created for solving #425 .

The problem was that after integrating newlib we created a bunch of pointer functions, to be able to support `fileXio` and `fio`:

https://github.com/ps2dev/ps2sdk/blob/master/ee/libcglue/include/ps2sdkapi.h#L20-L39

These functions by default are pointing to `fio`, however after loading `fileXio` irxs and calling to `fileXioInit();` all these functions are then pointing to `fileXio`. 
If we decide to `reset_IOP` we need to assure that we are pointing back these pointer functions to the original ones from `fio` otherwise, it will try to call some `fileXio` functions from IOP which aren't loaded anymore, having a beautiful frozen app.

The solution has been to keep a backup of the previous reference of the pointer functions, restoring them when calling `fileXioExit();`

So the way of using it should be:
```c
extern unsigned char iomanX_irx[] __attribute__((aligned(16)));
extern unsigned int size_iomanX_irx;

extern unsigned char fileXio_irx[] __attribute__((aligned(16)));
extern unsigned int size_fileXio_irx;

static void reset_IOP() {
   SifExitRpc();
   SifInitRpc(0);

   while(!SifIopReset(NULL, 0x80000000)){};

   while(!SifIopSync()){};
   SifInitRpc(0);
   sbv_patch_enable_lmb();
   sbv_patch_disable_prefix_check();
}

static void init_drivers() {
   SifExecModuleBuffer(&iomanX_irx, size_iomanX_irx, 0, NULL, NULL);
   SifExecModuleBuffer(&fileXio_irx, size_fileXio_irx, 0, NULL, NULL);

   fileXioInit();
}

static void deinit_drivers() {
   fileXioExit();
}

int main()
{
   reset_IOP();
   init_drivers();
   printf("Hello world with fileXio loaded!\n");

   deinit_drivers();
   reset_IOP();
   printf("Hello world after reset IOP!\n");
   return 0;
}
```

Close #425 

Cheers