### PR TITLE
Fix relative paths

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -19,20 +19,22 @@ SLEEP_OBJS = nanosleep.o
 
 SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 
+CWD_OBJS = __cwd.o __get_drive.o getcwd.o __path_absolute.o __init_cwd.o
+
 PS2SDKAPI_OBJS = _ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
 	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o
 
-GLUE_OBJS = __direct_pwd.o __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o __normalized_path.o _open.o _close.o _read.o _write.o \
+GLUE_OBJS = __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o __normalized_path.o _open.o _close.o _read.o _write.o \
 	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \
-	rmdir.o _link.o _unlink.o _rename.o  getcwd.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
+	rmdir.o _link.o _unlink.o _rename.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
 	truncate.o symlink.o readlink.o utime.o fchown.o getrandom.o getentropy.o _isatty.o chmod.o fchmod.o fchmodat.o pathconf.o \
 	fsync.o getuid.o geteuid.o getpwuid.o getpwnam.o
 
 LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o __retarget_lock_close.o \
 	__retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o __retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
 
-EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(PS2SDKAPI_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
+EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(CWD_OBJS) $(PS2SDKAPI_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
@@ -46,6 +48,9 @@ $(SLEEP_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)sleep.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(GLUE_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)glue.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
+
+$(CWD_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)cwd.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(PS2SDKAPI_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)ps2sdkapi.c

--- a/ee/libcglue/src/cwd.c
+++ b/ee/libcglue/src/cwd.c
@@ -1,0 +1,202 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/param.h>
+#include <dirent.h>
+#include <errno.h>
+
+#ifdef F___cwd
+/* the present working directory variable. */
+char __cwd[MAXNAMLEN + 1] = { 0 };
+#else
+extern char __cwd[MAXNAMLEN + 1];
+#endif
+
+#ifdef F___get_drive
+/* Return the number of bytes taken up by the "drive:" prefix,
+   or -1 if it's not found */
+int __get_drive(const char *d)
+{
+	int i;
+	for(i=0; d[i]; i++) {
+		if(! ((d[i] >= 'a' && d[i] <= 'z') ||
+		      (d[i] >= '0' && d[i] <= '9') ))
+			break;
+	}
+	if(d[i] == ':') return i+1;
+	return -1;
+}
+#else 
+int __get_drive(const char *d);
+#endif
+
+#ifdef F_getcwd
+char *getcwd(char *buf, size_t size)
+{
+	if(!buf) {
+		errno = EINVAL;
+		return NULL;
+	}		
+
+	if(strlen(__cwd) >= size) {
+		errno = ERANGE;
+		return NULL;
+	}
+
+	strcpy(buf, __cwd);
+	return buf;
+}
+#endif
+
+#ifdef F___path_absolute
+/* Like strcpy, but returns 0 if the string doesn't fit */
+static int __safe_strcpy(char *out, const char *in, int maxlen)
+{
+	for( ; maxlen > 0 && *in ; maxlen-- )
+		*(out++) = *(in++);
+	if(maxlen < 1) return 0;
+	*out = 0;
+	return 1;
+}
+
+/* Like strcat, but returns 0 if the string doesn't fit */
+static int __safe_strcat(char *out, const char *in, int maxlen)
+{
+	for( ; *out ; out++,maxlen-- )
+		continue;
+	return __safe_strcpy(out, in, maxlen);
+}
+
+/* Normalize a pathname (without leading "drive:") by removing
+   . and .. components, duplicated /, etc. */
+static int __path_normalize(char *out, int len)
+{
+	int i, j;
+	int first, next;
+
+	/* First append "/" to make the rest easier */
+	if(!__safe_strcat(out,"/",len)) return -10;
+
+	/* Convert "//" to "/" */
+	for(i=0; out[i+1]; i++) {
+		if(out[i]=='/' && out[i+1]=='/') {
+			for(j=i+1; out[j]; j++)
+				out[j] = out[j+1];
+			i--;
+		}
+	}
+
+	/* Convert "/./" to "/" */
+	for(i=0; out[i] && out[i+1] && out[i+2]; i++) {
+		if(out[i]=='/' && out[i+1]=='.' && out[i+2]=='/') {
+			for(j=i+1; out[j]; j++)
+				out[j] = out[j+2];
+			i--;
+		}
+	}
+
+	/* Convert "/asdf/../" to "/" until we can't anymore.  Also
+	 * convert leading "/../" to "/" */
+	first = next = 0;
+	while(1) {
+		/* If a "../" follows, remove it and the parent */
+		if(out[next+1] && out[next+1]=='.' && 
+		   out[next+2] && out[next+2]=='.' &&
+		   out[next+3] && out[next+3]=='/') {
+			for(j=0; out[first+j+1]; j++)
+				out[first+j+1] = out[next+j+4];
+			first = next = 0;
+			continue;
+		}
+
+		/* Find next slash */
+		first = next;
+		for(next=first+1; out[next] && out[next] != '/'; next++)
+			continue;
+		if(!out[next]) break;
+	}
+
+	/* Remove trailing "/" */
+	for(i=1; out[i]; i++)
+		continue;
+	if(i >= 1 && out[i-1] == '/') 
+		out[i-1] = 0;
+
+	return 0;
+}
+
+/* Convert relative path to absolute path. */
+int __path_absolute(const char *in, char *out, int len)
+{
+	int dr;
+
+	/* See what the relative URL starts with */
+	dr = __get_drive(in);
+	if(dr > 0 && in[dr] == '/') {
+		/* It starts with "drive:/", so it's already absolute */
+		if(!__safe_strcpy(out, in, len))
+			return -1;
+	} else if(in[0] == '/') {
+		/* It's absolute, but missing the drive, so use cwd's drive */
+		if(strlen(__cwd) >= len)
+			return -2;
+		strcpy(out, __cwd);
+		dr = __get_drive(out);
+		out[dr] = 0;
+		if(!__safe_strcat(out, in, len))
+			return -3;
+	} else {
+		/* It's not absolute, so append it to the current cwd */
+		if(strlen(__cwd) >= len)
+			return -4;
+		strcpy(out, __cwd);
+		if(!__safe_strcat(out, "/", len)) 
+			return -6;
+		if(!__safe_strcat(out, in, len)) 
+			return -7;
+	}
+
+	/* Now normalize the pathname portion */
+	dr = __get_drive(out);
+	if(dr < 0) dr = 0;
+	return __path_normalize(out + dr, len - dr);
+}
+#endif
+
+#ifdef F___init_cwd
+/* Set the current working directory (CWD) to the path where the module was launched. */
+void __init_cwd(int argc, char ** argv)
+{
+	if (argc == 0) // naplink!
+    {
+	chdir("host:");
+    } else {
+	char * p, * s = 0;
+	// let's find the last slash, or at worst, the :
+	for (p = argv[0]; *p; p++) {
+	    if ((*p == '/') || (*p == '\\') || (*p == ':')) {
+		s = p;
+	    }
+	}
+	// Nothing?! strange, let's use host.
+	if (!s) {
+	    chdir("host:");
+	} else {
+	    char backup = *(++s);
+	    *s = 0;
+	    chdir(argv[0]);
+	    *s = backup;
+	}
+    }
+}
+#endif

--- a/ee/libcglue/src/init.c
+++ b/ee/libcglue/src/init.c
@@ -13,6 +13,7 @@
  * The global init/deinit code for our crt0.
  */
 
+void __init_cwd(int argc, char ** argv);
 void _libcglue_timezone_update();
 void _libcglue_rtc_update();
 void __fdman_init();
@@ -76,27 +77,8 @@ void _libcglue_deinit()
 __attribute__((weak))
 void _libcglue_args_parse(int argc, char ** argv)
 {
-    if (argc == 0) // naplink!
-    {
-	chdir("host:");
-    } else {
-	char * p, * s = 0;
-	// let's find the last slash, or at worst, the :
-	for (p = argv[0]; *p; p++) {
-	    if ((*p == '/') || (*p == '\\') || (*p == ':')) {
-		s = p;
-	    }
-	}
-	// Nothing?! strange, let's use host.
-	if (!s) {
-	    chdir("host:");
-	} else {
-	    char backup = *(++s);
-	    *s = 0;
-	    chdir(argv[0]);
-	    *s = backup;
-	}
-    }
+    /* Initialize cwd from this program's path */
+	__init_cwd(argc, argv);
 }
 #endif
 


### PR DESCRIPTION
## Description
This PR improves the method that transforms the relative path into absolute paths, something needs to support POSIX functions with relative paths.

Specific content for `cwd` and paths has been moved to a separate file.

The returned error for several functions has been improved.

Once again the base code has been taken from the PSPSDK.

Cheers.