### PR TITLE
Added some vnops to allow time for the clip flags to update in calculate_vertices

### DIFF
--- a/ee/math3d/src/math3d.c
+++ b/ee/math3d/src/math3d.c
@@ -600,6 +600,10 @@ void vector_triangle_normal(VECTOR output, VECTOR a, VECTOR b, VECTOR c) {
    "vmadday		$ACC, $vf2, $vf6\n"
    "vmaddz		$vf7, $vf3, $vf6\n"
    "vclipw.xyz		$vf7, $vf7	\n" // FIXME: Clip detection is still kinda broken.
+   "vnop                                \n"
+   "vnop                                \n"
+   "vnop                                \n"
+   "vnop                                \n"
    "cfc2		$10, $18	\n"
    "beq			$10, $0, 3f	\n"
    "2:					\n"
@@ -621,7 +625,11 @@ void vector_triangle_normal(VECTOR output, VECTOR a, VECTOR b, VECTOR c) {
    "vmaddax		ACC, vf1, vf6	\n"
    "vmadday		ACC, vf2, vf6	\n"
    "vmaddz		vf7, vf3, vf6	\n"
-   "vclipw.xyz		vf7, vf7	\n" // FIXME: Clip detection is still kinda broken.
+   "vclipw.xyz		vf7, vf7	\n"
+   "vnop                                \n"
+   "vnop                                \n"
+   "vnop                                \n"
+   "vnop                                \n" // FIXME: Clip detection is still kinda broken.
    "cfc2		$10, $18	\n"
    "beq			$10, $0, 3f	\n"
    "2:					\n"


### PR DESCRIPTION
On the PS2, the clip flag is pipelined, and takes approximately 3-4 cycles to complete after a `vclipw`. This pull request adds 4 `vnops` after `vclipw` in the `calculate_vertices` function to allow time for the flag to properly update. This should fix the broken clipping seen in `cube.elf`.