### PR TITLE
Apply normalized to all functions

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -23,7 +23,7 @@ PS2SDKAPI_OBJS = _ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
 	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o
 
-GLUE_OBJS = __direct_pwd.o __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o _open.o _close.o _read.o _write.o \
+GLUE_OBJS = __direct_pwd.o __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o __normalized_path.o _open.o _close.o _read.o _write.o \
 	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \
 	rmdir.o _link.o _unlink.o _rename.o  getcwd.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
 	truncate.o symlink.o readlink.o utime.o fchown.o getrandom.o getentropy.o _isatty.o chmod.o fchmod.o fchmodat.o pathconf.o \

--- a/ee/libcglue/samples/regress/runner.c
+++ b/ee/libcglue/samples/regress/runner.c
@@ -21,39 +21,18 @@
 
 extern int libc_add_tests(test_suite *p);
 
-#ifdef _EE
-int iop_ret = 0;
-
-void iop_start(void)
+static void iop_start(void)
 {
     SifInitRpc(0);
 
     sbv_patch_fileio();
-    /*
-    SifLoadStartModule("rom0:FILEIO", 0, NULL, &iop_ret);
-    if (iop_ret < 0)
-        return;
-    SifLoadStartModule("host:iomanX.irx", 0, NULL, &iop_ret);
-    if (iop_ret < 0)
-        return;
-    SifLoadStartModule("host:fileXio.irx", 0, NULL, &iop_ret);
-    if (iop_ret < 0)
-        return;
-
-    fileXioInit();
-    */
 }
-#endif
 
 int main(int argc, char *argv[])
 {
     test_suite suite;
 
-#ifdef _EE
-    /* Check the IOP setup status. */
-    if (iop_ret < 0)
-        return 1;
-#endif
+    iop_start();
 
     /* initialize test suite */
     init_testsuite(&suite);

--- a/ee/libcglue/samples/regress/stdio_tests.c
+++ b/ee/libcglue/samples/regress/stdio_tests.c
@@ -20,6 +20,25 @@ static const char *test_fopen_fclose(void *arg)
     return NULL;
 }
 
+static const char *test_create_remove(void *arg)
+{
+    FILE *fp = fopen((char *)arg, "wt");
+    if (fp == NULL)
+    {
+        return "failed to create test file";
+    }
+
+    fclose(fp);
+
+    if (remove((char *)arg) != 0)
+    {
+        return "failed to remove test file";
+    }
+
+    printf("\nSUCCESS: all checks passed\n");
+    return NULL;
+}
+
 static const char *test_fgets(void *arg)
 {
     char buf[64], *ret;
@@ -428,25 +447,18 @@ int libc_add_tests(test_suite *p)
     const char *textfile, *textfile2, *invalidtextfile;
     const char *dir, *dir2;
 
-#ifdef _EE
-    textfile        = "host:testfiles/dummy";
-    textfile2       = "host:testfiles/dummy2";
-    invalidtextfile = "host:testfiles/invalidtextfile"; // This file shouldn't exist
-    dir             = "host:testfiles/";
-    dir2            = "host:dummydir/";
-#else
     textfile        = "testfiles/dummy";
     textfile2       = "testfiles/dummy2";
     invalidtextfile = "testfiles/invalidtextfile";
     dir             = "testfiles/";
     dir2            = "dummydir/";
-#endif
 
     /* If testing using usbd/usbhdfsd or ps2hdd/ps2fs, this adds a 10
        second delay so that the devices can initialize fully.
     sleep(10); */
 
     add_test(p, "fopen, fclose\n", test_fopen_fclose, (void *)textfile);
+    add_test(p, "create, remove\n", test_create_remove, (void *)textfile2);
     add_test(p, "fgets\n", test_fgets, (void *)textfile);
     add_test(p, "fread\n", test_fread, (void *)textfile);
     add_test(p, "fwrite\n", test_fwrite, (void *)textfile2);


### PR DESCRIPTION
## Description
This PR is to improve the usage of relative paths in all the POSIX functions. The same approach is also used by PSP.

More tests have been added to the regress sample

The remove file function has also been fixed, as newlib is using `_unlink` when removing a file.

Cheers.