### PR TITLE
Revert "[EE Makefile]: imitate IOP Makefiles"

### DIFF
--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -50,8 +50,6 @@ endif
 
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
 
-EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
-
 # These macros can be used to simplify certain build rules.
 EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
 EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
@@ -59,31 +57,23 @@ EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 # Command for ensuring the output directory for the rule exists.
 DIR_GUARD = @$(MKDIR) -p $(@D)
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c
+%.o: %.c
 	$(DIR_GUARD)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cc
+%.o: %.cc
 	$(DIR_GUARD)
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cpp
+%.o: %.cpp
 	$(DIR_GUARD)
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.S
+%.o: %.S
 	$(DIR_GUARD)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.s
-	$(DIR_GUARD)
-	$(EE_AS) $(EE_ASFLAGS) $< -o $@
-
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.S
-	$(DIR_GUARD)
-	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
-
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.s
+%.o: %.s
 	$(DIR_GUARD)
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 


### PR DESCRIPTION
Reverts ps2dev/ps2sdk#421

Because it is making `ps2sdk-ports` to not compile, some `makefile` over there needs to be updated.

@israpps is already working on it, he will create the PR back, when the other PRs from `ps2sdk-ports` were ready.

Cheers.