### PR TITLE
Fixes for ATA BDM

### DIFF
--- a/iop/dev9/ata_bd/Makefile
+++ b/iop/dev9/ata_bd/Makefile
@@ -11,4 +11,6 @@ IOP_INC_DIR = $(PS2SDKSRC)/iop/dev9/atad/include/
 
 ATA_ENABLE_BDM ?= 1
 
+IOP_BIN ?= ata_bd.irx
+
 include $(PS2SDKSRC)/iop/dev9/atad/Makefile

--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -315,13 +315,16 @@ int _start(int argc, char *argv[])
             g_ata_bd[i].sectorSize = 512;
             g_ata_bd[i].sectorOffset = 0;
             g_ata_bd[i].sectorCount = 0;
-            
+
             g_ata_bd[i].read  = ata_bd_read;
             g_ata_bd[i].write = ata_bd_write;
             g_ata_bd[i].flush = ata_bd_flush;
             g_ata_bd[i].stop  = ata_bd_stop;
         }
     }
+
+    ata_get_devinfo(0);
+    ata_get_devinfo(1);
 #endif
 
     if (RegisterLibraryEntries(&_exp_atad) != 0) {


### PR DESCRIPTION
In this PR:
[Fix module name: ata_bd.irx](https://github.com/ps2dev/ps2sdk/commit/2ef60c59d1244ca85dbe2590de2e6ab4f5dffaeb)
[Initialize the HDD's so they can connect to BDM](https://github.com/ps2dev/ps2sdk/commit/4c5e750057d3fd6d02cc35e6f536c7c5d5f3f79a)