### PR TITLE
Using more functionality from newlib and clean-up

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -10,6 +10,9 @@ EE_LIB = libcglue.a
 
 CORE_OBJS = timezone.o rtc.o
 
+FDMAN_OBJS = __fdman_sema.o __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_deinit.o __fdman_get_new_descriptor.o \
+	__fdman_get_dup_descriptor.o __fdman_release_descriptor.o
+
 INIT_OBJS = __libpthreadglue_init.o __libpthreadglue_deinit.o _libcglue_init.o _libcglue_deinit.o _libcglue_args_parse.o
 
 SLEEP_OBJS = nanosleep.o
@@ -25,7 +28,7 @@ GLUE_OBJS = __dummy_passwd.o __direct_pwd.o __transform_errno.o __transform64_er
 LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o __retarget_lock_close.o \
 	__retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o __retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
 
-EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
+EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
@@ -39,6 +42,9 @@ $(SLEEP_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)sleep.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(GLUE_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)glue.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
+
+$(FDMAN_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)fdman.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(INIT_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)init.c

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -19,16 +19,20 @@ SLEEP_OBJS = nanosleep.o
 
 SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 
-GLUE_OBJS = __dummy_passwd.o __direct_pwd.o __transform_errno.o __transform64_errno.o __fill_stat.o _ps2sdk_ioctl.o compile_time_check.o _open.o _close.o _read.o _write.o \
-	_fstat.o _stat.o lstat.o access.o opendir.o readdir.o rewinddir.o closedir.o _lseek.o lseek64.o chdir.o mkdir.o \
-	rmdir.o _link.o _unlink.o getcwd.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
-	_isatty.o symlink.o truncate.o chmod.o fchmod.o fchmodat.o pathconf.o \
-	readlink.o utime.o fchown.o getrandom.o getentropy.o getpwuid.o fsync.o getpwnam.o getuid.o geteuid.o
+PS2SDKAPI_OBJS = _ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
+	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
+	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o
+
+GLUE_OBJS = __direct_pwd.o __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o _open.o _close.o _read.o _write.o \
+	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \
+	rmdir.o _link.o _unlink.o _rename.o  getcwd.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
+	truncate.o symlink.o readlink.o utime.o fchown.o getrandom.o getentropy.o _isatty.o chmod.o fchmod.o fchmodat.o pathconf.o \
+	fsync.o getuid.o geteuid.o getpwuid.o getpwnam.o
 
 LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o __retarget_lock_close.o \
 	__retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o __retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
 
-EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
+EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(PS2SDKAPI_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
@@ -42,6 +46,9 @@ $(SLEEP_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)sleep.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(GLUE_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)glue.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
+
+$(PS2SDKAPI_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)ps2sdkapi.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(FDMAN_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)fdman.c

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -33,10 +33,9 @@ extern int (*_ps2sdk_stat)(const char *path, struct stat *buf);
 extern int (*_ps2sdk_readlink)(const char *path, char *buf, size_t bufsiz);
 extern int (*_ps2sdk_symlink)(const char *target, const char *linkpath);
 
-extern DIR * (*_ps2sdk_opendir)(const char *path);
-extern struct dirent * (*_ps2sdk_readdir)(DIR *dir);
-extern void (*_ps2sdk_rewinddir)(DIR *dir);
-extern int (*_ps2sdk_closedir)(DIR *dir);
+extern int (*_ps2sdk_dopen)(const char *path);
+extern int (*_ps2sdk_dread)(int fd, struct dirent *dir);
+extern int (*_ps2sdk_dclose)(int fd);
 
 #define PS2_CLOCKS_PER_SEC kBUSCLKBY256 // 576.000
 #define PS2_CLOCKS_PER_MSEC (PS2_CLOCKS_PER_SEC / 1000) // 576

--- a/ee/libcglue/samples/rewinddir/Makefile
+++ b/ee/libcglue/samples/rewinddir/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = mem_test nanosleep regress rewinddir
+SAMPLE_DIR = libcglue/rewinddir
 
 include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+include $(PS2SDKSRC)/samples/Rules.samples

--- a/ee/libcglue/samples/rewinddir/Makefile.sample
+++ b/ee/libcglue/samples/rewinddir/Makefile.sample
@@ -1,0 +1,40 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+SCREEN_DEBUG = 1
+VERBOSE = 0
+
+EE_BIN   = rewinddir_test.elf
+EE_OBJS  = main.o
+
+ifeq ($(SCREEN_DEBUG), 1)
+EE_LIBS += -ldebug
+EE_CFLAGS += -DSCREEN_DEBUG
+endif
+
+ifeq ($(VERBOSE), 1)
+EE_CFLAGS += -DVERBOSE
+endif
+
+all: $(EE_BIN) input
+
+input:
+	mkdir -p testfiles/
+	echo "hello world" > testfiles/dummy
+
+clean:
+	rm -rf $(EE_BIN) $(EE_OBJS)
+
+run: $(EE_BIN)
+	ps2client execee host:$(EE_BIN)
+
+reset:
+	ps2client reset
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/ee/libcglue/samples/rewinddir/main.c
+++ b/ee/libcglue/samples/rewinddir/main.c
@@ -1,0 +1,79 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2005, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Malloc tester
+*/
+
+#include <stdio.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <kernel.h>
+
+#if defined(SCREEN_DEBUG)
+#include <debug.h>
+#endif
+
+#if defined(SCREEN_DEBUG)
+#define custom_printf(args...) \
+    printf(args);              \
+    scr_printf(args);
+#else
+#define custom_printf(args...) printf(args);
+#endif
+
+int main(int argc, char *argv[])
+{
+    // Buffer to store the current working directory
+    char cwd[1024];
+
+#if defined(SCREEN_DEBUG)
+    init_scr();
+    sleep(3);
+#endif
+    custom_printf("\n\nStarting rewinddir TESTS...\n");
+
+    // Get the current working directory
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        custom_printf("Error getting current working directory");
+        return 1;
+    }
+
+    // Open the current directory
+    DIR *directory = opendir(cwd);
+
+    // Check if the directory can be opened
+    if (directory == NULL) {
+        custom_printf("Error opening directory");
+        return 1;
+    }
+
+    // Read directory entries
+    struct dirent *entry;
+    while ((entry = readdir(directory)) != NULL) {
+        // Check if the entry is a directory using d_type
+        custom_printf("%s -> %s\n", entry->d_name, entry->d_type == DT_DIR ? "Directory" : "File");
+    }
+
+    custom_printf("\n\nExecuting rewinddir function...\n");
+    rewinddir(directory);
+
+    while ((entry = readdir(directory)) != NULL) {
+        // Check if the entry is a directory using d_type
+        custom_printf("%s -> %s\n", entry->d_name, entry->d_type == DT_DIR ? "Directory" : "File");
+    }
+
+    custom_printf("\n\nTest finished!\n");
+
+    // Close the directory
+    closedir(directory);
+
+    SleepThread();
+
+    return 0;
+}

--- a/ee/libcglue/src/fdman.c
+++ b/ee/libcglue/src/fdman.c
@@ -1,0 +1,161 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (C)2001, Gustavo Scotti (gustavo@scotti.com)
+# (c) 2003 Marcus R. Brown <mrbrown@0xd6.org>
+# (c) 2023 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * fdman.c - Manager for fd.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include <kernel.h>
+#include "fdman.h"
+
+#ifdef F___fdman_sema
+int __fdman_sema = -1;
+#else
+extern int __fdman_sema;
+#endif
+
+#ifdef F___descriptor_data_pool
+__descriptormap_type  __descriptor_data_pool[__FILENO_MAX];
+#else
+extern __descriptormap_type  __descriptor_data_pool[__FILENO_MAX];
+#endif
+
+#ifdef F___descriptormap
+__descriptormap_type *__descriptormap[__FILENO_MAX];
+#else
+extern __descriptormap_type *__descriptormap[__FILENO_MAX];
+#endif
+
+
+#ifdef F___fdman_init
+void __fdman_init()
+{
+	ee_sema_t sema;
+
+	/* Initialize mutex */
+	sema.init_count      = 1;
+    sema.max_count       = 1;
+    sema.option          = 0;
+	__fdman_sema = CreateSema(&sema);
+	if (__fdman_sema < 0) {
+		abort();
+	}
+
+	/* Initialize descriptor data*/
+	memset(__descriptor_data_pool, 0, sizeof(__descriptormap_type) *__FILENO_MAX);
+	/* Initialize descriptor map*/
+	memset(__descriptormap, 0, sizeof(__descriptormap_type*)*__FILENO_MAX);
+
+	// We assume STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO are initialized
+	__descriptormap[0] = &__descriptor_data_pool[0];
+	__descriptormap[0]->descriptor = STDIN_FILENO;
+	__descriptormap[0]->type = __DESCRIPTOR_TYPE_TTY;
+
+	__descriptormap[1] = &__descriptor_data_pool[1];
+	__descriptormap[1]->descriptor = STDOUT_FILENO;
+	__descriptormap[1]->type = __DESCRIPTOR_TYPE_TTY;
+
+	__descriptormap[2] = &__descriptor_data_pool[2];
+	__descriptormap[2]->descriptor = STDERR_FILENO;
+	__descriptormap[2]->type = __DESCRIPTOR_TYPE_TTY;
+}
+#endif
+
+#ifdef F___fdman_deinit
+void __fdman_deinit()
+{
+	if (__fdman_sema > 0) {
+		DeleteSema(__fdman_sema);
+	}
+}
+#endif
+
+
+#ifdef F___fdman_get_new_descriptor
+int __fdman_get_new_descriptor()
+{
+	int i = 0;
+
+	WaitSema(__fdman_sema); /* lock here to make thread safe */
+	for (i = 0; i < __FILENO_MAX; i++) {
+		if (__descriptormap[i] == NULL) {
+			__descriptormap[i] = &__descriptor_data_pool[i];
+			__descriptormap[i]->ref_count++;
+			SignalSema(__fdman_sema); /* release lock */
+			return i;
+		}
+	}
+	SignalSema(__fdman_sema); /* release lock */
+		
+	errno = ENOMEM;
+	return -1;
+}
+#endif
+
+
+#ifdef F___fdman_get_dup_descriptor
+int __fdman_get_dup_descriptor(int fd)
+{
+	int i = 0;
+	
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	WaitSema(__fdman_sema); /* lock here to make thread safe */
+	for (i = 0; i < __FILENO_MAX; i++) {
+		if (__descriptormap[i] == NULL) {
+			__descriptormap[i] = &__descriptor_data_pool[fd];
+			__descriptormap[i]->ref_count++;
+			SignalSema(__fdman_sema); /* release lock */
+			return i;
+		}
+	}
+	SignalSema(__fdman_sema); /* release lock */
+	
+	errno = ENOMEM;
+	return -1;
+}
+#endif
+
+
+#ifdef F___fdman_release_descriptor
+void __fdman_release_descriptor(int fd)
+{
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return;
+	}
+
+	__descriptormap[fd]->ref_count--;
+	
+	if (__descriptormap[fd]->ref_count == 0) {
+		
+		if (__descriptormap[fd]->filename != NULL) {
+			free(__descriptormap[fd]->filename);
+		}
+		__descriptormap[fd]->filename = NULL;
+		__descriptormap[fd]->descriptor = 0;
+		__descriptormap[fd]->type = 0;
+		__descriptormap[fd]->flags = 0;
+		
+	}
+	__descriptormap[fd] = NULL;
+}
+#endif

--- a/ee/libcglue/src/fdman.h
+++ b/ee/libcglue/src/fdman.h
@@ -1,0 +1,49 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#ifndef _FDMAN_H_
+
+#include <sys/types.h>
+
+#define _FDMAN_H_
+
+#define __FILENO_MAX 1024
+
+#define __IS_FD_VALID(FD) \
+		( (FD >= 0) && (FD < __FILENO_MAX) && (__descriptormap[FD] != NULL) )
+
+#define __IS_FD_OF_TYPE(FD, TYPE) \
+		( (__IS_FD_VALID(FD)) && (__descriptormap[FD]->type == TYPE) )
+		
+typedef enum {
+	__DESCRIPTOR_TYPE_FILE,
+	__DESCRIPTOR_TYPE_FOLDER,
+	__DESCRIPTOR_TYPE_PIPE,
+	__DESCRIPTOR_TYPE_SOCKET,
+	__DESCRIPTOR_TYPE_TTY
+} __fdman_fd_types;
+
+typedef struct {
+	uint32_t descriptor;
+	uint32_t flags;
+	uint32_t ref_count;
+	char *filename;
+	uint8_t type;
+} __descriptormap_type;
+	
+extern __descriptormap_type *__descriptormap[__FILENO_MAX];
+
+void __fdman_init();
+void __fdman_deinit();
+int  __fdman_get_new_descriptor();
+int  __fdman_get_dup_descriptor(int fd);
+void __fdman_release_descriptor(int fd);
+
+#endif

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -16,6 +16,7 @@
 #include <kernel.h>
 #include <timer.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <sio.h>
 
 #include <pwd.h>
@@ -37,11 +38,10 @@
 #include <tamtypes.h>
 
 #define NEWLIB_PORT_AWARE
-#include "fileio.h"
 #include "io_common.h"
-#include "iox_stat.h"
 #include "ps2sdkapi.h"
 #include "timer_alarm.h"
+#include "fdman.h"
 
 
 extern void * _end;
@@ -84,54 +84,6 @@ int64_t __transform64_errno(int64_t res) {
 }
 #else
 int64_t __transform64_errno(int64_t res);
-#endif
-
-#ifdef F___fill_stat
-static time_t io_to_posix_time(const unsigned char *ps2time)
-{
-        struct tm tim;
-        tim.tm_sec  = ps2time[1];
-        tim.tm_min  = ps2time[2];
-        tim.tm_hour = ps2time[3];
-        tim.tm_mday = ps2time[4];
-        tim.tm_mon  = ps2time[5] - 1;
-        tim.tm_year = ((u16)ps2time[6] | ((u16)ps2time[7] << 8)) - 1900;
-        return mktime(&tim);
-}
-
-static mode_t io_to_posix_mode(unsigned int ps2mode)
-{
-        mode_t posixmode = 0;
-        if (ps2mode & FIO_SO_IFREG) posixmode |= S_IFREG;
-        if (ps2mode & FIO_SO_IFDIR) posixmode |= S_IFDIR;
-        if (ps2mode & FIO_SO_IROTH) posixmode |= S_IRUSR|S_IRGRP|S_IROTH;
-        if (ps2mode & FIO_SO_IWOTH) posixmode |= S_IWUSR|S_IWGRP|S_IWOTH;
-        if (ps2mode & FIO_SO_IXOTH) posixmode |= S_IXUSR|S_IXGRP|S_IXOTH;
-        return posixmode;
-}
-
-void __fill_stat(struct stat *stat, const io_stat_t *fiostat)
-{
-        stat->st_dev = 0;
-        stat->st_ino = 0;
-        stat->st_mode = io_to_posix_mode(fiostat->mode);
-        stat->st_nlink = 0;
-        stat->st_uid = 0;
-        stat->st_gid = 0;
-        stat->st_rdev = 0;
-        stat->st_size = ((off_t)fiostat->hisize << 32) | (off_t)fiostat->size;
-        stat->st_atime = io_to_posix_time(fiostat->atime);
-        stat->st_mtime = io_to_posix_time(fiostat->mtime);
-        stat->st_ctime = io_to_posix_time(fiostat->ctime);
-        stat->st_blksize = 16*1024;
-        stat->st_blocks = stat->st_size / 512;
-}
-#else
-void __fill_stat(struct stat *stat, const io_stat_t *fiostat);
-#endif
-
-#ifdef F__ps2sdk_ioctl
-int (*_ps2sdk_ioctl)(int, int, void*) = fioIoctl;
 #endif
 
 #define IOP_O_RDONLY       0x0001
@@ -248,10 +200,10 @@ static int isCdromPath(const char *path)
 	return !strncmp(path, "cdrom0:", 7) || !strncmp(path, "cdrom:", 6);
 }
 
-int (*_ps2sdk_open)(const char*, int, ...) = (void *)fioOpen;
-
 int _open(const char *buf, int flags, ...) {
 	int iop_flags = 0;
+	int is_dir = 0;
+	int iop_fd, fd;
 
 	// newlib frags differ from iop flags
 	if ((flags & 3) == O_RDONLY) iop_flags |= IOP_O_RDONLY;
@@ -263,6 +215,10 @@ int _open(const char *buf, int flags, ...) {
 	if (flags & O_TRUNC)         iop_flags |= IOP_O_TRUNC;
 	if (flags & O_EXCL)          iop_flags |= IOP_O_EXCL;
 	//if (flags & O_???)           iop_flags |= IOP_O_NOWAIT;
+	if (flags & O_DIRECTORY) {
+		iop_flags |= IOP_O_DIROPEN;
+		is_dir = 1;
+	}
 
 	char *t_fname = normalize_path(buf);
 	char b_fname[FILENAME_MAX];
@@ -312,73 +268,122 @@ int _open(const char *buf, int flags, ...) {
 		}
 	}
 
-	return __transform_errno(_ps2sdk_open(t_fname, iop_flags));
+	iop_fd = is_dir ? _ps2sdk_dopen(t_fname) : _ps2sdk_open(t_fname, iop_flags);
+	if (iop_fd >= 0) {
+		fd = __fdman_get_new_descriptor();
+		if (fd != -1) {
+			__descriptormap[fd]->descriptor = iop_fd;
+			__descriptormap[fd]->type = is_dir ? __DESCRIPTOR_TYPE_FOLDER : __DESCRIPTOR_TYPE_FILE;
+			__descriptormap[fd]->flags = flags;
+			__descriptormap[fd]->filename = strdup(t_fname);
+			return fd;
+		}
+		else {
+			is_dir ? _ps2sdk_dclose(iop_fd) : _ps2sdk_close(iop_fd);
+			errno = ENOMEM;
+			return -1;
+		}
+	} 
+	else {
+		return __transform_errno(iop_fd);
+	}
 }
 #endif
 
 #ifdef F__close
-int (*_ps2sdk_close)(int) = fioClose;
-
 int _close(int fd) {
-	return __transform_errno(_ps2sdk_close(fd));
+	int ret = 0;
+
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	switch(__descriptormap[fd]->type)
+	{
+		case __DESCRIPTOR_TYPE_FILE:
+		case __DESCRIPTOR_TYPE_TTY:
+			if (__descriptormap[fd]->ref_count == 1) {
+				ret = __transform_errno(_ps2sdk_close(__descriptormap[fd]->descriptor));
+			}
+			__fdman_release_descriptor(fd);
+			return ret;
+			break;
+		case __DESCRIPTOR_TYPE_FOLDER:
+			if (__descriptormap[fd]->ref_count == 1) {
+				ret = __transform_errno(_ps2sdk_dclose(__descriptormap[fd]->descriptor));
+			}
+			__fdman_release_descriptor(fd);
+			return ret;
+			break;
+		case __DESCRIPTOR_TYPE_PIPE:
+			// Not supported yet
+			break;
+		case __DESCRIPTOR_TYPE_SOCKET:
+			// Not supported yet
+			break;
+		default:
+			break;
+	}
+
+	errno = EBADF;
+	return -1;
 }
 #endif
 
 #ifdef F__read
-int (*_ps2sdk_read)(int, void*, int) = fioRead;
-
 int _read(int fd, void *buf, size_t nbytes) {
-	return __transform_errno(_ps2sdk_read(fd, buf, nbytes));
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	switch(__descriptormap[fd]->type)
+	{
+		case __DESCRIPTOR_TYPE_FILE:
+		case __DESCRIPTOR_TYPE_TTY:
+			return __transform_errno(_ps2sdk_read(__descriptormap[fd]->descriptor, buf, nbytes));
+			break;
+		case __DESCRIPTOR_TYPE_PIPE:
+			break;
+		case __DESCRIPTOR_TYPE_SOCKET:
+			break;
+		default:
+			break;
+	}
+
+	errno = EBADF;
+	return -1;
 }
 #endif
 
 #ifdef F__write
-int (*_ps2sdk_write)(int, const void*, int) = fioWrite;
-
 int _write(int fd, const void *buf, size_t nbytes) {
-	// HACK: stdout and strerr to serial
-	//if ((fd==1) || (fd==2))
-	//	return sio_write((void *)buf, nbytes);
-
-	return __transform_errno(_ps2sdk_write(fd, buf, nbytes));
-}
-#endif
-
-#ifdef F__fstat
-int _fstat(int fd, struct stat *buf) {
-	if (fd >=0 && fd <= 1) {
-		// Character device
-		buf->st_mode = S_IFCHR;
-		buf->st_blksize = 0;
-	}
-	else {
-		// Block device
-		buf->st_mode = S_IFBLK;
-		buf->st_blksize = 16*1024;
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
 	}
 
-	return 0;
+	switch(__descriptormap[fd]->type)
+	{
+		case __DESCRIPTOR_TYPE_FILE:
+		case __DESCRIPTOR_TYPE_TTY:
+			return __transform_errno(_ps2sdk_write(__descriptormap[fd]->descriptor, buf, nbytes));
+			break;
+		case __DESCRIPTOR_TYPE_PIPE:
+			break;
+		case __DESCRIPTOR_TYPE_SOCKET:
+			break;
+		default:
+			break;
+	}
+
+	errno = EBADF;
+	return -1;
 }
-#else
-int _fstat(int fd, struct stat *buf);
 #endif
 
 #ifdef F__stat
-static int fioGetstatHelper(const char *path, struct stat *buf) {
-        io_stat_t fiostat;
-
-        if (fioGetstat(path, &fiostat) < 0) {
-			errno = ENOENT;
-			return -1;
-        }
-
-        __fill_stat(buf, &fiostat);
-
-        return 0;
-}
-
-int (*_ps2sdk_stat)(const char *path, struct stat *buf) = fioGetstatHelper;
-
 int _stat(const char *path, struct stat *buf) {
     return __transform_errno(_ps2sdk_stat(path, buf));
 }
@@ -387,6 +392,38 @@ int _stat(const char *path, struct stat *buf) {
 #ifdef F_lstat
 int lstat(const char *path, struct stat *buf) {
     return __transform_errno(stat(path, buf));
+}
+#endif
+
+#ifdef F__fstat
+int _fstat(int fd, struct stat *buf) {
+	int ret;
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	switch(__descriptormap[fd]->type)
+	{
+		case __DESCRIPTOR_TYPE_TTY:
+			memset(buf, '\0', sizeof(struct stat));
+			buf->st_mode = S_IFCHR;
+			return 0;
+			break;		
+		case __DESCRIPTOR_TYPE_FILE:
+			if (__descriptormap[fd]->filename != NULL) {
+				ret = stat(__descriptormap[fd]->filename, buf);
+				return ret;
+			}
+			break;
+		case __DESCRIPTOR_TYPE_PIPE:
+		case __DESCRIPTOR_TYPE_SOCKET:
+		default:
+			break;
+	}
+
+	errno = EBADF;
+	return -1;
 }
 #endif
 
@@ -400,130 +437,143 @@ int access(const char *fn, int flags) {
 	if (flags & W_OK) {
 		if (s.st_mode & S_IWRITE)
 			return 0;
+		errno = EACCES;
 		return -1;
 	}
 	return 0;
 }
 #endif
 
-#ifdef F_opendir
-static DIR *fioOpendirHelper(const char *path)
+#ifdef F__fcntl
+int _fcntl(int fd, int cmd, ...)
 {
-	int dd;
-	DIR *dir;
-
-	dd = fioDopen(path);
-	if (dd < 0) {
-		errno = ENOENT;
-		return NULL;
-	}
-
-	dir = malloc(sizeof(DIR));
-	dir->dd_fd = dd;
-	dir->dd_buf = malloc(sizeof(struct dirent));
-
-	return dir;
-}
-
-DIR * (*_ps2sdk_opendir)(const char *path) = fioOpendirHelper;
-
-DIR *opendir(const char *path)
-{
-    return _ps2sdk_opendir(path);
-}
-#endif
-
-#ifdef F_readdir
-static struct dirent *fioReaddirHelper(DIR *dir)
-{
-	int rv;
-	struct dirent *de;
-	io_dirent_t fiode;
-
-	if(dir == NULL) {
+	if (!__IS_FD_VALID(fd)) {
 		errno = EBADF;
-		return NULL;
+		return -1;
 	}
 
-	de = (struct dirent *)dir->dd_buf;
-	rv = fioDread(dir->dd_fd, &fiode);
-	if (rv <= 0) {
-		errno = -rv;
-		return NULL;
+	switch (cmd)
+	{
+		case F_DUPFD:
+		{
+			return __fdman_get_dup_descriptor(fd);
+			break;
+		}
+		case F_GETFL:
+		{
+			return __descriptormap[fd]->flags;
+			break;
+		}
+		case F_SETFL:
+		{
+			int newfl;
+			va_list args;
+	
+			va_start (args, cmd);         /* Initialize the argument list. */
+			newfl =  va_arg(args, int);
+			va_end (args);                /* Clean up. */
+
+			__descriptormap[fd]->flags = newfl;
+
+			switch(__descriptormap[fd]->type)
+			{
+				case __DESCRIPTOR_TYPE_FILE:
+					break;
+				case __DESCRIPTOR_TYPE_PIPE:
+					break;
+				case __DESCRIPTOR_TYPE_SOCKET:
+					break;
+				default:
+					break;
+			}
+			return 0;
+			break;
+		}
 	}
 
-	__fill_stat(&de->d_stat, &fiode.stat);
-	strncpy(de->d_name, fiode.name, 255);
-	de->d_name[255] = 0;
-
-	return de;
+	errno = EBADF;
+	return -1;
 }
+#endif /* F__fcntl */
 
-struct dirent * (*_ps2sdk_readdir)(DIR *dir) = fioReaddirHelper;
-
-struct dirent *readdir(DIR *dir)
+#ifdef F_getdents
+int getdents(int fd, void *dd_buf, int count)
 {
-    return _ps2sdk_readdir(dir);
+	struct dirent *dirp;
+	int rv, read;
+
+	read = 0;
+	dirp = (struct dirent *)dd_buf;
+
+   rv = _ps2sdk_dread(__descriptormap[fd]->descriptor, dirp);
+   if (rv < 0) {
+      return __transform_errno(rv);
+   } else if (rv == 0) {
+      return read;
+   }
+
+   read += sizeof(struct dirent);	
+   dirp->d_reclen = count;
+
+	return read;
 }
 #endif
 
-#ifdef F_rewinddir
-static void fioRewinddirHelper(DIR *dir)
-{
-	(void)dir;
-	errno = ENOSYS;
-	printf("rewinddir not implemented\n");
-}
 
-void (*_ps2sdk_rewinddir)(DIR *dir) = fioRewinddirHelper;
-
-void rewinddir(DIR *dir)
-{
-    return _ps2sdk_rewinddir(dir);
-}
-#endif
-
-#ifdef F_closedir
-static int fioClosedirHelper(DIR *dir)
-{
-	int res;
-
-	if(dir == NULL) {
-		return -EBADF;
-	}
-
-	res = fioDclose(dir->dd_fd);
-	free(dir->dd_buf);
-	free(dir);
-
-	return res;
-}
-
-int (*_ps2sdk_closedir)(DIR *dir) = fioClosedirHelper;
-
-int closedir(DIR *dir)
-{
-    return __transform_errno(_ps2sdk_closedir(dir));
-}
-#endif
 
 #ifdef F__lseek
-int (*_ps2sdk_lseek)(int, int, int) = fioLseek;
+static off_t _lseekDir(int fd, off_t offset, int whence)
+{
+	int i;
+	int uid;
+	struct dirent dir;
+
+	if (whence != SEEK_SET || __descriptormap[fd]->filename == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	_ps2sdk_dclose(__descriptormap[fd]->descriptor);
+	uid = _ps2sdk_dopen(__descriptormap[fd]->filename);
+	__descriptormap[fd]->descriptor = uid;
+	for (i = 0; i < offset; i++) {
+		_ps2sdk_dread(uid, &dir);
+	}
+
+	return offset;
+}
 
 off_t _lseek(int fd, off_t offset, int whence)
 {
-	return __transform_errno(_ps2sdk_lseek(fd, offset, whence));
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	switch(__descriptormap[fd]->type)
+	{
+		case __DESCRIPTOR_TYPE_FILE:
+			return __transform_errno(_ps2sdk_lseek(__descriptormap[fd]->descriptor, offset, whence));
+			break;
+		case __DESCRIPTOR_TYPE_FOLDER:
+			return _lseekDir(fd, offset, whence);
+			break;
+		case __DESCRIPTOR_TYPE_PIPE:
+			break;
+		case __DESCRIPTOR_TYPE_SOCKET:
+			break;
+		default:
+			break;
+	}
+
+	errno = EBADF;
+	return -1;
 }
 #endif
 
 #ifdef F_lseek64
-int64_t (*_ps2sdk_lseek64)(int, int64_t, int) = NULL;
-
 off64_t lseek64(int fd, off64_t offset, int whence)
 {
-    if (_ps2sdk_lseek64 == NULL)
-        return EOVERFLOW;
-
     return __transform64_errno(_ps2sdk_lseek64(fd, offset, whence));
 }
 #endif
@@ -536,48 +586,34 @@ int chdir(const char *path) {
 #endif
 
 #ifdef F_mkdir
-int fioMkdirHelper(const char *path, int mode) {
-  // Old fio mkdir has no mode argument
-	(void)mode;
-
-  return fioMkdir(path);
-}
-
-int (*_ps2sdk_mkdir)(const char*, int) = fioMkdirHelper;
-
 int mkdir(const char *path, mode_t mode) {
     return __transform_errno(_ps2sdk_mkdir(path, mode));
 }
 #endif
 
 #ifdef F_rmdir
-int (*_ps2sdk_rmdir)(const char*) = fioRmdir;
-
 int rmdir(const char *path) {
     return __transform_errno(_ps2sdk_rmdir(path));
 }
 #endif
 
 #ifdef F__link
-int fioRename(const char *old, const char *new) {
-	(void)old;
-	(void)new;
-
-  return -ENOSYS;
-}
-
-int (*_ps2sdk_rename)(const char*, const char*) = fioRename;
-
 int _link(const char *old, const char *new) {
-    return __transform_errno(_ps2sdk_rename(old, new));
+    errno = ENOSYS;
+	return -1; /* not supported */
 }
 #endif
 
 #ifdef F__unlink
-int (*_ps2sdk_remove)(const char*) = fioRemove;
-
 int _unlink(const char *path) {
-    return __transform_errno(_ps2sdk_remove(path));
+    errno = ENOSYS;
+	return -1; /* not supported */
+}
+#endif
+
+#ifdef F__rename
+int _rename(const char *old, const char *new) {
+    return __transform_errno(_ps2sdk_rename(old, new));
 }
 #endif
 
@@ -777,13 +813,6 @@ int truncate(const char *path, off_t length)
 #endif
 
 #ifdef F_symlink
-static int _default_symlink(const char *target, const char *linkpath)
-{
-	return link(target, linkpath);
-}
-
-int (*_ps2sdk_symlink)(const char *target, const char *linkpath) = _default_symlink;
-
 int symlink(const char *target, const char *linkpath)
 {
   return __transform_errno(_ps2sdk_symlink(target, linkpath));
@@ -791,14 +820,6 @@ int symlink(const char *target, const char *linkpath)
 #endif
 
 #ifdef F_readlink
-static ssize_t _default_readlink(const char *path, char *buf, size_t bufsiz)
-{
-	errno = ENOSYS;
-	return -1; /* not supported */
-}
-
-int (*_ps2sdk_readlink)(const char *path, char *buf, size_t bufsiz) = _default_readlink;
-
 ssize_t readlink(const char *path, char *buf, size_t bufsiz)
 {
 	return 	_ps2sdk_readlink(path, buf, bufsiz);

--- a/ee/libcglue/src/init.c
+++ b/ee/libcglue/src/init.c
@@ -15,8 +15,10 @@
 
 void _libcglue_timezone_update();
 void _libcglue_rtc_update();
+void __fdman_init();
 void pthread_init();
 void pthread_terminate();
+void __fdman_deinit();
 
 int chdir(const char *path);
 
@@ -41,6 +43,7 @@ __attribute__((weak))
 void __libpthreadglue_deinit()
 {
 	pthread_terminate();
+	__fdman_deinit();
 }
 #else
 void __libpthreadglue_deinit();
@@ -50,6 +53,9 @@ void __libpthreadglue_deinit();
 __attribute__((weak))
 void _libcglue_init()
 {
+	/* Initialize filedescriptor management */
+	__fdman_init();
+
 	/* Initialize pthread library */
 	__libpthreadglue_init();
 

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -1,0 +1,203 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (C)2001, Gustavo Scotti (gustavo@scotti.com)
+# (c) 2003 Marcus R. Brown <mrbrown@0xd6.org>
+# (c) 2023 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * fdman.c - Manager for fd.
+ */
+
+#include <ps2sdkapi.h>
+#include <string.h>
+#include <errno.h>
+#define NEWLIB_PORT_AWARE
+#include <fileio.h>
+#include "iox_stat.h"
+
+/** Inter-library helpers, default value */
+#ifdef F__ps2sdk_close
+int (*_ps2sdk_close)(int) = fioClose;
+#endif
+
+#ifdef F__ps2sdk_open
+int (*_ps2sdk_open)(const char*, int, ...) = (void *)fioOpen;
+#endif
+
+#ifdef F__ps2sdk_read
+int (*_ps2sdk_read)(int, void*, int) = fioRead;
+#endif
+
+#ifdef F__ps2sdk_lseek
+int (*_ps2sdk_lseek)(int, int, int) = fioLseek;
+#endif
+
+#ifdef F__ps2sdk_lseek64
+static off64_t _default_lseek64(int fd, off64_t offset, int whence)
+{
+	errno = ENOSYS;
+	return -1; /* not supported */
+}
+
+int64_t (*_ps2sdk_lseek64)(int, int64_t, int) = _default_lseek64;
+#endif
+
+#ifdef F__ps2sdk_write
+int (*_ps2sdk_write)(int, const void*, int) = fioWrite;
+#endif
+
+#ifdef F__ps2sdk_ioctl
+int (*_ps2sdk_ioctl)(int, int, void*) = fioIoctl;
+#endif
+
+#ifdef F__ps2sdk_remove
+int (*_ps2sdk_remove)(const char*) = fioRemove;
+#endif
+
+#ifdef F__ps2sdk_rename
+static int fioRename(const char *old, const char *new) {
+	errno = ENOSYS;
+	return -1; /* not supported */
+}
+
+int (*_ps2sdk_rename)(const char*, const char*) = fioRename;
+#endif
+
+#ifdef F__ps2sdk_mkdir
+static int fioMkdirHelper(const char *path, int mode) {
+  // Old fio mkdir has no mode argument
+	(void)mode;
+
+  return fioMkdir(path);
+}
+
+int (*_ps2sdk_mkdir)(const char*, int) = fioMkdirHelper;
+#endif
+
+#ifdef F__ps2sdk_rmdir
+int (*_ps2sdk_rmdir)(const char*) = fioRmdir;
+#endif
+
+#ifdef F__ps2sdk_stat
+static time_t io_to_posix_time(const unsigned char *ps2time)
+{
+        struct tm tim;
+        tim.tm_sec  = ps2time[1];
+        tim.tm_min  = ps2time[2];
+        tim.tm_hour = ps2time[3];
+        tim.tm_mday = ps2time[4];
+        tim.tm_mon  = ps2time[5] - 1;
+        tim.tm_year = ((u16)ps2time[6] | ((u16)ps2time[7] << 8)) - 1900;
+        return mktime(&tim);
+}
+
+static mode_t io_to_posix_mode(unsigned int ps2mode)
+{
+        mode_t posixmode = 0;
+        if (ps2mode & FIO_SO_IFREG) posixmode |= S_IFREG;
+        if (ps2mode & FIO_SO_IFDIR) posixmode |= S_IFDIR;
+        if (ps2mode & FIO_SO_IROTH) posixmode |= S_IRUSR|S_IRGRP|S_IROTH;
+        if (ps2mode & FIO_SO_IWOTH) posixmode |= S_IWUSR|S_IWGRP|S_IWOTH;
+        if (ps2mode & FIO_SO_IXOTH) posixmode |= S_IXUSR|S_IXGRP|S_IXOTH;
+        return posixmode;
+}
+
+static void __fill_stat(struct stat *stat, const io_stat_t *fiostat)
+{
+        stat->st_dev = 0;
+        stat->st_ino = 0;
+        stat->st_mode = io_to_posix_mode(fiostat->mode);
+        stat->st_nlink = 0;
+        stat->st_uid = 0;
+        stat->st_gid = 0;
+        stat->st_rdev = 0;
+        stat->st_size = ((off_t)fiostat->hisize << 32) | (off_t)fiostat->size;
+        stat->st_atime = io_to_posix_time(fiostat->atime);
+        stat->st_mtime = io_to_posix_time(fiostat->mtime);
+        stat->st_ctime = io_to_posix_time(fiostat->ctime);
+        stat->st_blksize = 16*1024;
+        stat->st_blocks = stat->st_size / 512;
+}
+
+static int fioGetstatHelper(const char *path, struct stat *buf) {
+        io_stat_t fiostat;
+
+        if (fioGetstat(path, &fiostat) < 0) {
+			errno = ENOENT;
+			return -1;
+        }
+
+        __fill_stat(buf, &fiostat);
+
+        return 0;
+}
+
+int (*_ps2sdk_stat)(const char *path, struct stat *buf) = fioGetstatHelper;
+#endif
+
+#ifdef F__ps2sdk_readlink
+static ssize_t _default_readlink(const char *path, char *buf, size_t bufsiz)
+{
+	errno = ENOSYS;
+	return -1; /* not supported */
+}
+
+int (*_ps2sdk_readlink)(const char *path, char *buf, size_t bufsiz) = _default_readlink;
+#endif
+
+#ifdef F__ps2sdk_symlink
+static int _default_symlink(const char *target, const char *linkpath)
+{
+	errno = ENOSYS;
+	return -1; /* not supported */
+}
+
+int (*_ps2sdk_symlink)(const char *target, const char *linkpath) = _default_symlink;
+#endif
+
+#ifdef F__ps2sdk_dopen
+int (*_ps2sdk_dopen)(const char *path) = fioDopen;
+#endif
+
+#ifdef F__ps2sdk_dread
+static int fioDreadHelper(int fd, struct dirent *dir) {
+	int rv;
+	io_dirent_t iodir;
+
+	// Took from io_dirent_t
+	#define __MAXNAMLEN 256
+
+	rv = fioDread(fd, &iodir);
+	if (rv < 0) {
+		errno = ENOENT;
+		return -1;
+	}
+
+	dir->d_fileno = rv; // TODO: This number should be in theory a unique number per file
+	strncpy(dir->d_name, iodir.name, __MAXNAMLEN);
+	dir->d_name[__MAXNAMLEN - 1] = 0;
+	dir->d_reclen = 0;
+	switch (iodir.stat.mode & FIO_SO_IFMT) {
+		case FIO_SO_IFLNK: dir->d_type = DT_LNK;     break;
+		case FIO_SO_IFDIR: dir->d_type = DT_DIR;     break;
+		case FIO_SO_IFREG: dir->d_type = DT_REG;     break;
+		default:          dir->d_type = DT_UNKNOWN; break;
+	}
+
+
+	return rv;
+}
+
+int (*_ps2sdk_dread)(int fd, struct dirent *dir) = fioDreadHelper;
+#endif
+
+#ifdef F__ps2sdk_dclose
+int (*_ps2sdk_dclose)(int fd) = fioDclose;
+#endif

--- a/samples/Makefile_sample
+++ b/samples/Makefile_sample
@@ -27,6 +27,7 @@ SUBDIRS += kernel/nanoHelloWorld
 SUBDIRS += libcglue/regress
 SUBDIRS += libcglue/mem_test
 SUBDIRS += libcglue/nanosleep
+SUBDIRS += libcglue/rewinddir
 SUBDIRS += libgs/doublebuffer
 SUBDIRS += libgs/draw
 #SUBDIRS += mpeg                #TODO: not modified for updated newlib


### PR DESCRIPTION
## Description
The main scope of this PR is to remove several helpers we created for open/close dir and use better what's it is provided by newlib.

It will also bring the usage of other functions such as `rewinddir` and some others.

This PR requires to be merged first: https://github.com/ps2dev/newlib/pull/8

The implementation of this PR follows the same approach that PSP did.

I have created an example to check that `readdir` keeps working, however could be nice to test some other examples.
I will try to add more examples later
<img width="752" alt="Screenshot 2023-11-27 at 19 51 56" src="https://github.com/ps2dev/ps2sdk/assets/10010409/456b7fa7-14bd-4001-b729-742bf0e66f53">


As a summary the new functions being used from `newlib` are (they belong to the flag `HAVE_OPENDIR`):
- `closedir` https://man7.org/linux/man-pages/man3/closedir.3.html
- `dirfd` https://man7.org/linux/man-pages/man3/dirfd.3.html
- `ftw` https://man7.org/linux/man-pages/man3/ftw.3.html
- `nftw` https://www.man7.org/linux/man-pages/man3/nftw.3p.html
- `opendir` https://man7.org/linux/man-pages/man3/opendir.3.html
- `readdir` https://man7.org/linux/man-pages/man3/readdir.3.html
- `rewinddir` https://man7.org/linux/man-pages/man3/rewinddir.3.html
- `scandir` https://man7.org/linux/man-pages/man3/scandir.3.html
- `alphasort` https://linux.die.net/man/3/alphasort
- `seekdir` https://man7.org/linux/man-pages/man3/seekdir.3.html
- `telldir` https://man7.org/linux/man-pages/man3/telldir.3.html

That also requires to implement in our `glue.c`:
- `getdents` https://man7.org/linux/man-pages/man2/getdents.2.html


The `rename` function is being redirected to the proper IOP `rename` functions, it was previously done through a `unlink` and `link` process.

Some other functions, the ones for the flags, `_NO_POSIX_SPAWN` `_NO_EXECVE` `NO_EXEC`, have been skipped as they are;t possible to use (so far).

As a summary, with this PR, we have made a good step in approaching a more Linux and POSIX-friendly SO (maybe in the future we can even use pipe/sockets for IO functions) and we have removed some unnecessary helpers functions created for `fileIO` and `fileXio`.

Cheers.
