### PR TITLE
Improve mixing usage `fileio` and `fileXio`

### DIFF
--- a/ee/font/samples/font.c
+++ b/ee/font/samples/font.c
@@ -1,6 +1,7 @@
 #include <dma.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <tamtypes.h>
 

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -65,16 +65,25 @@ GLUE_OBJS += SyncDCache.o iSyncDCache.o InvalidDCache.o iInvalidDCache.o
 SIO_OBJS = sio_init.o sio_putc.o sio_getc.o sio_write.o sio_read.o sio_puts.o \
 	sio_gets.o sio_getc_block.o sio_flush.o sio_putsn.o
 
-ROM0_OBJS = _info_internals.o GetRomName.o IsDESRMachine.o IsT10K.o
+ROM0_OBJS = _info_internals.o GetRomNameWithIODriver.o GetRomName.o IsDESRMachineWithIODriver.o IsDESRMachine.o IsT10KWithIODriver.o IsT10K.o
 
 ### Config objects
 
-CONFIG_OBJS = _config_internals.o IsEarlyJap.o configGetLanguage.o \
-	configSetLanguage.o configGetTvScreenType.o configSetTvScreenType.o \
-	configGetDateFormat.o configSetDateFormat.o configGetTimeFormat.o \
-	configSetTimeFormat.o configGetTimezone.o configSetTimezone.o \
-	configIsSpdifEnabled.o configSetSpdifEnabled.o configGetTime.o \
-	configIsDaylightSavingEnabled.o configSetDaylightSavingEnabled.o
+CONFIG_OBJS = _config_internals.o __adjustTime.o IsEarlyJap.o \
+	configGetLanguageWithIODriver.o configGetLanguage.o \
+	configSetLanguageWithIODriver.o configSetLanguage.o \
+	configGetTvScreenTypeWithIODriver.o configGetTvScreenType.o \
+	configSetTvScreenTypeWithIODriver.o configSetTvScreenType.o \
+	configGetDateFormatWithIODriver.o configGetDateFormat.o \
+	configSetDateFormatWithIODriver.o configSetDateFormat.o \
+	configGetTimeFormatWithIODriver.o configGetTimeFormat.o \
+	configSetTimeFormatWithIODriver.o configSetTimeFormat.o \
+	configGetTimezoneWithIODriver.o configGetTimezone.o \
+	configSetTimezoneWithIODriver.o configSetTimezone.o \
+	configGetSpdifEnabledWithIODriver.o configIsSpdifEnabled.o \
+	configSetSpdifEnabledWithIODriver.o configSetSpdifEnabled.o \
+	configIsDaylightSavingEnabledWithIODriver.o configIsDaylightSavingEnabled.o \
+	configSetDaylightSavingEnabledWithIODriver.o configSetDaylightSavingEnabled.o
 
 ### Patch objects
 

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -69,7 +69,7 @@ ROM0_OBJS = _info_internals.o GetRomNameWithIODriver.o GetRomName.o IsDESRMachin
 
 ### Config objects
 
-CONFIG_OBJS = _config_internals.o __adjustTime.o IsEarlyJap.o \
+CONFIG_OBJS = _config_internals.o converttobcd.o convertfrombcd.o __adjustTime.o IsEarlyJap.o \
 	configGetLanguageWithIODriver.o configGetLanguage.o \
 	configSetLanguageWithIODriver.o configSetLanguage.o \
 	configGetTvScreenTypeWithIODriver.o configGetTvScreenType.o \
@@ -80,10 +80,11 @@ CONFIG_OBJS = _config_internals.o __adjustTime.o IsEarlyJap.o \
 	configSetTimeFormatWithIODriver.o configSetTimeFormat.o \
 	configGetTimezoneWithIODriver.o configGetTimezone.o \
 	configSetTimezoneWithIODriver.o configSetTimezone.o \
-	configGetSpdifEnabledWithIODriver.o configIsSpdifEnabled.o \
+	configIsSpdifEnabledWithIODriver.o configIsSpdifEnabled.o \
 	configSetSpdifEnabledWithIODriver.o configSetSpdifEnabled.o \
 	configIsDaylightSavingEnabledWithIODriver.o configIsDaylightSavingEnabled.o \
-	configSetDaylightSavingEnabledWithIODriver.o configSetDaylightSavingEnabled.o
+	configSetDaylightSavingEnabledWithIODriver.o configSetDaylightSavingEnabled.o \
+	configConvertToGmtTime.o configConvertToLocalTimeWithIODriver.o configConvertToLocalTime.o
 
 ### Patch objects
 

--- a/ee/kernel/include/osd_config.h
+++ b/ee/kernel/include/osd_config.h
@@ -217,11 +217,6 @@ void configSetDaylightSavingEnabledWithIODriver(int daylightSaving, _io_driver *
  * (ps2 clock is in JST time)
  */
 void configConvertToGmtTime(sceCdCLOCK *time);
-
-/** converts the time returned from the ps2's clock into LOCAL time
- * (ps2 clock is in JST time)
- */
-void configConvertToLocalTime(sceCdCLOCK *time);
 void configConvertToLocalTimeWithIODriver(sceCdCLOCK *time, _io_driver *driver);
 #endif
 

--- a/ee/kernel/include/osd_config.h
+++ b/ee/kernel/include/osd_config.h
@@ -25,6 +25,7 @@
 #define __OSD_CONFIG_H__
 
 #include <tamtypes.h>
+#include <rom0_info.h>
 #ifndef OSD_CONFIG_NO_LIBCDVD
 #include <libcdvd.h>
 #endif
@@ -128,69 +129,88 @@ extern "C" {
  * @return Language value (See OSD_LANGUAGES above)
  */
 int configGetLanguage(void);
+int configGetLanguageWithIODriver(_io_driver *driver);
+
 /** sets the default language of the ps2
  * @param language Language value (See OSD_LANGUAGES above)
  */
 void configSetLanguage(int language);
+void configSetLanguageWithIODriver(int language, _io_driver *driver);
 
 
 /** get the tv screen type the ps2 is setup for
  * @return 0 = 4:3; 1 = fullscreen; 2 = 16:9
  */
 int configGetTvScreenType(void);
+int configGetTvScreenTypeWithIODriver(_io_driver *driver);
+
 /** set the tv screen type
  * @param screenType 0 = 4:3; 1 = fullscreen; 2 = 16:9
  */
 void configSetTvScreenType(int screenType);
-
+void configSetTvScreenTypeWithIODriver(int screenType, _io_driver *driver);
 
 /** gets the date display format
  * @return 0 = yyyy/mm/dd; 1 = mm/dd/yyyy; 2 = dd/mm/yyyy
  */
 int configGetDateFormat(void);
+int configGetDateFormatWithIODriver(_io_driver *driver);
+
 /** sets the date display format
  * @param dateFormat 0 = yyyy/mm/dd; 1 = mm/dd/yyyy; 2 = dd/mm/yyyy
  */
 void configSetDateFormat(int dateFormat);
-
+void configSetDateFormatWithIODriver(int dateFormat, _io_driver *driver);
 
 /** gets the time display format
  * (whether 24hour time or not)
  * @return 0 = 24hour; 1 = 12hour
  */
 int configGetTimeFormat(void);
+int configGetTimeFormatWithIODriver(_io_driver *driver);
+
 /** sets the time display format
  * (whether 24hour time or not)
  * @param timeFormat 0 = 24hour; 1 = 12hour
  */
 void configSetTimeFormat(int timeFormat);
+void configSetTimeFormatWithIODriver(int timeFormat, _io_driver *driver);
 
 /** get timezone
  * @return offset in minutes from GMT
  */
 int configGetTimezone(void);
+int configGetTimezoneWithIODriver(_io_driver *driver);
+
 /** set timezone
  * @param offset offset in minutes from GMT
  */
 void configSetTimezone(int offset);
+void configSetTimezoneWithIODriver(int timezoneOffset, _io_driver *driver, void (*finishedCallback)(void));
 
 /** checks whether the spdif is enabled or not
  * @return 1 = on; 0 = off
  */
 int configIsSpdifEnabled(void);
+int configIsSpdifEnabledWithIODriver(_io_driver *driver);
+
 /** sets whether the spdif is enabled or not
  * @param enabled 1 = on; 0 = off
  */
 void configSetSpdifEnabled(int enabled);
+void configSetSpdifEnabledWithIODriver(int enabled, _io_driver *driver);
 
 /** checks whether daylight saving is currently set
  * @return 1 = on; 0 = off
  */
 int configIsDaylightSavingEnabled(void);
+int configIsDaylightSavingEnabledWithIODriver(_io_driver *driver);
+
 /** sets daylight saving
  * @param enabled 1 = on; 0 = off
  */
 void configSetDaylightSavingEnabled(int enabled);
+void configSetDaylightSavingEnabledWithIODriver(int daylightSaving, _io_driver *driver, void (*finishedCallback)(void));
 
 #ifndef OSD_CONFIG_NO_LIBCDVD
 /** converts the time returned from the ps2's clock into GMT time
@@ -202,6 +222,7 @@ void configConvertToGmtTime(sceCdCLOCK *time);
  * (ps2 clock is in JST time)
  */
 void configConvertToLocalTime(sceCdCLOCK *time);
+void configConvertToLocalTimeWithIODriver(sceCdCLOCK *time, _io_driver *driver);
 #endif
 
 // Internal functions.

--- a/ee/kernel/include/rom0_info.h
+++ b/ee/kernel/include/rom0_info.h
@@ -21,17 +21,25 @@
 extern "C" {
 #endif
 
+typedef struct {
+    int (*open)(const char *name, int flags, ...);
+    int (*close)(int fd);
+    int (*read)(int fd, void *buf, int nbyte);
+} _io_driver;
+
 /** check whether the PlayStation 2 is actually a DESR-XXXX machine
  *
  * @return 1 if DESR-XXXX machine; 0 if not
  */
 int IsDESRMachine(void);
+int IsDESRMachineWithIODriver(_io_driver *driver);
 
 /** check whether the PlayStation 2 is actually a TOOL DTL-T10000(H)
  *
  * @return 1 if DTL-T10000(H); 0 if not
  */
 int IsT10K(void);
+int IsT10KWithIODriver(_io_driver *driver);
 
 /** gets the romname from the current ps2
  * 14 chars - doesnt set a null terminator
@@ -40,6 +48,7 @@ int IsT10K(void);
  * @return pointer to buffer containing romname
  */
 char *GetRomName(char *romname);
+char *GetRomNameWithIODriver(char *romname, _io_driver *driver);
 
 #ifdef __cplusplus
 }

--- a/ee/kernel/src/osd_config.c
+++ b/ee/kernel/src/osd_config.c
@@ -46,19 +46,13 @@ extern ConfigParamT10K g_t10KConfig;
 ConfigParamT10K g_t10KConfig = {540, TV_SCREEN_43, DATE_YYYYMMDD, LANGUAGE_JAPANESE, 0, 0, 0};
 #endif
 
-// the following functions are all used in time conversion
-#ifdef F___adjustTime
-static unsigned char frombcd(unsigned char bcd)
-{
-    return bcd - (bcd >> 4) * 6;
-}
-
-static unsigned char tobcd(unsigned char dec)
+#ifdef F_converttobcd
+static inline unsigned char tobcd(unsigned char dec)
 {
     return dec + (dec / 10) * 6;
 }
 
-static void converttobcd(sceCdCLOCK *time)
+void converttobcd(sceCdCLOCK *time)
 {
     time->second = tobcd(time->second);
     time->minute = tobcd(time->minute);
@@ -67,8 +61,18 @@ static void converttobcd(sceCdCLOCK *time)
     time->month  = tobcd(time->month);
     time->year   = tobcd(time->year);
 }
+#else
+extern void converttobcd(sceCdCLOCK *time);
+#endif
 
-static void convertfrombcd(sceCdCLOCK *time)
+#ifdef F_convertfrombcd
+static inline unsigned char frombcd(unsigned char bcd)
+{
+    return bcd - (bcd >> 4) * 6;
+}
+
+
+void convertfrombcd(sceCdCLOCK *time)
 {
     time->second = frombcd(time->second);
     time->minute = frombcd(time->minute);
@@ -77,7 +81,11 @@ static void convertfrombcd(sceCdCLOCK *time)
     time->month  = frombcd(time->month);
     time->year   = frombcd(time->year);
 }
+#else
+extern void convertfrombcd(sceCdCLOCK *time);
+#endif
 
+#ifdef F___adjustTime
 static const unsigned char gDaysInMonths[12] = {
     31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
@@ -486,8 +494,8 @@ void configSetTimezone(int timezoneOffset)
 }
 #endif
 
-#ifdef F_configGetSpdifEnabledWithIODriver
-int configGetSpdifEnabledWithIODriver(_io_driver *driver)
+#ifdef F_configIsSpdifEnabledWithIODriver
+int configIsSpdifEnabledWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
 

--- a/ee/kernel/src/osd_config.c
+++ b/ee/kernel/src/osd_config.c
@@ -17,13 +17,14 @@
 
 #include <tamtypes.h>
 #include <kernel.h>
-#include <ps2sdkapi.h>
 #include <stdio.h>
 #include <sys/fcntl.h>
 #include <sys/unistd.h>
 #include <string.h>
 #include <osd_config.h>
 #include <rom0_info.h>
+#define NEWLIB_PORT_AWARE
+#include <fileio.h>
 
 /** config param data as stored on a DTL-T10000(H) TOOL */
 typedef struct
@@ -37,10 +38,144 @@ typedef struct
     u8 timeFormat;
 } ConfigParamT10K;
 
+#define defaultIODriver { (void *)fioOpen, fioClose, fioRead }
+
 extern ConfigParamT10K g_t10KConfig;
 
 #ifdef F__config_internals
 ConfigParamT10K g_t10KConfig = {540, TV_SCREEN_43, DATE_YYYYMMDD, LANGUAGE_JAPANESE, 0, 0, 0};
+#endif
+
+// the following functions are all used in time conversion
+#ifdef F___adjustTime
+static unsigned char frombcd(unsigned char bcd)
+{
+    return bcd - (bcd >> 4) * 6;
+}
+
+static unsigned char tobcd(unsigned char dec)
+{
+    return dec + (dec / 10) * 6;
+}
+
+static void converttobcd(sceCdCLOCK *time)
+{
+    time->second = tobcd(time->second);
+    time->minute = tobcd(time->minute);
+    time->hour   = tobcd(time->hour);
+    time->day    = tobcd(time->day);
+    time->month  = tobcd(time->month);
+    time->year   = tobcd(time->year);
+}
+
+static void convertfrombcd(sceCdCLOCK *time)
+{
+    time->second = frombcd(time->second);
+    time->minute = frombcd(time->minute);
+    time->hour   = frombcd(time->hour);
+    time->day    = frombcd(time->day);
+    time->month  = frombcd(time->month);
+    time->year   = frombcd(time->year);
+}
+
+static const unsigned char gDaysInMonths[12] = {
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+static void adddate(sceCdCLOCK *time)
+{
+    // get the days in each month and fix up feb depending on leap year
+    unsigned char days_in_months[12];
+    memcpy(days_in_months, gDaysInMonths, 12);
+    if ((time->year & 3) == 0)
+        days_in_months[1] = 29;
+
+    // increment the day and check its within the "day of the month" bounds
+    time->day++;
+    if (time->day > days_in_months[time->month - 1]) {
+        time->day = 1;
+
+        // increment the month and check its within the "months in a year" bounds
+        time->month++;
+        if (time->month == 13) {
+            time->month = 1;
+
+            // check the year and increment it
+            time->year++;
+            if (time->year == 100) {
+                time->year = 0;
+            }
+        }
+    }
+}
+
+static void subdate(sceCdCLOCK *time)
+{
+    // get the days in each month and fix up feb depending on leap year
+    unsigned char days_in_months[12];
+    memcpy(days_in_months, gDaysInMonths, 12);
+    if ((time->year & 3) == 0)
+        days_in_months[1] = 29;
+
+    // decrement the day and check its within the "day of the month" bounds
+    time->day--;
+    if (time->day == 0) {
+        // decrement the month and check its within the "months in a year" bounds
+        time->month--;
+        if (time->month == 0) {
+            time->month = 12;
+
+            // check the year and decrement it
+            if (time->year == 0)
+                time->year = 99;
+            else
+                time->year--;
+        }
+
+        time->day = days_in_months[time->month - 1];
+    }
+}
+
+static void addhour(sceCdCLOCK *time)
+{
+    time->hour++;
+    if (time->hour == 24) {
+        adddate(time);
+        time->hour = 0;
+    }
+}
+
+static void subhour(sceCdCLOCK *time)
+{
+    if (time->hour == 0) {
+        subdate(time);
+        time->hour = 23;
+    } else
+        time->hour--;
+}
+
+void __adjustTime(sceCdCLOCK *time, int offset)
+{
+    convertfrombcd(time);
+    offset += time->minute;
+
+    if (offset >= 0) {
+        while (offset >= 60) {
+            addhour(time);
+            offset -= 60;
+        }
+        time->minute = offset;
+    } else {
+        while (offset < 0) {
+            subhour(time);
+            offset += 60;
+        }
+        time->minute = offset;
+    }
+
+    converttobcd(time);
+}
+#else
+extern void __adjustTime(sceCdCLOCK *time, int offset);
 #endif
 
 #ifdef F_IsEarlyJap
@@ -50,12 +185,12 @@ int IsEarlyJap(ConfigParam config)
 }
 #endif
 
-#ifdef F_configGetLanguage
-int configGetLanguage(void)
+#ifdef F_configGetLanguageWithIODriver
+int configGetLanguageWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.language;
 
     GetOsdConfigParam(&config);
@@ -65,15 +200,23 @@ int configGetLanguage(void)
 }
 #endif
 
-#ifdef F_configSetLanguage
-void configSetLanguage(int language)
+#ifdef F_configGetLanguage
+int configGetLanguage(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configGetLanguageWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetLanguageWithIODriver
+void configSetLanguageWithIODriver(int language, _io_driver *driver)
 {
     ConfigParam config;
 
     // make sure language is valid
     if (language < LANGUAGE_JAPANESE || language > LANGUAGE_PORTUGUESE)
         return;
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.language = language;
 
     // set language
@@ -86,12 +229,20 @@ void configSetLanguage(int language)
 }
 #endif
 
-#ifdef F_configGetTvScreenType
-int configGetTvScreenType(void)
+#ifdef F_configSetLanguage
+void configSetLanguage(int language)
+{
+    _io_driver driver = defaultIODriver;
+    configSetLanguageWithIODriver(language, &driver);
+}
+#endif
+
+#ifdef F_configGetTvScreenTypeWithIODriver
+int configGetTvScreenTypeWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.screenType;
 
     GetOsdConfigParam(&config);
@@ -99,15 +250,23 @@ int configGetTvScreenType(void)
 }
 #endif
 
-#ifdef F_configSetTvScreenType
-void configSetTvScreenType(int screenType)
+#ifdef F_configGetTvScreenType
+int configGetTvScreenType(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configGetTvScreenTypeWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetTvScreenTypeWithIODriver
+void configSetTvScreenTypeWithIODriver(int screenType, _io_driver *driver)
 {
     ConfigParam config;
 
     // make sure screen type is valid
     if (screenType < TV_SCREEN_43 || screenType > TV_SCREEN_169)
         return;
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.screenType = screenType;
 
     // set screen type
@@ -117,13 +276,21 @@ void configSetTvScreenType(int screenType)
 }
 #endif
 
-#ifdef F_configGetDateFormat
-int configGetDateFormat(void)
+#ifdef F_configSetTvScreenType
+void configSetTvScreenType(int screenType)
+{
+    _io_driver driver = defaultIODriver;
+    configSetTvScreenTypeWithIODriver(screenType, &driver);
+}
+#endif
+
+#ifdef F_configGetDateFormatWithIODriver
+int configGetDateFormatWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
     Config2Param config2;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.dateFormat;
 
     GetOsdConfigParam(&config);
@@ -134,8 +301,16 @@ int configGetDateFormat(void)
 }
 #endif
 
-#ifdef F_configSetDateFormat
-void configSetDateFormat(int dateFormat)
+#ifdef F_configGetDateFormat
+int configGetDateFormat(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configGetDateFormatWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetDateFormatWithIODriver
+void configSetDateFormatWithIODriver(int dateFormat, _io_driver *driver)
 {
     ConfigParam config;
     Config2Param config2;
@@ -143,7 +318,7 @@ void configSetDateFormat(int dateFormat)
     // make sure date format is valid
     if (dateFormat < DATE_YYYYMMDD || dateFormat > DATE_DDMMYYYY)
         return;
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.dateFormat = dateFormat;
 
     // set date format
@@ -156,13 +331,21 @@ void configSetDateFormat(int dateFormat)
 }
 #endif
 
-#ifdef F_configGetTimeFormat
-int configGetTimeFormat(void)
+#ifdef F_configSetDateFormat
+void configSetDateFormat(int dateFormat)
+{
+    _io_driver driver = defaultIODriver;
+    configSetDateFormatWithIODriver(dateFormat, &driver);
+}
+#endif
+
+#ifdef F_configGetTimeFormatWithIODriver
+int configGetTimeFormatWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
     Config2Param config2;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.timeFormat;
 
     GetOsdConfigParam(&config);
@@ -173,8 +356,16 @@ int configGetTimeFormat(void)
 }
 #endif
 
-#ifdef F_configSetTimeFormat
-void configSetTimeFormat(int timeFormat)
+#ifdef F_configGetTimeFormat
+int configGetTimeFormat(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configGetTimeFormatWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetTimeFormatWithIODriver
+void configSetTimeFormatWithIODriver(int timeFormat, _io_driver *driver)
 {
     ConfigParam config;
     Config2Param config2;
@@ -182,7 +373,7 @@ void configSetTimeFormat(int timeFormat)
     // make sure time format is valid
     if (timeFormat < TIME_24H || timeFormat > TIME_12H)
         return;
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.timeFormat = timeFormat;
 
     // set time format
@@ -195,13 +386,21 @@ void configSetTimeFormat(int timeFormat)
 }
 #endif
 
-#ifdef F_configGetTimezone
-int configGetTimezone(void)
+#ifdef F_configSetTimeFormat
+void configSetTimeFormat(int timeFormat)
+{
+    _io_driver driver = defaultIODriver;
+    configSetTimeFormatWithIODriver(timeFormat, &driver);
+}
+#endif
+
+#ifdef F_configGetTimezoneWithIODriver
+int configGetTimezoneWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
     int timezoneOffset;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
     {
         timezoneOffset = g_t10KConfig.timezoneOffset;
     }
@@ -231,13 +430,21 @@ int configGetTimezone(void)
 }
 #endif
 
-#ifdef F_configSetTimezone
-void configSetTimezone(int timezoneOffset)
+#ifdef F_configGetTimezone
+int configGetTimezone(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configGetTimezoneWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetTimezoneWithIODriver
+void configSetTimezoneWithIODriver(int timezoneOffset, _io_driver *driver, void (*finishedCallback)(void))
 {
     ConfigParam config;
 
     // set offset from GMT
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.timezoneOffset = timezoneOffset;
 
     GetOsdConfigParam(&config);
@@ -266,16 +473,25 @@ void configSetTimezone(int timezoneOffset)
     }
 
     SetOsdConfigParam(&config);
-    _libcglue_timezone_update();
+    if (finishedCallback)
+        finishedCallback();
 }
 #endif
 
-#ifdef F_configIsSpdifEnabled
-int configIsSpdifEnabled(void)
+#ifdef F_configSetTimezone
+void configSetTimezone(int timezoneOffset)
+{
+    _io_driver driver = defaultIODriver;
+    configSetTimezoneWithIODriver(timezoneOffset, &driver, NULL);
+}
+#endif
+
+#ifdef F_configGetSpdifEnabledWithIODriver
+int configGetSpdifEnabledWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.spdifMode ^ 1;
 
     GetOsdConfigParam(&config);
@@ -283,12 +499,20 @@ int configIsSpdifEnabled(void)
 }
 #endif
 
-#ifdef F_configSetSpdifEnabled
-void configSetSpdifEnabled(int enabled)
+#ifdef F_configIsSpdifEnabled
+int configIsSpdifEnabled(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configIsSpdifEnabledWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetSpdifEnabledWithIODriver
+void configSetSpdifEnabledWithIODriver(int enabled, _io_driver *driver)
 {
     ConfigParam config;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.spdifMode = enabled ^ 1;
 
     GetOsdConfigParam(&config);
@@ -297,13 +521,21 @@ void configSetSpdifEnabled(int enabled)
 }
 #endif
 
-#ifdef F_configIsDaylightSavingEnabled
-int configIsDaylightSavingEnabled(void)
+#ifdef F_configSetSpdifEnabled
+void configSetSpdifEnabled(int enabled)
+{
+    _io_driver driver = defaultIODriver;
+    configSetSpdifEnabledWithIODriver(enabled, &driver);
+}
+#endif
+
+#ifdef F_configIsDaylightSavingEnabledWithIODriver
+int configIsDaylightSavingEnabledWithIODriver(_io_driver *driver)
 {
     ConfigParam config;
     Config2Param config2;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         return g_t10KConfig.daylightSaving;
 
     GetOsdConfigParam(&config);
@@ -315,13 +547,21 @@ int configIsDaylightSavingEnabled(void)
 }
 #endif
 
-#ifdef F_configSetDaylightSavingEnabled
-void configSetDaylightSavingEnabled(int daylightSaving)
+#ifdef F_configIsDaylightSavingEnabled
+int configIsDaylightSavingEnabled(void)
+{
+    _io_driver driver = defaultIODriver;
+    return configIsDaylightSavingEnabledWithIODriver(&driver);
+}
+#endif
+
+#ifdef F_configSetDaylightSavingEnabledWithIODriver
+void configSetDaylightSavingEnabledWithIODriver(int daylightSaving, _io_driver *driver, void (*finishedCallback)(void))
 {
     ConfigParam config;
     Config2Param config2;
 
-    if (IsT10K())
+    if (IsT10KWithIODriver(driver))
         g_t10KConfig.daylightSaving = daylightSaving;
 
     GetOsdConfigParam(&config);
@@ -330,145 +570,39 @@ void configSetDaylightSavingEnabled(int daylightSaving)
     GetOsdConfigParam2(&config2, sizeof(config2), 0);
     config2.daylightSaving = daylightSaving;
     SetOsdConfigParam2(&config2, sizeof(config2), 0);
-    _libcglue_timezone_update();
+    if (finishedCallback)
+        finishedCallback();
 }
 #endif
 
-// the following functions are all used in time conversion
-
-#ifdef F_configGetTime
-unsigned char frombcd(unsigned char bcd)
+#ifdef F_configSetDaylightSavingEnabled
+void configSetDaylightSavingEnabled(int daylightSaving)
 {
-    return bcd - (bcd >> 4) * 6;
+    _io_driver driver = defaultIODriver;
+    configSetDaylightSavingEnabledWithIODriver(daylightSaving, &driver, NULL);
 }
-unsigned char tobcd(unsigned char dec)
-{
-    return dec + (dec / 10) * 6;
-}
+#endif
 
-void converttobcd(sceCdCLOCK *time)
-{
-    time->second = tobcd(time->second);
-    time->minute = tobcd(time->minute);
-    time->hour   = tobcd(time->hour);
-    time->day    = tobcd(time->day);
-    time->month  = tobcd(time->month);
-    time->year   = tobcd(time->year);
-}
-void convertfrombcd(sceCdCLOCK *time)
-{
-    time->second = frombcd(time->second);
-    time->minute = frombcd(time->minute);
-    time->hour   = frombcd(time->hour);
-    time->day    = frombcd(time->day);
-    time->month  = frombcd(time->month);
-    time->year   = frombcd(time->year);
-}
-
-static const unsigned char gDaysInMonths[12] = {
-    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-
-void adddate(sceCdCLOCK *time)
-{
-    // get the days in each month and fix up feb depending on leap year
-    unsigned char days_in_months[12];
-    memcpy(days_in_months, gDaysInMonths, 12);
-    if ((time->year & 3) == 0)
-        days_in_months[1] = 29;
-
-    // increment the day and check its within the "day of the month" bounds
-    time->day++;
-    if (time->day > days_in_months[time->month - 1]) {
-        time->day = 1;
-
-        // increment the month and check its within the "months in a year" bounds
-        time->month++;
-        if (time->month == 13) {
-            time->month = 1;
-
-            // check the year and increment it
-            time->year++;
-            if (time->year == 100) {
-                time->year = 0;
-            }
-        }
-    }
-}
-void subdate(sceCdCLOCK *time)
-{
-    // get the days in each month and fix up feb depending on leap year
-    unsigned char days_in_months[12];
-    memcpy(days_in_months, gDaysInMonths, 12);
-    if ((time->year & 3) == 0)
-        days_in_months[1] = 29;
-
-    // decrement the day and check its within the "day of the month" bounds
-    time->day--;
-    if (time->day == 0) {
-        // decrement the month and check its within the "months in a year" bounds
-        time->month--;
-        if (time->month == 0) {
-            time->month = 12;
-
-            // check the year and decrement it
-            if (time->year == 0)
-                time->year = 99;
-            else
-                time->year--;
-        }
-
-        time->day = days_in_months[time->month - 1];
-    }
-}
-
-void addhour(sceCdCLOCK *time)
-{
-    time->hour++;
-    if (time->hour == 24) {
-        adddate(time);
-        time->hour = 0;
-    }
-}
-void subhour(sceCdCLOCK *time)
-{
-    if (time->hour == 0) {
-        subdate(time);
-        time->hour = 23;
-    } else
-        time->hour--;
-}
-
-void AdjustTime(sceCdCLOCK *time, int offset)
-{
-    convertfrombcd(time);
-    offset += time->minute;
-
-    if (offset >= 0) {
-        while (offset >= 60) {
-            addhour(time);
-            offset -= 60;
-        }
-        time->minute = offset;
-    } else {
-        while (offset < 0) {
-            subhour(time);
-            offset += 60;
-        }
-        time->minute = offset;
-    }
-
-    converttobcd(time);
-}
-
+#ifdef F_configConvertToGmtTime
 void configConvertToGmtTime(sceCdCLOCK *time)
 {
-    AdjustTime(time, -540);
+    __adjustTime(time, -540);
 }
+#endif
 
+#ifdef F_configConvertToLocalTimeWithIODriver
+void configConvertToLocalTimeWithIODriver(sceCdCLOCK *time, _io_driver *driver)
+{
+    int timezone_offset = configGetTimezoneWithIODriver(driver);
+    int daylight_saving = configIsDaylightSavingEnabledWithIODriver(driver);
+    __adjustTime(time, timezone_offset - 540 + (daylight_saving * 60));
+}
+#endif
+
+#ifdef F_configConvertToLocalTime
 void configConvertToLocalTime(sceCdCLOCK *time)
 {
-    int timezone_offset = configGetTimezone();
-    int daylight_saving = configIsDaylightSavingEnabled();
-    AdjustTime(time, timezone_offset - 540 + (daylight_saving * 60));
+    _io_driver driver = defaultIODriver;
+    configConvertToLocalTimeWithIODriver(time, &driver);
 }
 #endif

--- a/ee/kernel/src/timer_alarm.c
+++ b/ee/kernel/src/timer_alarm.c
@@ -11,7 +11,6 @@
 #include <tamtypes.h>
 #include <kernel.h>
 #include <timer.h>
-#include <ps2sdkapi.h>
 #include <timer_alarm.h>
 
 #ifdef TIME_USE_T0

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -8,7 +8,9 @@
 
 EE_LIB = libcglue.a
 
-CORE_OBJS = timezone.o rtc.o
+CORE_OBJS = rtc.o
+
+TIMEZONE_OBJS = _libcglue_timezone_update.o ps2sdk_setTimezone.o ps2sdk_setDaylightSaving.o
 
 FDMAN_OBJS = __fdman_sema.o __descriptor_data_pool.o __descriptormap.o __fdman_init.o __fdman_deinit.o __fdman_get_new_descriptor.o \
 	__fdman_get_dup_descriptor.o __fdman_release_descriptor.o
@@ -37,12 +39,15 @@ GLUE_OBJS = __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_t
 LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o __retarget_lock_close.o \
 	__retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o __retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o
 
-EE_OBJS = $(CORE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(CWD_OBJS) $(PS2SDKAPI_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
+EE_OBJS = $(CORE_OBJS) $(TIMEZONE_OBJS) $(SJIS_OBJS) $(TIME_OBJS) $(FDMAN_OBJS) $(INIT_OBJS) $(SLEEP_OBJS) $(TERMINATE_OBJS) $(CWD_OBJS) $(PS2SDKAPI_OBJS) $(GLUE_OBJS) $(LOCK_OBJS)
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
 include $(PS2SDKSRC)/ee/Rules.make
 include $(PS2SDKSRC)/ee/Rules.release
+
+$(TIMEZONE_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)timezone.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(SJIS_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)sjis.c
 	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -24,6 +24,7 @@ SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 CWD_OBJS = __cwd.o __get_drive.o getcwd.o __path_absolute.o __init_cwd.o
 
 PS2SDKAPI_OBJS = \
+	__fioOpenHelper.o __fioLseek64Helper.o __fioRenameHelper.o __fioMkdirHelper.o __fioGetstatHelper.o __fioReadlinkHelper.o __fioSymlinkHelper.o __fioDreadHelper.o \
 	_ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
 	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o \

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -23,7 +23,10 @@ CWD_OBJS = __cwd.o __get_drive.o getcwd.o __path_absolute.o __init_cwd.o
 
 PS2SDKAPI_OBJS = _ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
-	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o
+	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o \
+	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
+	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
+	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o
 
 GLUE_OBJS = __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o __normalized_path.o _open.o _close.o _read.o _write.o \
 	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -23,12 +23,20 @@ SJIS_OBJS = isSpecialSJIS.o isSpecialASCII.o strcpy_ascii.o strcpy_sjis.o
 
 CWD_OBJS = __cwd.o __get_drive.o getcwd.o __path_absolute.o __init_cwd.o
 
-PS2SDKAPI_OBJS = _ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
+PS2SDKAPI_OBJS = \
+	_ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
 	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o \
 	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
 	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
-	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o
+	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o \
+	_glue_ps2sdk_close.o _glue_ps2sdk_open.o _glue_ps2sdk_read.o _glue_ps2sdk_lseek.o _glue_ps2sdk_lseek64.o _glue_ps2sdk_write.o _glue_ps2sdk_ioctl.o \
+	_glue_ps2sdk_remove.o _glue_ps2sdk_rename.o _glue_ps2sdk_mkdir.o _glue_ps2sdk_rmdir.o _glue_ps2sdk_stat.o _glue_ps2sdk_readlink.o _glue_ps2sdk_symlink.o \
+	_glue_ps2sdk_dopen.o _glue_ps2sdk_dread.o _glue_ps2sdk_dclose.o \
+	_predefined_ps2sdk_close.o _predefined_ps2sdk_open.o _predefined_ps2sdk_read.o _predefined_ps2sdk_lseek.o _predefined_ps2sdk_lseek64.o _predefined_ps2sdk_write.o _predefined_ps2sdk_ioctl.o \
+	_predefined_ps2sdk_remove.o _predefined_ps2sdk_rename.o _predefined_ps2sdk_mkdir.o _predefined_ps2sdk_rmdir.o _predefined_ps2sdk_stat.o _predefined_ps2sdk_readlink.o _predefined_ps2sdk_symlink.o \
+	_predefined_ps2sdk_dopen.o _predefined_ps2sdk_dread.o _predefined_ps2sdk_dclose.o 
+
 
 GLUE_OBJS = __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_time_check.o __normalized_path.o _open.o _close.o _read.o _write.o \
 	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \

--- a/ee/libcglue/include/file-advanced.h
+++ b/ee/libcglue/include/file-advanced.h
@@ -1,0 +1,92 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#ifndef __FILE_ADVANCED_H__
+#define __FILE_ADVANCED_H__
+
+#define NEWLIB_PORT_AWARE
+#include <fileio.h>
+#include <fileXio_rpc.h>
+#include "iox_stat.h"
+
+extern uint8_t __usingFileXIO;
+
+
+static inline void swapToFileXio() {
+    fileXioInit();
+    __usingFileXIO = 1;
+}
+
+#define FILE_SWAP_PS2SDK_FUNCTIONS() \
+    uint8_t __usingFileXIO = 0; \
+    int __fileXioGetstatHelper(const char *path, struct stat *buf); \
+    int __fileXioDreadHelper(int fd, struct dirent *dir); \
+    int __fioOpenHelper(const char* path, int flags, ...); \
+    off64_t __fioLseek64Helper(int fd, off64_t offset, int whence); \
+    int __fioRenameHelper(const char *oldpath, const char *newpath); \
+    int __fioMkdirHelper(const char *path, int mode); \
+    int __fioGetstatHelper(const char *path, struct stat *buf); \
+    int __fioReadlinkHelper(const char *path, char *buf, size_t bufsize); \
+    int __fioSymlinkHelper(const char *oldpath, const char *newpath); \
+    int __fioDreadHelper(int fd, struct dirent *dir); \
+    void _predefined_ps2sdk_close() { \
+        _ps2sdk_close = __usingFileXIO ? fileXioClose : fioClose; \
+    } \
+    void _predefined_ps2sdk_open() { \
+        _ps2sdk_open = __usingFileXIO ? fileXioOpen : __fioOpenHelper; \
+    } \
+    void _predefined_ps2sdk_read() { \
+        _ps2sdk_read = __usingFileXIO ? fileXioRead : fioRead; \
+    } \
+    void _predefined_ps2sdk_lseek() { \
+        _ps2sdk_lseek = __usingFileXIO ? fileXioLseek : fioLseek; \
+    } \
+    void _predefined_ps2sdk_lseek64() { \
+        _ps2sdk_lseek64 = __usingFileXIO ? fileXioLseek64 : __fioLseek64Helper; \
+    } \
+    void _predefined_ps2sdk_write() { \
+        _ps2sdk_write = __usingFileXIO ? fileXioWrite : fioWrite; \
+    } \
+    void _predefined_ps2sdk_ioctl() { \
+        _ps2sdk_ioctl = __usingFileXIO ? fileXioIoctl : fioIoctl; \
+    } \
+    void _predefined_ps2sdk_remove() { \
+        _ps2sdk_remove = __usingFileXIO ? fileXioRemove : fioRemove; \
+    } \
+    void _predefined_ps2sdk_rename() { \
+        _ps2sdk_rename = __usingFileXIO ? fileXioRename : __fioRenameHelper; \
+    } \
+    void _predefined_ps2sdk_mkdir() { \
+        _ps2sdk_mkdir = __usingFileXIO ? fileXioMkdir : __fioMkdirHelper; \
+    } \
+    void _predefined_ps2sdk_rmdir() { \
+        _ps2sdk_rmdir = __usingFileXIO ? fileXioRmdir : fioRmdir; \
+    } \
+    void _predefined_ps2sdk_stat() { \
+        _ps2sdk_stat = __usingFileXIO ? __fileXioGetstatHelper : __fioGetstatHelper; \
+    } \
+    void _predefined_ps2sdk_readlink() { \
+        _ps2sdk_readlink = __usingFileXIO ? fileXioReadlink : __fioReadlinkHelper; \
+    } \
+    void _predefined_ps2sdk_symlink() { \
+        _ps2sdk_symlink = __usingFileXIO ? fileXioSymlink : __fioSymlinkHelper; \
+    } \
+    void _predefined_ps2sdk_dopen() { \
+        _ps2sdk_dopen = __usingFileXIO ? fileXioDopen : fioDopen; \
+    } \
+    void _predefined_ps2sdk_dclose() { \
+        _ps2sdk_dclose = __usingFileXIO ? fileXioDclose : fioDclose; \
+    } \
+    void _predefined_ps2sdk_dread() { \
+        _ps2sdk_dread = __usingFileXIO ? __fileXioDreadHelper : __fioDreadHelper; \
+    } \
+
+ 
+#endif /* __FILE_ADVANCED_H__ */

--- a/ee/libcglue/include/file-advanced.h
+++ b/ee/libcglue/include/file-advanced.h
@@ -24,6 +24,11 @@ static inline void swapToFileXio() {
     __usingFileXIO = 1;
 }
 
+static inline void swapToFileIO() {
+    fileXioExit();
+    __usingFileXIO = 0;
+}
+
 #define FILE_SWAP_PS2SDK_FUNCTIONS() \
     uint8_t __usingFileXIO = 0; \
     int __fileXioGetstatHelper(const char *path, struct stat *buf); \

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -37,6 +37,25 @@ extern int (*_ps2sdk_dopen)(const char *path);
 extern int (*_ps2sdk_dread)(int fd, struct dirent *dir);
 extern int (*_ps2sdk_dclose)(int fd);
 
+// Functions to set the inter-library helpers
+void _set_ps2sdk_close();
+void _set_ps2sdk_open();
+void _set_ps2sdk_read();
+void _set_ps2sdk_lseek();
+void _set_ps2sdk_lseek64();
+void _set_ps2sdk_write();
+void _set_ps2sdk_ioctl();
+void _set_ps2sdk_remove();
+void _set_ps2sdk_rename();
+void _set_ps2sdk_mkdir();
+void _set_ps2sdk_rmdir();
+void _set_ps2sdk_stat();
+void _set_ps2sdk_readlink();
+void _set_ps2sdk_symlink();
+void _set_ps2sdk_dopen();
+void _set_ps2sdk_dread();
+void _set_ps2sdk_dclose();
+
 #define PS2_CLOCKS_PER_SEC kBUSCLKBY256 // 576.000
 #define PS2_CLOCKS_PER_MSEC (PS2_CLOCKS_PER_SEC / 1000) // 576
 

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -70,8 +70,6 @@ static inline ps2_clock_t ps2_clock(void) {
     return (ps2_clock_t)(GetTimerSystemTime() >> 8);
 }
 
-extern void _libcglue_timezone_update();
-
 extern s64 _ps2sdk_rtc_offset_from_busclk;
 extern void _libcglue_rtc_update();
 
@@ -79,6 +77,12 @@ extern void _libcglue_rtc_update();
 // this should have been defined in unistd.h
 typedef int64_t off64_t;
 off64_t lseek64(int fd, off64_t offset, int whence);
+
+// Functions to be used related to timezone
+extern void _libcglue_timezone_update();
+
+void ps2sdk_setTimezone(int timezone);
+void ps2sdk_setDaylightSaving(int daylightSaving);
 
 /* The fd we provide to final user aren't actually the same than IOP's fd
 * so this function allow you to get actual IOP's fd from public fd

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -38,23 +38,23 @@ extern int (*_ps2sdk_dread)(int fd, struct dirent *dir);
 extern int (*_ps2sdk_dclose)(int fd);
 
 // Functions to set the inter-library helpers
-void _set_ps2sdk_close();
-void _set_ps2sdk_open();
-void _set_ps2sdk_read();
-void _set_ps2sdk_lseek();
-void _set_ps2sdk_lseek64();
-void _set_ps2sdk_write();
-void _set_ps2sdk_ioctl();
-void _set_ps2sdk_remove();
-void _set_ps2sdk_rename();
-void _set_ps2sdk_mkdir();
-void _set_ps2sdk_rmdir();
-void _set_ps2sdk_stat();
-void _set_ps2sdk_readlink();
-void _set_ps2sdk_symlink();
-void _set_ps2sdk_dopen();
-void _set_ps2sdk_dread();
-void _set_ps2sdk_dclose();
+void _glue_ps2sdk_close();
+void _glue_ps2sdk_open();
+void _glue_ps2sdk_read();
+void _glue_ps2sdk_lseek();
+void _glue_ps2sdk_lseek64();
+void _glue_ps2sdk_write();
+void _glue_ps2sdk_ioctl();
+void _glue_ps2sdk_remove();
+void _glue_ps2sdk_rename();
+void _glue_ps2sdk_mkdir();
+void _glue_ps2sdk_rmdir();
+void _glue_ps2sdk_stat();
+void _glue_ps2sdk_readlink();
+void _glue_ps2sdk_symlink();
+void _glue_ps2sdk_dopen();
+void _glue_ps2sdk_dread();
+void _glue_ps2sdk_dclose();
 
 #define PS2_CLOCKS_PER_SEC kBUSCLKBY256 // 576.000
 #define PS2_CLOCKS_PER_MSEC (PS2_CLOCKS_PER_SEC / 1000) // 576

--- a/ee/libcglue/samples/timezone/Makefile
+++ b/ee/libcglue/samples/timezone/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = mem_test nanosleep regress rewinddir timezone
+SAMPLE_DIR = libcglue/timezone
 
 include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+include $(PS2SDKSRC)/samples/Rules.samples

--- a/ee/libcglue/samples/timezone/Makefile.sample
+++ b/ee/libcglue/samples/timezone/Makefile.sample
@@ -1,0 +1,36 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+SCREEN_DEBUG = 1
+VERBOSE = 0
+
+EE_BIN   = timezone_test.elf
+EE_OBJS  = main.o
+
+ifeq ($(SCREEN_DEBUG), 1)
+EE_LIBS += -ldebug
+EE_CFLAGS += -DSCREEN_DEBUG
+endif
+
+ifeq ($(VERBOSE), 1)
+EE_CFLAGS += -DVERBOSE
+endif
+
+all: $(EE_BIN)
+
+clean:
+	rm -rf $(EE_BIN) $(EE_OBJS)
+
+run: $(EE_BIN)
+	ps2client execee host:$(EE_BIN)
+
+reset:
+	ps2client reset
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/ee/libcglue/samples/timezone/main.c
+++ b/ee/libcglue/samples/timezone/main.c
@@ -1,0 +1,78 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2005, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Malloc tester
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <kernel.h>
+
+#if defined(SCREEN_DEBUG)
+#include <debug.h>
+#endif
+
+#if defined(SCREEN_DEBUG)
+#define custom_printf(args...) \
+    printf(args);              \
+    scr_printf(args);
+#else
+#define custom_printf(args...) printf(args);
+#endif
+
+int main(int argc, char *argv[]) 
+{
+#if defined(SCREEN_DEBUG)
+    init_scr();
+    sleep(3);
+#endif
+    custom_printf("\n\nStarting Timezone test...\n");
+ 
+    // Get the value of the TZ environment variable
+    char *time_zone = getenv("TZ");
+
+    if (time_zone != NULL) {
+        custom_printf("Current time zone: %s\n", time_zone);
+    } else {
+        perror("Error getting time zone");
+        return 1;
+    }
+
+    while (1) {
+        // Clear the screen part where the time is printed
+        scr_setXY(0, 4);
+        scr_clearline(4);
+
+        // Get the current time
+        time_t raw_time;
+        struct tm *time_info;
+
+        time(&raw_time);
+        time_info = localtime(&raw_time);
+
+        if (time_info == NULL) {
+            perror("Error getting local time");
+            return 1;
+        }
+
+        // Print the current hour
+        custom_printf("Current hour: %02d:%02d:%02d\n",
+               time_info->tm_hour, time_info->tm_min, time_info->tm_sec);
+
+        // Refresh every second
+        sleep(1);
+        // You can use usleep(1000000) for more precise intervals if needed
+    }
+
+    SleepThread();
+
+    return 0;
+}

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -143,10 +143,10 @@ int _open(const char *buf, int flags, ...) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_dopen == NULL) _set_ps2sdk_dopen();
-	if (_ps2sdk_open == NULL) _set_ps2sdk_open();
-	if (_ps2sdk_dclose == NULL) _set_ps2sdk_dclose();
-	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+	_glue_ps2sdk_dopen();
+	_glue_ps2sdk_open();
+	_glue_ps2sdk_dclose();
+	_glue_ps2sdk_close();
 
 	// newlib frags differ from iop flags
 	if ((flags & 3) == O_RDONLY) iop_flags |= IOP_O_RDONLY;
@@ -195,7 +195,7 @@ int _close(int fd) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+	_glue_ps2sdk_close();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -237,7 +237,7 @@ int _read(int fd, void *buf, size_t nbytes) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_read == NULL) _set_ps2sdk_read();
+	_glue_ps2sdk_read();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -266,7 +266,7 @@ int _write(int fd, const void *buf, size_t nbytes) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_write == NULL) _set_ps2sdk_write();
+	_glue_ps2sdk_write();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -297,7 +297,7 @@ int _stat(const char *path, struct stat *buf) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_stat == NULL) _set_ps2sdk_stat();
+	_glue_ps2sdk_stat();
 
 	return __transform_errno(_ps2sdk_stat(dest, buf));
 }
@@ -427,7 +427,7 @@ int getdents(int fd, void *dd_buf, int count)
 	dirp = (struct dirent *)dd_buf;
 
 	// Set ps2sdk functions
-	if (_ps2sdk_dread == NULL) _set_ps2sdk_dread();
+	_glue_ps2sdk_dread();
 
 	rv = _ps2sdk_dread(__descriptormap[fd]->descriptor, dirp);
 	if (rv < 0) {
@@ -458,9 +458,9 @@ static off_t _lseekDir(int fd, off_t offset, int whence)
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
-	if (_ps2sdk_dopen == NULL) _set_ps2sdk_dopen();
-	if (_ps2sdk_dread == NULL) _set_ps2sdk_dread();
+	_glue_ps2sdk_close();
+	_glue_ps2sdk_dopen();
+	_glue_ps2sdk_dread();
 
 	_ps2sdk_dclose(__descriptormap[fd]->descriptor);
 	uid = _ps2sdk_dopen(__descriptormap[fd]->filename);
@@ -480,7 +480,7 @@ off_t _lseek(int fd, off_t offset, int whence)
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_lseek == NULL) _set_ps2sdk_lseek();
+	_glue_ps2sdk_lseek();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -512,7 +512,7 @@ off64_t lseek64(int fd, off64_t offset, int whence)
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_lseek64 == NULL) _set_ps2sdk_lseek64();
+	_glue_ps2sdk_lseek64();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -558,7 +558,7 @@ int mkdir(const char *path, mode_t mode) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_mkdir == NULL) _set_ps2sdk_mkdir();
+	_glue_ps2sdk_mkdir();
 
 	return __transform_errno(_ps2sdk_mkdir(dest, mode));
 }
@@ -574,7 +574,7 @@ int rmdir(const char *path) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_rmdir == NULL) _set_ps2sdk_rmdir();
+	_glue_ps2sdk_rmdir();
 
 	return __transform_errno(_ps2sdk_rmdir(dest));
 }
@@ -596,7 +596,7 @@ int _unlink(const char *path) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_remove == NULL) _set_ps2sdk_remove();
+	_glue_ps2sdk_remove();
 
 	return __transform_errno(_ps2sdk_remove(dest));
 }
@@ -618,7 +618,7 @@ int _rename(const char *old, const char *new) {
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_rename == NULL) _set_ps2sdk_rename();
+	_glue_ps2sdk_rename();
 
 	return __transform_errno(_ps2sdk_rename(oldname, newname));
 }
@@ -829,7 +829,7 @@ int symlink(const char *target, const char *linkpath)
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_symlink == NULL) _set_ps2sdk_symlink();
+	_glue_ps2sdk_symlink();
 
 	return __transform_errno(_ps2sdk_symlink(dest_target, dest_linkpath));
 }
@@ -846,7 +846,7 @@ ssize_t readlink(const char *path, char *buf, size_t bufsiz)
 	}
 
 	// Set ps2sdk functions
-	if (_ps2sdk_readlink == NULL) _set_ps2sdk_readlink();
+	_glue_ps2sdk_readlink();
 
 	return 	__transform_errno(_ps2sdk_readlink(dest, buf, bufsiz));
 }

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -142,6 +142,12 @@ int _open(const char *buf, int flags, ...) {
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_dopen == NULL) _set_ps2sdk_dopen();
+	if (_ps2sdk_open == NULL) _set_ps2sdk_open();
+	if (_ps2sdk_dclose == NULL) _set_ps2sdk_dclose();
+	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+
 	// newlib frags differ from iop flags
 	if ((flags & 3) == O_RDONLY) iop_flags |= IOP_O_RDONLY;
 	if ((flags & 3) == O_WRONLY) iop_flags |= IOP_O_WRONLY;
@@ -188,6 +194,9 @@ int _close(int fd) {
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+
 	switch(__descriptormap[fd]->type)
 	{
 		case __DESCRIPTOR_TYPE_FILE:
@@ -227,6 +236,9 @@ int _read(int fd, void *buf, size_t nbytes) {
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_read == NULL) _set_ps2sdk_read();
+
 	switch(__descriptormap[fd]->type)
 	{
 		case __DESCRIPTOR_TYPE_FILE:
@@ -252,6 +264,9 @@ int _write(int fd, const void *buf, size_t nbytes) {
 		errno = EBADF;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_write == NULL) _set_ps2sdk_write();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -280,6 +295,9 @@ int _stat(const char *path, struct stat *buf) {
 		errno = ENAMETOOLONG;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_stat == NULL) _set_ps2sdk_stat();
 
 	return __transform_errno(_ps2sdk_stat(dest, buf));
 }
@@ -408,15 +426,18 @@ int getdents(int fd, void *dd_buf, int count)
 	read = 0;
 	dirp = (struct dirent *)dd_buf;
 
-   rv = _ps2sdk_dread(__descriptormap[fd]->descriptor, dirp);
-   if (rv < 0) {
-		return __transform_errno(rv);
-   } else if (rv == 0) {
-		return read;
-   }
+	// Set ps2sdk functions
+	if (_ps2sdk_dread == NULL) _set_ps2sdk_dread();
 
-   read += sizeof(struct dirent);	
-   dirp->d_reclen = count;
+	rv = _ps2sdk_dread(__descriptormap[fd]->descriptor, dirp);
+	if (rv < 0) {
+		return __transform_errno(rv);
+	} else if (rv == 0) {
+		return read;
+	}
+
+	read += sizeof(struct dirent);	
+	dirp->d_reclen = count;
 
 	return read;
 }
@@ -436,6 +457,11 @@ static off_t _lseekDir(int fd, off_t offset, int whence)
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+	if (_ps2sdk_dopen == NULL) _set_ps2sdk_dopen();
+	if (_ps2sdk_dread == NULL) _set_ps2sdk_dread();
+
 	_ps2sdk_dclose(__descriptormap[fd]->descriptor);
 	uid = _ps2sdk_dopen(__descriptormap[fd]->filename);
 	__descriptormap[fd]->descriptor = uid;
@@ -452,6 +478,9 @@ off_t _lseek(int fd, off_t offset, int whence)
 		errno = EBADF;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_lseek == NULL) _set_ps2sdk_lseek();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -481,6 +510,9 @@ off64_t lseek64(int fd, off64_t offset, int whence)
 		errno = EBADF;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_lseek64 == NULL) _set_ps2sdk_lseek64();
 
 	switch(__descriptormap[fd]->type)
 	{
@@ -525,6 +557,9 @@ int mkdir(const char *path, mode_t mode) {
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_mkdir == NULL) _set_ps2sdk_mkdir();
+
 	return __transform_errno(_ps2sdk_mkdir(dest, mode));
 }
 #endif
@@ -537,6 +572,9 @@ int rmdir(const char *path) {
 		errno = ENAMETOOLONG;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_rmdir == NULL) _set_ps2sdk_rmdir();
 
 	return __transform_errno(_ps2sdk_rmdir(dest));
 }
@@ -557,6 +595,9 @@ int _unlink(const char *path) {
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_remove == NULL) _set_ps2sdk_remove();
+
 	return __transform_errno(_ps2sdk_remove(dest));
 }
 #endif
@@ -575,6 +616,9 @@ int _rename(const char *old, const char *new) {
 		errno = ENAMETOOLONG;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_rename == NULL) _set_ps2sdk_rename();
 
 	return __transform_errno(_ps2sdk_rename(oldname, newname));
 }
@@ -784,6 +828,9 @@ int symlink(const char *target, const char *linkpath)
 		return -1;
 	}
 
+	// Set ps2sdk functions
+	if (_ps2sdk_symlink == NULL) _set_ps2sdk_symlink();
+
 	return __transform_errno(_ps2sdk_symlink(dest_target, dest_linkpath));
 }
 #endif
@@ -797,6 +844,10 @@ ssize_t readlink(const char *path, char *buf, size_t bufsiz)
 		errno = ENAMETOOLONG;
 		return -1;
 	}
+
+	// Set ps2sdk functions
+	if (_ps2sdk_readlink == NULL) _set_ps2sdk_readlink();
+
 	return 	__transform_errno(_ps2sdk_readlink(dest, buf, bufsiz));
 }
 #endif

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -99,14 +99,18 @@ void _set_ps2sdk_close() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_open
-static int fioOpenHelper(const char* path, int flags, ...) {
+#ifdef F___fioOpenHelper
+int __fioOpenHelper(const char* path, int flags, ...) {
   return fioOpen(path, flags);
 }
+#else
+int __fioOpenHelper(const char* path, int flags, ...);
+#endif
 
+#ifdef F__set_ps2sdk_open
 __attribute__((weak))
 void _set_ps2sdk_open() {
-    _ps2sdk_open = fioOpenHelper;
+    _ps2sdk_open = __fioOpenHelper;
 }
 #endif
 
@@ -124,16 +128,20 @@ void _set_ps2sdk_lseek() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_lseek64
-static off64_t _default_lseek64(int fd, off64_t offset, int whence)
+#ifdef F___fioLseek64Helper
+off64_t __fioLseek64Helper(int fd, off64_t offset, int whence)
 {
 	errno = ENOSYS;
 	return -1; /* not supported */
 }
+#else
+off64_t __fioLseek64Helper(int fd, off64_t offset, int whence);
+#endif
 
+#ifdef F__set_ps2sdk_lseek64
 __attribute__((weak))
 void _set_ps2sdk_lseek64() {
-    _ps2sdk_lseek64 = _default_lseek64;
+    _ps2sdk_lseek64 = __fioLseek64Helper;
 }
 #endif
 
@@ -158,29 +166,37 @@ void _set_ps2sdk_remove() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_rename
-static int fioRename(const char *old, const char *new) {
+#ifdef F___fioRenameHelper
+int __fioRenameHelper(const char *old, const char *new) {
 	errno = ENOSYS;
 	return -1; /* not supported */
 }
+#else
+int __fioRenameHelper(const char *old, const char *new);
+#endif
 
+#ifdef F__set_ps2sdk_rename
 __attribute__((weak))
 void _set_ps2sdk_rename() {
-    _ps2sdk_rename = fioRename;
+    _ps2sdk_rename = __fioRenameHelper;
 }
 #endif
 
-#ifdef F__set_ps2sdk_mkdir
-static int fioMkdirHelper(const char *path, int mode) {
+#ifdef F___fioMkdirHelper
+int __fioMkdirHelper(const char *path, int mode) {
   // Old fio mkdir has no mode argument
 	(void)mode;
 
   return fioMkdir(path);
 }
+#else
+int __fioMkdirHelper(const char *path, int mode);
+#endif
 
+#ifdef F__set_ps2sdk_mkdir
 __attribute__((weak))
 void _set_ps2sdk_mkdir() {
-    _ps2sdk_mkdir = fioMkdirHelper;
+    _ps2sdk_mkdir = __fioMkdirHelper;
 }
 #endif
 
@@ -191,7 +207,7 @@ void _set_ps2sdk_rmdir() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_stat
+#ifdef F___fioGetstatHelper
 static time_t io_to_posix_time(const unsigned char *ps2time)
 {
         struct tm tim;
@@ -232,7 +248,7 @@ static void __fill_stat(struct stat *stat, const io_stat_t *fiostat)
         stat->st_blocks = stat->st_size / 512;
 }
 
-static int fioGetstatHelper(const char *path, struct stat *buf) {
+int __fioGetstatHelper(const char *path, struct stat *buf) {
         io_stat_t fiostat;
 
         if (fioGetstat(path, &fiostat) < 0) {
@@ -244,36 +260,48 @@ static int fioGetstatHelper(const char *path, struct stat *buf) {
 
         return 0;
 }
+#else
+int __fioGetstatHelper(const char *path, struct stat *buf);
+#endif
 
+#ifdef F__set_ps2sdk_stat
 __attribute__((weak))
 void _set_ps2sdk_stat() {
-    _ps2sdk_stat = fioGetstatHelper;
+    _ps2sdk_stat = __fioGetstatHelper;
 }
+#endif
+
+#ifdef F___fioReadlinkHelper
+ssize_t __fioReadlinkHelper(const char *path, char *buf, size_t bufsiz)
+{
+	errno = ENOSYS;
+	return -1; /* not supported */
+}
+#else
+ssize_t __fioReadlinkHelper(const char *path, char *buf, size_t bufsiz);
 #endif
 
 #ifdef F__set_ps2sdk_readlink
-static ssize_t default_readlink(const char *path, char *buf, size_t bufsiz)
-{
-	errno = ENOSYS;
-	return -1; /* not supported */
-}
-
 __attribute__((weak))
 void _set_ps2sdk_readlink() {
-    _ps2sdk_readlink = default_readlink;
+    _ps2sdk_readlink = __fioReadlinkHelper;
 }
 #endif
 
-#ifdef F__set_ps2sdk_symlink
-static int default_symlink(const char *target, const char *linkpath)
+#ifdef F___fioSymlinkHelper
+int __fioSymlinkHelper(const char *target, const char *linkpath)
 {
 	errno = ENOSYS;
 	return -1; /* not supported */
 }
+#else
+int __fioSymlinkHelper(const char *target, const char *linkpath);
+#endif
 
+#ifdef F__set_ps2sdk_symlink
 __attribute__((weak))
 void _set_ps2sdk_symlink() {
-    _ps2sdk_symlink = default_symlink;
+    _ps2sdk_symlink = __fioSymlinkHelper;
 }
 #endif
 
@@ -284,8 +312,8 @@ void _set_ps2sdk_dopen() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_dread
-static int fioDreadHelper(int fd, struct dirent *dir) {
+#ifdef F___fioDreadHelper
+int __fioDreadHelper(int fd, struct dirent *dir) {
 	int rv;
 	io_dirent_t iodir;
 
@@ -312,10 +340,14 @@ static int fioDreadHelper(int fd, struct dirent *dir) {
 
 	return rv;
 }
+#else
+int __fioDreadHelper(int fd, struct dirent *dir);
+#endif
 
+#ifdef F__set_ps2sdk_dread
 __attribute__((weak))
 void _set_ps2sdk_dread() {
-    _ps2sdk_dread = fioDreadHelper;
+    _ps2sdk_dread = __fioDreadHelper;
 }
 #endif
 

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -325,3 +325,293 @@ void _set_ps2sdk_dclose() {
     _ps2sdk_dclose = fioDclose;
 }
 #endif
+
+
+#ifdef F__predefined_ps2sdk_close
+__attribute__((weak))
+void _predefined_ps2sdk_close() {}
+#endif
+
+#ifdef F__glue_ps2sdk_close
+void _predefined_ps2sdk_close();
+void _set_ps2sdk_close();
+
+void _glue_ps2sdk_close() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_close();
+
+    if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_open
+__attribute__((weak))
+void _predefined_ps2sdk_open() {}
+#endif
+
+#ifdef F__glue_ps2sdk_open
+void _predefined_ps2sdk_open();
+void _set_ps2sdk_open();
+
+void _glue_ps2sdk_open() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_open();
+
+    if (_ps2sdk_open == NULL) _set_ps2sdk_open();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_read
+__attribute__((weak))
+void _predefined_ps2sdk_read() {}
+#endif
+
+#ifdef F__glue_ps2sdk_read
+void _predefined_ps2sdk_read();
+void _set_ps2sdk_read();
+
+void _glue_ps2sdk_read() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_read();
+
+    if (_ps2sdk_read == NULL) _set_ps2sdk_read();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_lseek
+__attribute__((weak))
+void _predefined_ps2sdk_lseek() {}
+#endif
+
+#ifdef F__glue_ps2sdk_lseek
+void _predefined_ps2sdk_lseek();
+void _set_ps2sdk_lseek();
+
+void _glue_ps2sdk_lseek() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_lseek();
+
+    if (_ps2sdk_lseek == NULL) _set_ps2sdk_lseek();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_lseek64
+__attribute__((weak))
+void _predefined_ps2sdk_lseek64() {}
+#endif
+
+#ifdef F__glue_ps2sdk_lseek64
+void _predefined_ps2sdk_lseek64();
+void _set_ps2sdk_lseek64();
+
+void _glue_ps2sdk_lseek64() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_lseek64();
+
+    if (_ps2sdk_lseek64 == NULL) _set_ps2sdk_lseek64();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_write
+__attribute__((weak))
+void _predefined_ps2sdk_write() {}
+#endif
+
+#ifdef F__glue_ps2sdk_write
+void _predefined_ps2sdk_write();
+void _set_ps2sdk_write();
+
+void _glue_ps2sdk_write() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_write();
+
+    if (_ps2sdk_write == NULL) _set_ps2sdk_write();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_ioctl
+__attribute__((weak))
+void _predefined_ps2sdk_ioctl() {}
+#endif
+
+#ifdef F__glue_ps2sdk_ioctl
+void _predefined_ps2sdk_ioctl();
+void _set_ps2sdk_ioctl();
+
+void _glue_ps2sdk_ioctl() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_ioctl();
+
+    if (_ps2sdk_ioctl == NULL) _set_ps2sdk_ioctl();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_remove
+__attribute__((weak))
+void _predefined_ps2sdk_remove() {}
+#endif
+
+#ifdef F__glue_ps2sdk_remove
+void _predefined_ps2sdk_remove();
+void _set_ps2sdk_remove();
+
+void _glue_ps2sdk_remove() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_remove();
+
+    if (_ps2sdk_remove == NULL) _set_ps2sdk_remove();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_rename
+__attribute__((weak))
+void _predefined_ps2sdk_rename() {}
+#endif
+
+#ifdef F__glue_ps2sdk_rename
+void _predefined_ps2sdk_rename();
+void _set_ps2sdk_rename();
+
+void _glue_ps2sdk_rename() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_rename();
+
+    if (_ps2sdk_rename == NULL) _set_ps2sdk_rename();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_mkdir
+__attribute__((weak))
+void _predefined_ps2sdk_mkdir() {}
+#endif
+
+#ifdef F__glue_ps2sdk_mkdir
+void _predefined_ps2sdk_mkdir();
+void _set_ps2sdk_mkdir();
+
+void _glue_ps2sdk_mkdir() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_mkdir();
+
+    if (_ps2sdk_mkdir == NULL) _set_ps2sdk_mkdir();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_rmdir
+__attribute__((weak))
+void _predefined_ps2sdk_rmdir() {}
+#endif
+
+#ifdef F__glue_ps2sdk_rmdir
+void _predefined_ps2sdk_rmdir();
+void _set_ps2sdk_rmdir();
+
+void _glue_ps2sdk_rmdir() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_rmdir();
+
+    if (_ps2sdk_rmdir == NULL) _set_ps2sdk_rmdir();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_stat
+__attribute__((weak))
+void _predefined_ps2sdk_stat() {}
+#endif
+
+#ifdef F__glue_ps2sdk_stat
+void _predefined_ps2sdk_stat();
+void _set_ps2sdk_stat();
+
+void _glue_ps2sdk_stat() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_stat();
+
+    if (_ps2sdk_stat == NULL) _set_ps2sdk_stat();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_readlink
+__attribute__((weak))
+void _predefined_ps2sdk_readlink() {}
+#endif
+
+#ifdef F__glue_ps2sdk_readlink
+void _predefined_ps2sdk_readlink();
+void _set_ps2sdk_readlink();
+
+void _glue_ps2sdk_readlink() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_readlink();
+
+    if (_ps2sdk_readlink == NULL) _set_ps2sdk_readlink();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_symlink
+__attribute__((weak))
+void _predefined_ps2sdk_symlink() {}
+#endif
+
+#ifdef F__glue_ps2sdk_symlink
+void _predefined_ps2sdk_symlink();
+void _set_ps2sdk_symlink();
+
+void _glue_ps2sdk_symlink() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_symlink();
+
+    if (_ps2sdk_symlink == NULL) _set_ps2sdk_symlink();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_dopen
+__attribute__((weak))
+void _predefined_ps2sdk_dopen() {}
+#endif
+
+#ifdef F__glue_ps2sdk_dopen
+void _predefined_ps2sdk_dopen();
+void _set_ps2sdk_dopen();
+
+void _glue_ps2sdk_dopen() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_dopen();
+
+    if (_ps2sdk_dopen == NULL) _set_ps2sdk_dopen();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_dread
+__attribute__((weak))
+void _predefined_ps2sdk_dread() {}
+#endif
+
+#ifdef F__glue_ps2sdk_dread
+void _predefined_ps2sdk_dread();
+void _set_ps2sdk_dread();
+
+void _glue_ps2sdk_dread() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_dread();
+
+    if (_ps2sdk_dread == NULL) _set_ps2sdk_dread();
+}
+#endif
+
+#ifdef F__predefined_ps2sdk_dclose
+__attribute__((weak))
+void _predefined_ps2sdk_dclose() {}
+#endif
+
+#ifdef F__glue_ps2sdk_dclose
+void _predefined_ps2sdk_dclose();
+void _set_ps2sdk_dclose();
+
+void _glue_ps2sdk_dclose() {
+    // Check if predefined values are set
+    _predefined_ps2sdk_dclose();
+
+    if (_ps2sdk_dclose == NULL) _set_ps2sdk_dclose();
+}
+#endif

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -23,9 +23,9 @@
 
 static inline void setPS2SDKFunctions() {
 	// Set ps2sdk functions
-	if (_ps2sdk_open == NULL) _set_ps2sdk_open();
-	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
-	if (_ps2sdk_read == NULL) _set_ps2sdk_read();
+	_glue_ps2sdk_open();
+	_glue_ps2sdk_close();
+	_glue_ps2sdk_read();
 }
 
 #ifdef F__libcglue_timezone_update

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -42,7 +42,10 @@ void _libcglue_timezone_update()
     int minutes = tzOffsetAbs - hours * 60;
     int daylight = configIsDaylightSavingEnabledWithIODriver(&driver);
     static char tz[15];
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-overflow"
     sprintf(tz, "GMT%s%02i:%02i%s", tzOffset < 0 ? "+" : "-", hours, minutes, daylight ? "DST" : "");
+	#pragma GCC diagnostic pop
     setenv("TZ", tz, 1);
 }
 #endif

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -26,6 +26,12 @@ void _libcglue_timezone_update()
 {
     /* Initialize timezone from PS2 OSD configuration */
     int tzOffset = 0;
+	
+	// Set ps2sdk functions
+	if (_ps2sdk_open == NULL) _set_ps2sdk_open();
+	if (_ps2sdk_close == NULL) _set_ps2sdk_close();
+	if (_ps2sdk_read == NULL) _set_ps2sdk_read();
+
 	_io_driver driver = { _ps2sdk_open, _ps2sdk_close, _ps2sdk_read };
 	configGetTimezoneWithIODriver(&driver);
     int tzOffsetAbs = tzOffset < 0 ? -tzOffset : tzOffset;

--- a/ee/rpc/filexio/Makefile
+++ b/ee/rpc/filexio/Makefile
@@ -8,9 +8,30 @@
 
 EE_LIB = libfileXio.a
 
-EE_OBJS = fileXio_rpc.o erl-support.o
+CORE_OBJS = erl-support.o
+
+FILEXIO_RPC_OBJS = \
+	__cd0.o __sbuff.o __intr_data.o __fileXioInited.o __fileXioBlockMode.o __fileXioCompletionSema.o __lock_sema_id.o \
+	fileXioInit.o fileXioExit.o fileXioStop.o fileXioGetDeviceList.o fileXioGetdir.o fileXioMount.o fileXioUmount.o \
+	fileXioCopyfile.o fileXioMkdir.o fileXioRmdir.o fileXioRemove.o fileXioRename.o fileXioSymlink.o fileXioReadlink.o \
+	fileXioChdir.o fileXioOpen.o fileXioClose.o fileXioRead.o fileXioWrite.o fileXioLseek.o fileXioLseek64.o fileXioChStat.o \
+	fileXioGetStat.o fileXioFormat.o fileXioSync.o fileXioDopen.o fileXioDclose.o fileXioDread.o fileXioDevctl.o \
+	fileXioIoctl.o fileXioIoctl2.o fileXioWaitAsync.o fileXioSetBlockMode.o fileXioSetRWBufferSize.o
+
+FILEXIO_PS2SDK_OBJS = \
+	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
+	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
+	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o
+
+EE_OBJS = $(CORE_OBJS) $(FILEXIO_RPC_OBJS) $(FILEXIO_PS2SDK_OBJS) 
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
 include $(PS2SDKSRC)/ee/Rules.make
 include $(PS2SDKSRC)/ee/Rules.release
+
+$(FILEXIO_RPC_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)fileXio_rpc.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
+
+$(FILEXIO_PS2SDK_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)fileXio_ps2sdk.c
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@

--- a/ee/rpc/filexio/Makefile
+++ b/ee/rpc/filexio/Makefile
@@ -19,6 +19,7 @@ FILEXIO_RPC_OBJS = \
 	fileXioIoctl.o fileXioIoctl2.o fileXioWaitAsync.o fileXioSetBlockMode.o fileXioSetRWBufferSize.o
 
 FILEXIO_PS2SDK_OBJS = \
+	__fileXioGetstatHelper.o __fileXioDreadHelper.o \
 	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
 	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
 	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o

--- a/ee/rpc/filexio/include/fileXio_rpc.h
+++ b/ee/rpc/filexio/include/fileXio_rpc.h
@@ -35,7 +35,6 @@ extern "C" {
 #endif
 
 int fileXioInit(void);
-int fileXioInitSkipOverride(void);
 void fileXioExit(void);
 void fileXioSetBlockMode(int blocking);
 int fileXioWaitAsync(int mode, int *retVal);

--- a/ee/rpc/filexio/samples/Makefile
+++ b/ee/rpc/filexio/samples/Makefile
@@ -1,0 +1,12 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+SAMPLE_DIR = rpc/filexio
+
+include $(PS2SDKSRC)/Defs.make
+include $(PS2SDKSRC)/samples/Rules.samples

--- a/ee/rpc/filexio/samples/Makefile.sample
+++ b/ee/rpc/filexio/samples/Makefile.sample
@@ -1,0 +1,34 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+EE_BIN = filexio_sample.elf
+EE_OBJS = main.o
+EE_LIBS = -lfileXio
+EE_CFLAGS = -fdata-sections -ffunction-sections -flto
+EE_LDFLAGS = -fdata-sections -ffunction-sections -flto -Wl,--gc-sections
+
+IRX_FILES += iomanX.irx fileXio.irx
+EE_OBJS += $(IRX_FILES:.irx=_irx.o)
+
+all: $(EE_BIN) 
+
+clean:
+	rm -f $(EE_BIN) $(EE_OBJS)
+
+# IRX files
+%_irx.c:
+	$(PS2SDK)/bin/bin2c $(PS2SDK)/iop/irx/$*.irx $@ $*_irx
+
+run: $(EE_BIN)
+	ps2client execee host:$(EE_BIN)
+
+reset:
+	ps2client reset
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/ee/rpc/filexio/samples/main.c
+++ b/ee/rpc/filexio/samples/main.c
@@ -1,0 +1,58 @@
+#include <stdint.h>
+#include <kernel.h>
+#include <loadfile.h>
+#include <stdio.h>
+#include <sifrpc.h>
+#include <string.h>
+
+int __iomanX_id = -1;
+int __fileXio_id = -1;
+
+/* References to IOMANX.IRX */
+extern unsigned char iomanX_irx[] __attribute__((aligned(16)));
+extern unsigned int size_iomanX_irx;
+
+/* References to FILEXIO.IRX */
+extern unsigned char fileXio_irx[] __attribute__((aligned(16)));
+extern unsigned int size_fileXio_irx;
+
+static int loadIRXs(void) {
+    /* IOMANX.IRX */
+    __iomanX_id = SifExecModuleBuffer(&iomanX_irx, size_iomanX_irx, 0, NULL, NULL);
+    if (__iomanX_id < 0)
+        return -1;
+
+    /* FILEXIO.IRX */
+    __fileXio_id = SifExecModuleBuffer(&fileXio_irx, size_fileXio_irx, 0, NULL, NULL);
+    if (__fileXio_id < 0)
+        return -2;
+
+    return 0;
+}
+
+static int initLibraries(void) {
+    return fileXioInit();
+}
+
+static int init_fileXio_driver() {
+    int __fileXio_init_status = loadIRXs();
+    if (__fileXio_init_status < 0)
+        return __fileXio_init_status;
+
+    __fileXio_init_status = initLibraries();
+
+    return __fileXio_init_status;
+}
+
+int main(int argc, char *argv[])
+{
+	init_fileXio_driver();
+
+	while (1)
+	{
+		printf("Hello using fileXio\n");
+	}
+
+	return 0;
+}
+

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -1,0 +1,229 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (C)2001, Gustavo Scotti (gustavo@scotti.com)
+# (c) 2003 Marcus R. Brown <mrbrown@0xd6.org>
+# (c) 2023 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * fileXio_ps2sdk.c - Define set methods for _ps2sdk functions
+ */
+
+#include <ps2sdkapi.h>
+#include <string.h>
+#include <errno.h>
+#define NEWLIB_PORT_AWARE
+#include <fileXio_rpc.h>
+#include "iox_stat.h"
+
+/** Setting fileXio functions */
+#ifdef F__set_ps2sdk_close
+uint8_t __ps2sdk_fileXio_close = 0;
+void _set_ps2sdk_close() {
+    _ps2sdk_close = fileXioClose;
+}
+#endif
+
+#ifdef F__set_ps2sdk_open
+uint8_t __ps2sdk_fileXio_open = 0;
+void _set_ps2sdk_open() {
+    _ps2sdk_open = fileXioOpen;
+}
+#endif
+
+#ifdef F__set_ps2sdk_read
+uint8_t __ps2sdk_fileXio_read = 0;
+void _set_ps2sdk_read() {
+    _ps2sdk_read = fileXioRead;
+}
+#endif
+
+#ifdef F__set_ps2sdk_lseek
+uint8_t __ps2sdk_fileXio_lseek = 0;
+void _set_ps2sdk_lseek() {
+    _ps2sdk_lseek = fileXioLseek;
+}
+#endif
+
+#ifdef F__set_ps2sdk_lseek64
+uint8_t __ps2sdk_fileXio_lseek64 = 0;
+void _set_ps2sdk_lseek64() {
+    _ps2sdk_lseek64 = fileXioLseek64;
+}
+#endif
+
+#ifdef F__set_ps2sdk_write
+uint8_t __ps2sdk_fileXio_write = 0;
+void _set_ps2sdk_write() {
+    _ps2sdk_write = fileXioWrite;
+}
+#endif
+
+#ifdef F__set_ps2sdk_ioctl
+uint8_t __ps2sdk_fileXio_ioctl = 0;
+void _set_ps2sdk_ioctl() {
+    _ps2sdk_ioctl = fileXioIoctl;
+}
+#endif
+
+#ifdef F__set_ps2sdk_remove
+uint8_t __ps2sdk_fileXio_remove = 0;
+void _set_ps2sdk_remove() {
+    _ps2sdk_remove = fileXioRemove;
+}
+#endif
+
+#ifdef F__set_ps2sdk_rename
+uint8_t __ps2sdk_fileXio_rename = 0;
+void _set_ps2sdk_rename() {
+    _ps2sdk_rename = fileXioRename;
+}
+#endif
+
+#ifdef F__set_ps2sdk_mkdir
+uint8_t __ps2sdk_fileXio_mkdir = 0;
+void _set_ps2sdk_mkdir() {
+    _ps2sdk_mkdir = fileXioMkdir;
+}
+#endif
+
+#ifdef F__set_ps2sdk_rmdir
+uint8_t __ps2sdk_fileXio_rmdir = 0;
+void _set_ps2sdk_rmdir() {
+    _ps2sdk_rmdir = fileXioRmdir;
+}
+#endif
+
+#ifdef F__set_ps2sdk_stat
+static time_t io_to_posix_time(const unsigned char *ps2time)
+{
+        struct tm tim;
+        tim.tm_sec  = ps2time[1];
+        tim.tm_min  = ps2time[2];
+        tim.tm_hour = ps2time[3];
+        tim.tm_mday = ps2time[4];
+        tim.tm_mon  = ps2time[5] - 1;
+        tim.tm_year = ((u16)ps2time[6] | ((u16)ps2time[7] << 8)) - 1900;
+        return mktime(&tim);
+}
+
+static mode_t iox_to_posix_mode(unsigned int ps2mode)
+{
+        mode_t posixmode = 0;
+        if (ps2mode & FIO_S_IFREG) posixmode |= S_IFREG;
+        if (ps2mode & FIO_S_IFDIR) posixmode |= S_IFDIR;
+        if (ps2mode & FIO_S_IRUSR) posixmode |= S_IRUSR;
+        if (ps2mode & FIO_S_IWUSR) posixmode |= S_IWUSR;
+        if (ps2mode & FIO_S_IXUSR) posixmode |= S_IXUSR;
+        if (ps2mode & FIO_S_IRGRP) posixmode |= S_IRGRP;
+        if (ps2mode & FIO_S_IWGRP) posixmode |= S_IWGRP;
+        if (ps2mode & FIO_S_IXGRP) posixmode |= S_IXGRP;
+        if (ps2mode & FIO_S_IROTH) posixmode |= S_IROTH;
+        if (ps2mode & FIO_S_IWOTH) posixmode |= S_IWOTH;
+        if (ps2mode & FIO_S_IXOTH) posixmode |= S_IXOTH;
+        return posixmode;
+}
+
+static void fill_stat(struct stat *stat, const iox_stat_t *fiostat)
+{
+        stat->st_dev = 0;
+        stat->st_ino = 0;
+        stat->st_mode = iox_to_posix_mode(fiostat->mode);
+        stat->st_nlink = 0;
+        stat->st_uid = 0;
+        stat->st_gid = 0;
+        stat->st_rdev = 0;
+        stat->st_size = ((off_t)fiostat->hisize << 32) | (off_t)fiostat->size;
+        stat->st_atime = io_to_posix_time(fiostat->atime);
+        stat->st_mtime = io_to_posix_time(fiostat->mtime);
+        stat->st_ctime = io_to_posix_time(fiostat->ctime);
+        stat->st_blksize = 16*1024;
+        stat->st_blocks = stat->st_size / 512;
+}
+
+static int fileXioGetstatHelper(const char *path, struct stat *buf) {
+        iox_stat_t fiostat;
+
+        if (fileXioGetStat(path, &fiostat) < 0) {
+            errno = ENOENT;
+            return -1;
+        }
+
+        fill_stat(buf, &fiostat);
+
+        return 0;
+}
+
+uint8_t __ps2sdk_fileXio_stat = 0;
+void _set_ps2sdk_stat() {
+    _ps2sdk_stat = fileXioGetstatHelper;
+}
+#endif
+
+#ifdef F__set_ps2sdk_readlink
+uint8_t __ps2sdk_fileXio_readlink = 0;
+void _set_ps2sdk_readlink() {
+    _ps2sdk_readlink = fileXioReadlink;
+}
+#endif
+
+#ifdef F__set_ps2sdk_symlink
+uint8_t __ps2sdk_fileXio_symlink = 0;
+void _set_ps2sdk_symlink() {
+    _ps2sdk_symlink = fileXioSymlink;
+}
+#endif
+
+#ifdef F__set_ps2sdk_dopen
+uint8_t __ps2sdk_fileXio_dopen = 0;
+void _set_ps2sdk_dopen() {
+    _ps2sdk_dopen = fileXioDopen;
+}
+#endif
+
+#ifdef F__set_ps2sdk_dread
+static int fileXioDreadHelper(int fd, struct dirent *dir) {
+	int rv;
+	iox_dirent_t ioxdir;
+
+	// Took from iox_dirent_t
+	#define __MAXNAMLEN 256
+
+	rv = fileXioDread(fd, &ioxdir);
+	if (rv < 0) {
+		errno = ENOENT;
+		return -1;
+	}
+
+	dir->d_fileno = rv; // TODO: This number should be in theory a unique number per file
+	strncpy(dir->d_name, ioxdir.name, __MAXNAMLEN);
+	dir->d_name[__MAXNAMLEN - 1] = 0;
+	dir->d_reclen = 0;
+	switch (ioxdir.stat.mode & FIO_S_IFMT) {
+		case FIO_S_IFLNK: dir->d_type = DT_LNK;     break;
+		case FIO_S_IFDIR: dir->d_type = DT_DIR;     break;
+		case FIO_S_IFREG: dir->d_type = DT_REG;     break;
+		default:          dir->d_type = DT_UNKNOWN; break;
+	}
+
+	return rv;
+}
+
+uint8_t __ps2sdk_fileXio_dread = 0;
+void _set_ps2sdk_dread() {
+    _ps2sdk_dread = fileXioDreadHelper;
+}
+#endif
+
+#ifdef F__set_ps2sdk_dclose
+uint8_t __ps2sdk_fileXio_dclose = 0;
+void _set_ps2sdk_dclose() {
+    _ps2sdk_dclose = fileXioDclose;
+}
+#endif

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -100,7 +100,7 @@ void _set_ps2sdk_rmdir() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_stat
+#ifdef F___fileXioGetstatHelper
 static time_t io_to_posix_time(const unsigned char *ps2time)
 {
         struct tm tim;
@@ -147,7 +147,7 @@ static void fill_stat(struct stat *stat, const iox_stat_t *fiostat)
         stat->st_blocks = stat->st_size / 512;
 }
 
-static int fileXioGetstatHelper(const char *path, struct stat *buf) {
+int __fileXioGetstatHelper(const char *path, struct stat *buf) {
         iox_stat_t fiostat;
 
         if (fileXioGetStat(path, &fiostat) < 0) {
@@ -159,10 +159,14 @@ static int fileXioGetstatHelper(const char *path, struct stat *buf) {
 
         return 0;
 }
+#else
+int __fileXioGetstatHelper(const char *path, struct stat *buf);
+#endif
 
+#ifdef F__set_ps2sdk_stat
 uint8_t __ps2sdk_fileXio_stat = 0;
 void _set_ps2sdk_stat() {
-    _ps2sdk_stat = fileXioGetstatHelper;
+    _ps2sdk_stat = __fileXioGetstatHelper;
 }
 #endif
 
@@ -187,8 +191,8 @@ void _set_ps2sdk_dopen() {
 }
 #endif
 
-#ifdef F__set_ps2sdk_dread
-static int fileXioDreadHelper(int fd, struct dirent *dir) {
+#ifdef F___fileXioDreadHelper
+int __fileXioDreadHelper(int fd, struct dirent *dir) {
 	int rv;
 	iox_dirent_t ioxdir;
 
@@ -214,10 +218,14 @@ static int fileXioDreadHelper(int fd, struct dirent *dir) {
 
 	return rv;
 }
+#else
+int __fileXioDreadHelper(int fd, struct dirent *dir);
+#endif
 
+#ifdef F__set_ps2sdk_dread
 uint8_t __ps2sdk_fileXio_dread = 0;
 void _set_ps2sdk_dread() {
-    _ps2sdk_dread = fileXioDreadHelper;
+    _ps2sdk_dread = __fileXioDreadHelper;
 }
 #endif
 

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -29,137 +29,86 @@
 #include <errno.h>
 
 extern int _iop_reboot_count;
-static SifRpcClientData_t cd0;
-static unsigned int sbuff[0x1300] __attribute__((aligned (64)));
-static int _intr_data[0xC00] __attribute__((aligned(64)));
-static int fileXioInited = 0;
-static int fileXioBlockMode;
-static int fileXioCompletionSema = -1;
 
-/* Backup pointer functions to restore after exit fileXio */
-static int (*_backup_ps2sdk_close)(int);
-static int (*_backup_ps2sdk_open)(const char*, int, ...);
-static int (*_backup_ps2sdk_read)(int, void*, int);
-static int (*_backup_ps2sdk_lseek)(int, int, int);
-static int64_t (*_backup_ps2sdk_lseek64)(int, int64_t, int);
-static int (*_backup_ps2sdk_write)(int, const void*, int);
-static int (*_backup_ps2sdk_ioctl)(int, int, void*);
-static int (*_backup_ps2sdk_remove)(const char*);
-static int (*_backup_ps2sdk_rename)(const char*, const char*);
-static int (*_backup_ps2sdk_mkdir)(const char*, int);
-static int (*_backup_ps2sdk_rmdir)(const char*);
+/* Extern symbols to help fileXio override weak methods for fileXio_ps2sdk */
+/* More info here: https://stackoverflow.com/a/22178564 */
+extern uint8_t __ps2sdk_fileXio_close;
+extern uint8_t __ps2sdk_fileXio_open;
+extern uint8_t __ps2sdk_fileXio_read;
+extern uint8_t __ps2sdk_fileXio_lseek;
+extern uint8_t __ps2sdk_fileXio_lseek64;
+extern uint8_t __ps2sdk_fileXio_write;
+extern uint8_t __ps2sdk_fileXio_ioctl;
+extern uint8_t __ps2sdk_fileXio_remove;
+extern uint8_t __ps2sdk_fileXio_rename;
+extern uint8_t __ps2sdk_fileXio_mkdir;
+extern uint8_t __ps2sdk_fileXio_rmdir;
+extern uint8_t __ps2sdk_fileXio_stat;
+extern uint8_t __ps2sdk_fileXio_readlink;
+extern uint8_t __ps2sdk_fileXio_symlink;
+extern uint8_t __ps2sdk_fileXio_dopen;
+extern uint8_t __ps2sdk_fileXio_dread;
+extern uint8_t __ps2sdk_fileXio_dclose;
 
-static int (*_backup_ps2sdk_stat)(const char *path, struct stat *buf);
-static int (*_backup_ps2sdk_readlink)(const char *path, char *buf, size_t bufsiz);
-static int (*_backup_ps2sdk_symlink)(const char *target, const char *linkpath);
+#ifdef F___cd0
+SifRpcClientData_t __cd0;
+#else
+extern SifRpcClientData_t __cd0;
+#endif
 
-static int (*_backup_ps2sdk_dopen)(const char *path);
-static int (*_backup_ps2sdk_dread)(int fd, struct dirent *dir);
-static int (*_backup_ps2sdk_dclose)(int fd);
+#ifdef F___sbuff
+unsigned int __sbuff[0x1300] __attribute__((aligned (64)));
+#else
+extern unsigned int __sbuff[0x1300] __attribute__((aligned (64)));
+#endif
 
-static void _fxio_intr(void)
+#ifdef F___intr_data
+int __intr_data[0xC00] __attribute__((aligned(64)));
+#else
+extern int __intr_data[0xC00] __attribute__((aligned(64)));
+#endif
+
+#ifdef F___fileXioInited
+int __fileXioInited = 0;
+#else
+extern int __fileXioInited;
+#endif
+
+#ifdef F___fileXioBlockMode
+int __fileXioBlockMode;
+#else
+extern int __fileXioBlockMode;
+#endif
+
+#ifdef F___fileXioCompletionSema
+int __fileXioCompletionSema = -1;
+#else
+extern int __fileXioCompletionSema;
+#endif
+
+#ifdef F___lock_sema_id
+int __lock_sema_id = -1;
+#else
+extern int __lock_sema_id;
+#endif
+
+static inline void _fxio_intr(void)
 {
-	iSignalSema(fileXioCompletionSema);
+	iSignalSema(__fileXioCompletionSema);
 }
 
-static int _lock_sema_id = -1;
 static inline int _lock(void)
 {
-	return(WaitSema(_lock_sema_id));
+	return(WaitSema(__lock_sema_id));
 }
 
 static inline int _unlock(void)
 {
-	return(SignalSema(_lock_sema_id));
+	return(SignalSema(__lock_sema_id));
 }
 
-static time_t io_to_posix_time(const unsigned char *ps2time)
-{
-        struct tm tim;
-        tim.tm_sec  = ps2time[1];
-        tim.tm_min  = ps2time[2];
-        tim.tm_hour = ps2time[3];
-        tim.tm_mday = ps2time[4];
-        tim.tm_mon  = ps2time[5] - 1;
-        tim.tm_year = ((u16)ps2time[6] | ((u16)ps2time[7] << 8)) - 1900;
-        return mktime(&tim);
-}
-
-static mode_t iox_to_posix_mode(unsigned int ps2mode)
-{
-        mode_t posixmode = 0;
-        if (ps2mode & FIO_S_IFREG) posixmode |= S_IFREG;
-        if (ps2mode & FIO_S_IFDIR) posixmode |= S_IFDIR;
-        if (ps2mode & FIO_S_IRUSR) posixmode |= S_IRUSR;
-        if (ps2mode & FIO_S_IWUSR) posixmode |= S_IWUSR;
-        if (ps2mode & FIO_S_IXUSR) posixmode |= S_IXUSR;
-        if (ps2mode & FIO_S_IRGRP) posixmode |= S_IRGRP;
-        if (ps2mode & FIO_S_IWGRP) posixmode |= S_IWGRP;
-        if (ps2mode & FIO_S_IXGRP) posixmode |= S_IXGRP;
-        if (ps2mode & FIO_S_IROTH) posixmode |= S_IROTH;
-        if (ps2mode & FIO_S_IWOTH) posixmode |= S_IWOTH;
-        if (ps2mode & FIO_S_IXOTH) posixmode |= S_IXOTH;
-        return posixmode;
-}
-
-static void fill_stat(struct stat *stat, const iox_stat_t *fiostat)
-{
-        stat->st_dev = 0;
-        stat->st_ino = 0;
-        stat->st_mode = iox_to_posix_mode(fiostat->mode);
-        stat->st_nlink = 0;
-        stat->st_uid = 0;
-        stat->st_gid = 0;
-        stat->st_rdev = 0;
-        stat->st_size = ((off_t)fiostat->hisize << 32) | (off_t)fiostat->size;
-        stat->st_atime = io_to_posix_time(fiostat->atime);
-        stat->st_mtime = io_to_posix_time(fiostat->mtime);
-        stat->st_ctime = io_to_posix_time(fiostat->ctime);
-        stat->st_blksize = 16*1024;
-        stat->st_blocks = stat->st_size / 512;
-}
-
-static int fileXioGetstatHelper(const char *path, struct stat *buf) {
-        iox_stat_t fiostat;
-
-        if (fileXioGetStat(path, &fiostat) < 0) {
-            errno = ENOENT;
-            return -1;
-        }
-
-        fill_stat(buf, &fiostat);
-
-        return 0;
-}
-
-static int fileXioDreadHelper(int fd, struct dirent *dir) {
-	int rv;
-	iox_dirent_t ioxdir;
-
-	// Took from iox_dirent_t
-	#define __MAXNAMLEN 256
-
-	rv = fileXioDread(fd, &ioxdir);
-	if (rv < 0) {
-		errno = ENOENT;
-		return -1;
-	}
-
-	dir->d_fileno = rv; // TODO: This number should be in theory a unique number per file
-	strncpy(dir->d_name, ioxdir.name, __MAXNAMLEN);
-	dir->d_name[__MAXNAMLEN - 1] = 0;
-	dir->d_reclen = 0;
-	switch (ioxdir.stat.mode & FIO_S_IFMT) {
-		case FIO_S_IFLNK: dir->d_type = DT_LNK;     break;
-		case FIO_S_IFDIR: dir->d_type = DT_DIR;     break;
-		case FIO_S_IFREG: dir->d_type = DT_REG;     break;
-		default:          dir->d_type = DT_UNKNOWN; break;
-	}
-
-	return rv;
-}
-
-static int fileXioInitHelper(int overrideNewlibMethods)
+#ifdef F_fileXioInit
+int fileXioInit(void)
 {
 	int res;
 	ee_sema_t sp;
@@ -172,7 +121,7 @@ static int fileXioInitHelper(int overrideNewlibMethods)
 		fileXioExit();
 	}
 
-	if(fileXioInited)
+	if(__fileXioInited)
 	{
 		return 0;
 	}
@@ -180,9 +129,9 @@ static int fileXioInitHelper(int overrideNewlibMethods)
 	sp.init_count = 1;
 	sp.max_count = 1;
 	sp.option = 0;
-	_lock_sema_id = CreateSema(&sp);
+	__lock_sema_id = CreateSema(&sp);
 
-	while(((res = SifBindRpc(&cd0, FILEXIO_IRX, 0)) >= 0) && (cd0.server == NULL))
+	while(((res = SifBindRpc(&__cd0, FILEXIO_IRX, 0)) >= 0) && (__cd0.server == NULL))
 		nopdelay();
 
 	if(res < 0)
@@ -191,193 +140,84 @@ static int fileXioInitHelper(int overrideNewlibMethods)
 	sp.init_count = 1;
 	sp.max_count = 1;
 	sp.option = 0;
-	fileXioCompletionSema = CreateSema(&sp);
-	if (fileXioCompletionSema < 0)
+	__fileXioCompletionSema = CreateSema(&sp);
+	if (__fileXioCompletionSema < 0)
 		return -1;
 
-	fileXioInited = 1;
-	fileXioBlockMode = FXIO_WAIT;
-
-	if (overrideNewlibMethods) 
-	{
-		_backup_ps2sdk_close = _ps2sdk_close;
-		_ps2sdk_close = fileXioClose;
-		_backup_ps2sdk_open = _ps2sdk_open;
-		_ps2sdk_open = fileXioOpen;
-		_backup_ps2sdk_read = _ps2sdk_read;
-		_ps2sdk_read = fileXioRead;
-		_backup_ps2sdk_lseek = _ps2sdk_lseek;
-		_ps2sdk_lseek = fileXioLseek;
-		_backup_ps2sdk_lseek64 = _ps2sdk_lseek64;
-		_ps2sdk_lseek64 = fileXioLseek64;
-		_backup_ps2sdk_write = _ps2sdk_write;
-		_ps2sdk_write = fileXioWrite;
-		_backup_ps2sdk_ioctl = _ps2sdk_ioctl;
-		_ps2sdk_ioctl = fileXioIoctl;
-		_backup_ps2sdk_remove = _ps2sdk_remove;
-		_ps2sdk_remove= fileXioRemove;
-		_backup_ps2sdk_rename = _ps2sdk_rename;
-		_ps2sdk_rename= fileXioRename;
-		_backup_ps2sdk_mkdir = _ps2sdk_mkdir;
-		_ps2sdk_mkdir = fileXioMkdir;
-		_backup_ps2sdk_rmdir = _ps2sdk_rmdir;
-		_ps2sdk_rmdir = fileXioRmdir;
-		_backup_ps2sdk_stat = _ps2sdk_stat;
-		_ps2sdk_stat = fileXioGetstatHelper;
-		_backup_ps2sdk_readlink = _ps2sdk_readlink;
-		_ps2sdk_readlink = fileXioReadlink;
-		_backup_ps2sdk_symlink = _ps2sdk_symlink;
-		_ps2sdk_symlink = fileXioSymlink;
-		_backup_ps2sdk_dopen = _ps2sdk_dopen;
-		_ps2sdk_dopen = fileXioDopen;
-		_backup_ps2sdk_dread = _ps2sdk_dread;
-		_ps2sdk_dread = fileXioDreadHelper;
-		_backup_ps2sdk_dclose = _ps2sdk_dclose;
-		_ps2sdk_dclose = fileXioDclose;
-	}
+	__fileXioInited = 1;
+	__fileXioBlockMode = FXIO_WAIT;
 
 	return 0;
 }
+#endif
 
-int fileXioInit(void)
-{
-	return fileXioInitHelper(1);
-}
-
-int fileXioInitSkipOverride(void)
-{
-	return fileXioInitHelper(0);
-}
-
+#ifdef F_fileXioExit
 void fileXioExit(void)
 {
-	if(fileXioInited)
+	if(__fileXioInited)
 	{
-		if(_lock_sema_id >= 0) DeleteSema(_lock_sema_id);
-		if(fileXioCompletionSema >= 0) DeleteSema(fileXioCompletionSema);
+		if(__lock_sema_id >= 0) DeleteSema(__lock_sema_id);
+		if(__fileXioCompletionSema >= 0) DeleteSema(__fileXioCompletionSema);
 
-		memset(&cd0, 0, sizeof(cd0));
+		memset(&__cd0, 0, sizeof(__cd0));
 
-		fileXioInited = 0;
-	}
-
-	if (_backup_ps2sdk_close) {
-		_ps2sdk_close = _backup_ps2sdk_close;
-		_backup_ps2sdk_close = NULL;	
-	} 
-	if (_backup_ps2sdk_open) {
-		_ps2sdk_open = _backup_ps2sdk_open;
-		_backup_ps2sdk_open = NULL;	
-	} 
-	if (_backup_ps2sdk_read) {
-		_ps2sdk_read = _backup_ps2sdk_read;
-		_backup_ps2sdk_read = NULL;	
-	} 
-	if (_backup_ps2sdk_lseek) {
-		_ps2sdk_lseek = _backup_ps2sdk_lseek;
-		_backup_ps2sdk_lseek = NULL;	
-	} 
-	if (_backup_ps2sdk_lseek64) {
-		_ps2sdk_lseek64 = _backup_ps2sdk_lseek64;
-		_backup_ps2sdk_lseek64 = NULL;	
-	} 
-	if (_backup_ps2sdk_write) {
-		_ps2sdk_write = _backup_ps2sdk_write;
-		_backup_ps2sdk_write = NULL;	
-	} 
-	if (_backup_ps2sdk_ioctl) {
-		_ps2sdk_ioctl = _backup_ps2sdk_ioctl;
-		_backup_ps2sdk_ioctl = NULL;	
-	} 
-	if (_backup_ps2sdk_remove) {
-		_ps2sdk_remove = _backup_ps2sdk_remove;
-		_backup_ps2sdk_remove = NULL;	
-	} 
-	if (_backup_ps2sdk_rename) {
-		_ps2sdk_rename = _backup_ps2sdk_rename;
-		_backup_ps2sdk_rename = NULL;	
-	} 
-	if (_backup_ps2sdk_mkdir) {
-		_ps2sdk_mkdir = _backup_ps2sdk_mkdir;
-		_backup_ps2sdk_mkdir = NULL;	
-	} 
-	if (_backup_ps2sdk_rmdir) {
-		_ps2sdk_rmdir = _backup_ps2sdk_rmdir;
-		_backup_ps2sdk_rmdir = NULL;	
-	} 
-	if (_backup_ps2sdk_stat) {
-		_ps2sdk_stat = _backup_ps2sdk_stat;
-		_backup_ps2sdk_stat = NULL;
-	}
-	if (_backup_ps2sdk_readlink) {
-		_ps2sdk_readlink = _backup_ps2sdk_readlink;
-		_backup_ps2sdk_readlink = NULL;	
-	} 
-	if (_backup_ps2sdk_symlink) {
-		_ps2sdk_symlink = _backup_ps2sdk_symlink;
-		_backup_ps2sdk_symlink = NULL;	
-	} 
-	if (_backup_ps2sdk_dopen) {
-		_ps2sdk_dopen = _backup_ps2sdk_dopen;
-		_backup_ps2sdk_dopen = NULL;	
-	}
-	if (_backup_ps2sdk_dread) {
-		_ps2sdk_dread = _backup_ps2sdk_dread;
-		_backup_ps2sdk_dread = NULL;	
-	}
-	if (_backup_ps2sdk_dclose) {
-		_ps2sdk_dclose = _backup_ps2sdk_dclose;
-		_backup_ps2sdk_dclose = NULL;	
+		__fileXioInited = 0;
 	}
 }
+#endif
 
+#ifdef F_fileXioStop
 void fileXioStop(void)
 {
 	if(fileXioInit() < 0)
 		return;
 
-	SifCallRpc(&cd0, FILEXIO_STOP, 0, sbuff, 0, sbuff, 0, 0, 0);
+	SifCallRpc(&__cd0, FILEXIO_STOP, 0, __sbuff, 0, __sbuff, 0, 0, 0);
 
 	return;
 }
+#endif
 
+#ifdef F_fileXioGetDeviceList
 int fileXioGetDeviceList(struct fileXioDevice deviceEntry[], unsigned int req_entries)
 {
 	int rv;
-	struct fxio_devlist_packet *packet=(struct fxio_devlist_packet*)sbuff;
+	struct fxio_devlist_packet *packet=(struct fxio_devlist_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->deviceEntry = deviceEntry;
 	packet->reqEntries = req_entries;
 
 	// This will get the directory contents, and fill dirEntry via DMA
-	if((rv = SifCallRpc(&cd0, FILEXIO_GETDEVICELIST, fileXioBlockMode, sbuff, sizeof(struct fxio_devlist_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_GETDEVICELIST, __fileXioBlockMode, __sbuff, sizeof(struct fxio_devlist_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioGetdir
 int fileXioGetdir(const char* pathname, struct fileXioDirEntry dirEntry[], unsigned int req_entries)
 {
 	int rv;
-	struct fxio_getdir_packet *packet=(struct fxio_getdir_packet*)sbuff;
+	struct fxio_getdir_packet *packet=(struct fxio_getdir_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	// copy the requested pathname to the rpc buffer
 	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
@@ -388,235 +228,265 @@ int fileXioGetdir(const char* pathname, struct fileXioDirEntry dirEntry[], unsig
 	packet->reqEntries = req_entries;
 
 	// This will get the directory contents, and fill dirEntry via DMA
-	if((rv = SifCallRpc(&cd0, FILEXIO_GETDIR, fileXioBlockMode, sbuff, sizeof(struct fxio_getdir_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_GETDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_getdir_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioMount
 int fileXioMount(const char* mountpoint, const char* mountstring, int flag)
 {
 	int rv;
-	struct fxio_mount_packet *packet=(struct fxio_mount_packet*)sbuff;
+	struct fxio_mount_packet *packet=(struct fxio_mount_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->blockdevice, mountstring, sizeof(packet->blockdevice));
 	strncpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
 	packet->flags = flag;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_MOUNT, fileXioBlockMode, sbuff, sizeof(struct fxio_mount_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_MOUNT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_mount_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioUmount
 int fileXioUmount(const char* mountpoint)
 {
 	int rv;
-	struct fxio_unmount_packet *packet=(struct fxio_unmount_packet*)sbuff;
+	struct fxio_unmount_packet *packet=(struct fxio_unmount_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_UMOUNT, fileXioBlockMode, sbuff, sizeof(struct fxio_unmount_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_UMOUNT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_unmount_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioCopyfile
 int fileXioCopyfile(const char* source, const char* dest, int mode)
 {
 	int rv;
-	struct fxio_copyfile_packet *packet=(struct fxio_copyfile_packet*)sbuff;
+	struct fxio_copyfile_packet *packet=(struct fxio_copyfile_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->source, source, sizeof(packet->source));
 	strncpy(packet->dest, dest, sizeof(packet->dest));
 	packet->mode = mode;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_COPYFILE, fileXioBlockMode, sbuff, sizeof(struct fxio_copyfile_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_COPYFILE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_copyfile_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioMkdir
 int fileXioMkdir(const char* pathname, int mode)
 {
 	int rv;
-	struct fxio_mkdir_packet *packet=(struct fxio_mkdir_packet*)sbuff;
+	struct fxio_mkdir_packet *packet=(struct fxio_mkdir_packet*)__sbuff;
+
+	__ps2sdk_fileXio_mkdir = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
 	packet->mode = mode;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_MKDIR, fileXioBlockMode, sbuff, sizeof(struct fxio_mkdir_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_MKDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_mkdir_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioRmdir
 int fileXioRmdir(const char* pathname)
 {
 	int rv;
-	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)sbuff;
+	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
+
+	__ps2sdk_fileXio_rmdir = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_RMDIR, fileXioBlockMode, sbuff, sizeof(struct fxio_pathsel_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_RMDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioRemove
 int fileXioRemove(const char* pathname)
 {
 	int rv;
-	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)sbuff;
+	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
+
+	__ps2sdk_fileXio_remove = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_REMOVE, fileXioBlockMode, sbuff, sizeof(struct fxio_pathsel_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_REMOVE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioRename
 int fileXioRename(const char* source, const char* dest)
 {
 	int rv;
-	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)sbuff;
+	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)__sbuff;
+
+	__ps2sdk_fileXio_rename = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->source, source, sizeof(packet->source));
 	strncpy(packet->dest, dest, sizeof(packet->dest));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_RENAME, fileXioBlockMode, sbuff, sizeof(struct fxio_rename_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_RENAME, __fileXioBlockMode, __sbuff, sizeof(struct fxio_rename_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioSymlink
 int fileXioSymlink(const char* source, const char* dest)
 {
 	int rv;
-	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)sbuff;
+	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)__sbuff;
+
+	__ps2sdk_fileXio_symlink = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->source, source, sizeof(packet->source));
 	strncpy(packet->dest, dest, sizeof(packet->dest));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_SYMLINK, fileXioBlockMode, sbuff, sizeof(struct fxio_rename_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_SYMLINK, __fileXioBlockMode, __sbuff, sizeof(struct fxio_rename_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioReadlink
 int fileXioReadlink(const char* source, char* buf, unsigned int buflen)
 {
 	int rv;
-	struct fxio_readlink_packet *packet=(struct fxio_readlink_packet*)sbuff;
+	struct fxio_readlink_packet *packet=(struct fxio_readlink_packet*)__sbuff;
+
+	__ps2sdk_fileXio_readlink = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	if( !IS_UNCACHED_SEG(buf))
   	  SifWriteBackDCache(buf, buflen);
@@ -625,151 +495,169 @@ int fileXioReadlink(const char* source, char* buf, unsigned int buflen)
 	packet->buffer = buf;
 	packet->buflen = buflen;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_READLINK, fileXioBlockMode, sbuff, sizeof(struct fxio_readlink_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_READLINK, __fileXioBlockMode, __sbuff, sizeof(struct fxio_readlink_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioChdir
 int fileXioChdir(const char* pathname)
 {
 	int rv;
-	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)sbuff;
+	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_CHDIR, fileXioBlockMode, sbuff, sizeof(struct fxio_pathsel_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_CHDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioOpen
 int fileXioOpen(const char* source, int flags, ...)
 {
 	int rv, mode;
-	struct fxio_open_packet *packet=(struct fxio_open_packet*)sbuff;
+	struct fxio_open_packet *packet=(struct fxio_open_packet*)__sbuff;
 	va_list alist;
 
 	va_start(alist, flags);
 	mode = va_arg(alist, int);	//Retrieve the mode argument, regardless of whether it is expected or not.
 	va_end(alist);
 
+	__ps2sdk_fileXio_open = 1;
+
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, source, sizeof(packet->pathname));
 	packet->flags = flags;
 	packet->mode = mode;
-	if((rv = SifCallRpc(&cd0, FILEXIO_OPEN, fileXioBlockMode, sbuff, sizeof(struct fxio_open_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_OPEN, __fileXioBlockMode, __sbuff, sizeof(struct fxio_open_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioClose
 int fileXioClose(int fd)
 {
 	int rv;
-	struct fxio_close_packet *packet=(struct fxio_close_packet*)sbuff;
+	struct fxio_close_packet *packet=(struct fxio_close_packet*)__sbuff;
+
+	__ps2sdk_fileXio_close = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_CLOSE, fileXioBlockMode, sbuff, sizeof(struct fxio_close_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_CLOSE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_close_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
-static void recv_intr(void *data_raw)
+#ifdef F_fileXioRead
+static inline void recv_intr(void *data_raw)
 {
 	rests_pkt *rests = UNCACHED_SEG(data_raw);
 
 	if(rests->ssize) memcpy(rests->sbuf, rests->sbuffer, rests->ssize);
 	if(rests->esize) memcpy(rests->ebuf, rests->ebuffer, rests->esize);
 
-	iSignalSema(fileXioCompletionSema);
+	iSignalSema(__fileXioCompletionSema);
 }
 
 int fileXioRead(int fd, void *buf, int size)
 {
 	int rv;
-	struct fxio_read_packet *packet=(struct fxio_read_packet*)sbuff;
+	struct fxio_read_packet *packet=(struct fxio_read_packet*)__sbuff;
+
+	__ps2sdk_fileXio_read = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
 	packet->buffer = buf;
 	packet->size = size;
-	packet->intrData = _intr_data;
+	packet->intrData = __intr_data;
 
 	if (!IS_UNCACHED_SEG(buf))
 		SifWriteBackDCache(buf, size);
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_READ, fileXioBlockMode, sbuff, sizeof(struct fxio_read_packet), sbuff, 4, &recv_intr, _intr_data)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_READ, __fileXioBlockMode, __sbuff, sizeof(struct fxio_read_packet), __sbuff, 4, &recv_intr, __intr_data)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioWrite
 int fileXioWrite(int fd, const void *buf, int size)
 {
 	unsigned int miss;
 	int rv;
-	struct fxio_write_packet *packet=(struct fxio_write_packet*)sbuff;
+	struct fxio_write_packet *packet=(struct fxio_write_packet*)__sbuff;
+
+	__ps2sdk_fileXio_write = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	if((unsigned int)buf & 0x3F)
 	{
@@ -789,68 +677,76 @@ int fileXioWrite(int fd, const void *buf, int size)
 	if(!IS_UNCACHED_SEG(buf))
 		SifWriteBackDCache((void*)buf, size);
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_WRITE, fileXioBlockMode, sbuff, sizeof(struct fxio_write_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_WRITE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_write_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioLseek
 int fileXioLseek(int fd, int offset, int whence)
 {
 	int rv;
-	struct fxio_lseek_packet *packet=(struct fxio_lseek_packet*)sbuff;
+	struct fxio_lseek_packet *packet=(struct fxio_lseek_packet*)__sbuff;
+
+	__ps2sdk_fileXio_lseek = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
 	packet->offset = (u32)offset;
 	packet->whence = whence;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_LSEEK, fileXioBlockMode, sbuff, sizeof(struct fxio_lseek_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_LSEEK, __fileXioBlockMode, __sbuff, sizeof(struct fxio_lseek_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioLseek64
 //
 // NOTE: 64-bit
 //
 s64 fileXioLseek64(int fd, s64 offset, int whence)
 {
 	s64 rv;
-	struct fxio_lseek64_packet *packet=(struct fxio_lseek64_packet*)sbuff;
-	struct fxio_lseek64_return_pkt *ret_packet=(struct fxio_lseek64_return_pkt*)sbuff;
+	struct fxio_lseek64_packet *packet=(struct fxio_lseek64_packet*)__sbuff;
+	struct fxio_lseek64_return_pkt *ret_packet=(struct fxio_lseek64_return_pkt*)__sbuff;
+
+	__ps2sdk_fileXio_lseek64 = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
 	packet->offset_lo = (u32)(offset & 0xffffffff);
 	packet->offset_hi = (u32)((offset >> 32) & 0xffffffff);
 	packet->whence = whence;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_LSEEK64, fileXioBlockMode, sbuff, sizeof(struct fxio_lseek64_packet), sbuff, 8, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_LSEEK64, __fileXioBlockMode, __sbuff, sizeof(struct fxio_lseek64_packet), __sbuff, 8, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
 		else {
 			s64 rvHI = ret_packet->pos_hi;
 			rvHI = rvHI << 32;
@@ -858,23 +754,25 @@ s64 fileXioLseek64(int fd, s64 offset, int whence)
 		}
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioChStat
 int fileXioChStat(const char *name, iox_stat_t *stat, int mask)
 {
 	int rv;
-	struct fxio_chstat_packet *packet=(struct fxio_chstat_packet*)sbuff;
+	struct fxio_chstat_packet *packet=(struct fxio_chstat_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, name, sizeof(packet->pathname));
 	packet->stat = stat;
@@ -883,28 +781,32 @@ int fileXioChStat(const char *name, iox_stat_t *stat, int mask)
 	if(!IS_UNCACHED_SEG(stat))
 		SifWriteBackDCache(stat, sizeof(iox_stat_t));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_CHSTAT, fileXioBlockMode, sbuff, sizeof(struct fxio_chstat_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_CHSTAT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_chstat_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioGetStat
 int fileXioGetStat(const char *name, iox_stat_t *stat)
 {
 	int rv;
-	struct fxio_getstat_packet *packet=(struct fxio_getstat_packet*)sbuff;
+	struct fxio_getstat_packet *packet=(struct fxio_getstat_packet*)__sbuff;
+
+	__ps2sdk_fileXio_stat = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, name, sizeof(packet->pathname));
 	packet->stat = stat;
@@ -912,28 +814,30 @@ int fileXioGetStat(const char *name, iox_stat_t *stat)
 	if(!IS_UNCACHED_SEG(stat))
 		SifWriteBackDCache(stat, sizeof(iox_stat_t));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_GETSTAT, fileXioBlockMode, sbuff, sizeof(struct fxio_getstat_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_GETSTAT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_getstat_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioFormat
 int fileXioFormat(const char *dev, const char *blockdev, const void *args, int arglen)
 {
 	int rv;
-	struct fxio_format_packet *packet=(struct fxio_format_packet*)sbuff;
+	struct fxio_format_packet *packet=(struct fxio_format_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->device, dev, sizeof(packet->device));
 	if(blockdev)
@@ -943,102 +847,116 @@ int fileXioFormat(const char *dev, const char *blockdev, const void *args, int a
 	memcpy(packet->args, args, arglen);
 	packet->arglen = arglen;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_FORMAT, fileXioBlockMode,  sbuff, sizeof(struct fxio_format_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_FORMAT, __fileXioBlockMode,  __sbuff, sizeof(struct fxio_format_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioSync
 int fileXioSync(const char *devname, int flag)
 {
 	int rv;
-	struct fxio_sync_packet *packet=(struct fxio_sync_packet*)sbuff;
+	struct fxio_sync_packet *packet=(struct fxio_sync_packet*)__sbuff;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->device, devname, sizeof(packet->device));
 	packet->flags = flag;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_SYNC, fileXioBlockMode, sbuff, sizeof(struct fxio_sync_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_SYNC, __fileXioBlockMode, __sbuff, sizeof(struct fxio_sync_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioDopen
 int fileXioDopen(const char *name)
 {
 	int rv;
-	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)sbuff;
+	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
+
+	__ps2sdk_fileXio_dopen = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	strncpy(packet->pathname, name, sizeof(packet->pathname));
-	if((rv = SifCallRpc(&cd0, FILEXIO_DOPEN, fileXioBlockMode, sbuff, sizeof(struct fxio_pathsel_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_DOPEN, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioDclose
 int fileXioDclose(int fd)
 {
 	int rv;
-	struct fxio_close_packet *packet=(struct fxio_close_packet*)sbuff;
+	struct fxio_close_packet *packet=(struct fxio_close_packet*)__sbuff;
+
+	__ps2sdk_fileXio_dclose = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
-	if((rv = SifCallRpc(&cd0, FILEXIO_DCLOSE, fileXioBlockMode, sbuff, sizeof(struct fxio_close_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_DCLOSE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_close_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioDread
 int fileXioDread(int fd, iox_dirent_t *dirent)
 {
 	int rv;
-	struct fxio_dread_packet *packet=(struct fxio_dread_packet*)sbuff;
+	struct fxio_dread_packet *packet=(struct fxio_dread_packet*)__sbuff;
+
+	__ps2sdk_fileXio_dread = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->fd = fd;
 	packet->dirent = dirent;
@@ -1046,37 +964,39 @@ int fileXioDread(int fd, iox_dirent_t *dirent)
 	if (!IS_UNCACHED_SEG(dirent))
 		SifWriteBackDCache(dirent, sizeof(iox_dirent_t));
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_DREAD, fileXioBlockMode, sbuff, sizeof(struct fxio_dread_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_DREAD, __fileXioBlockMode, __sbuff, sizeof(struct fxio_dread_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
-static void fxio_ctl_intr(void *data_raw)
+static inline void fxio_ctl_intr(void *data_raw)
 {
 	struct fxio_ctl_return_pkt *pkt = UNCACHED_SEG(data_raw);
 
 	memcpy(pkt->dest, pkt->buf, pkt->len);
 
-	iSignalSema(fileXioCompletionSema);
+	iSignalSema(__fileXioCompletionSema);
 }
 
+#ifdef F_fileXioDevctl
 int fileXioDevctl(const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen)
 {
-	struct fxio_devctl_packet *packet = (struct fxio_devctl_packet *)sbuff;
+	struct fxio_devctl_packet *packet = (struct fxio_devctl_packet *)__sbuff;
 	int rv;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	if(arglen > CTL_BUF_SIZE) arglen = CTL_BUF_SIZE;
 	if(buflen > CTL_BUF_SIZE) buflen = CTL_BUF_SIZE;
@@ -1088,64 +1008,70 @@ int fileXioDevctl(const char *name, int cmd, void *arg, unsigned int arglen, voi
 	packet->arglen = arglen;
 	packet->buf = buf;
 	packet->buflen = buflen;
-	packet->intr_data = _intr_data;
+	packet->intr_data = __intr_data;
 
 	SifWriteBackDCache(buf, buflen);
 
 	if(buflen)
-		rv = SifCallRpc(&cd0, FILEXIO_DEVCTL, fileXioBlockMode, packet, sizeof(struct fxio_devctl_packet), sbuff, 4, &fxio_ctl_intr, _intr_data);
+		rv = SifCallRpc(&__cd0, FILEXIO_DEVCTL, __fileXioBlockMode, packet, sizeof(struct fxio_devctl_packet), __sbuff, 4, &fxio_ctl_intr, __intr_data);
 	else
-		rv = SifCallRpc(&cd0, FILEXIO_DEVCTL, fileXioBlockMode, packet, sizeof(struct fxio_devctl_packet), sbuff, 4, (void *)&_fxio_intr, NULL);
+		rv = SifCallRpc(&__cd0, FILEXIO_DEVCTL, __fileXioBlockMode, packet, sizeof(struct fxio_devctl_packet), __sbuff, 4, (void *)&_fxio_intr, NULL);
 
 	if(rv >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioIoctl
 int fileXioIoctl(int fd, int cmd, void *arg){
-	struct fxio_ioctl_packet *packet = (struct fxio_ioctl_packet *)sbuff;
+	struct fxio_ioctl_packet *packet = (struct fxio_ioctl_packet *)__sbuff;
 	int rv;
+
+	__ps2sdk_fileXio_ioctl = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	memcpy(packet->arg, arg, IOCTL_BUF_SIZE);
 
 	packet->fd = fd;
 	packet->cmd = cmd;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_IOCTL, fileXioBlockMode, packet, sizeof(struct fxio_ioctl_packet), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_IOCTL, __fileXioBlockMode, packet, sizeof(struct fxio_ioctl_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioIoctl2
 int fileXioIoctl2(int fd, int command, void *arg, unsigned int arglen, void *buf, unsigned int buflen)
 {
-	struct fxio_ioctl2_packet *packet = (struct fxio_ioctl2_packet *)sbuff;
+	struct fxio_ioctl2_packet *packet = (struct fxio_ioctl2_packet *)__sbuff;
 	int rv;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	if(arglen > CTL_BUF_SIZE) arglen = CTL_BUF_SIZE;
 	if(buflen > CTL_BUF_SIZE) buflen = CTL_BUF_SIZE;
@@ -1156,55 +1082,57 @@ int fileXioIoctl2(int fd, int command, void *arg, unsigned int arglen, void *buf
 	packet->arglen = arglen;
 	packet->buf = buf;
 	packet->buflen = buflen;
-	packet->intr_data = _intr_data;
+	packet->intr_data = __intr_data;
 
 	SifWriteBackDCache(buf, buflen);
 
 	if(buflen)
-		rv = SifCallRpc(&cd0, FILEXIO_IOCTL2, fileXioBlockMode, packet, sizeof(struct fxio_ioctl2_packet), sbuff, 4, &fxio_ctl_intr, _intr_data);
+		rv = SifCallRpc(&__cd0, FILEXIO_IOCTL2, __fileXioBlockMode, packet, sizeof(struct fxio_ioctl2_packet), __sbuff, 4, &fxio_ctl_intr, __intr_data);
 	else
-		rv = SifCallRpc(&cd0, FILEXIO_IOCTL2, fileXioBlockMode, packet, sizeof(struct fxio_ioctl2_packet), sbuff, 4, (void *)&_fxio_intr, NULL);
+		rv = SifCallRpc(&__cd0, FILEXIO_IOCTL2, __fileXioBlockMode, packet, sizeof(struct fxio_ioctl2_packet), __sbuff, 4, (void *)&_fxio_intr, NULL);
 
 	if(rv >= 0)
 	{
-		if(fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
-		else { rv = sbuff[0]; }
+		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
+		else { rv = __sbuff[0]; }
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
+#endif
 
+#ifdef F_fileXioWaitAsync
 int fileXioWaitAsync(int mode, int *retVal)
 {
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
-	if(fileXioBlockMode != FXIO_NOWAIT) return 0;
+	if(__fileXioBlockMode != FXIO_NOWAIT) return 0;
 
 	switch(mode)
 	{
 		case FXIO_WAIT:
 
-			WaitSema(fileXioCompletionSema);
-			SignalSema(fileXioCompletionSema);
+			WaitSema(__fileXioCompletionSema);
+			SignalSema(__fileXioCompletionSema);
 
 			if(retVal != NULL)
-				*retVal = *(int *)UNCACHED_SEG(&sbuff[0]);
+				*retVal = *(int *)UNCACHED_SEG(&__sbuff[0]);
 
 			return FXIO_COMPLETE;
 
 		case FXIO_NOWAIT:
 
-			if(PollSema(fileXioCompletionSema) < 0)
+			if(PollSema(__fileXioCompletionSema) < 0)
 				return FXIO_INCOMPLETE;
 
-			SignalSema(fileXioCompletionSema);
+			SignalSema(__fileXioCompletionSema);
 
 			if(retVal != NULL)
-				*retVal = *(int *)UNCACHED_SEG(&sbuff[0]);
+				*retVal = *(int *)UNCACHED_SEG(&__sbuff[0]);
 
 			return FXIO_COMPLETE;
 
@@ -1212,32 +1140,36 @@ int fileXioWaitAsync(int mode, int *retVal)
 			return -1;
 	}
 }
+#endif
 
+#ifdef F_fileXioSetBlockMode
 void fileXioSetBlockMode(int blocking)
 {
-	fileXioBlockMode = blocking;
+	__fileXioBlockMode = blocking;
 }
+#endif
 
+#ifdef F_fileXioSetRWBufferSize
 int fileXioSetRWBufferSize(int size){
-	struct fxio_rwbuff *packet = (struct fxio_rwbuff *)sbuff;
+	struct fxio_rwbuff *packet = (struct fxio_rwbuff *)__sbuff;
 	int rv;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
 	_lock();
-	WaitSema(fileXioCompletionSema);
+	WaitSema(__fileXioCompletionSema);
 
 	packet->size = size;
 
-	if((rv = SifCallRpc(&cd0, FILEXIO_SETRWBUFFSIZE, 0, packet, sizeof(struct fxio_rwbuff), sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
+	if((rv = SifCallRpc(&__cd0, FILEXIO_SETRWBUFFSIZE, 0, packet, sizeof(struct fxio_rwbuff), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
-		rv = sbuff[0];
+		rv = __sbuff[0];
 	}
 	else
-		SignalSema(fileXioCompletionSema);
+		SignalSema(__fileXioCompletionSema);
 
 	_unlock();
 	return(rv);
 }
-
+#endif

--- a/samples/Makefile_sample
+++ b/samples/Makefile_sample
@@ -40,6 +40,7 @@ SUBDIRS += rpc/audsrv/playcdda
 SUBDIRS += rpc/audsrv/playwav
 SUBDIRS += rpc/audsrv/playwav2
 SUBDIRS += rpc/audsrv/testcd
+SUBDIRS += rpc/filexio
 #SUBDIRS += rpc/camera          #TODO: not modified for updated newlib
 #SUBDIRS += rpc/memorycard      #TODO: not modified for updated newlib
 SUBDIRS += rpc/mtap

--- a/samples/Makefile_sample
+++ b/samples/Makefile_sample
@@ -28,6 +28,7 @@ SUBDIRS += libcglue/regress
 SUBDIRS += libcglue/mem_test
 SUBDIRS += libcglue/nanosleep
 SUBDIRS += libcglue/rewinddir
+SUBDIRS += libcglue/timezone
 SUBDIRS += libgs/doublebuffer
 SUBDIRS += libgs/draw
 #SUBDIRS += mpeg                #TODO: not modified for updated newlib


### PR DESCRIPTION
## Description
The main scope of this PR is to avoid having unused functions within the embedded ELF, unfortunately, the linker and compiler aren't that clever and require some help to make it work better.
More concretely most of the unused functions belong to the library used for performing IO operations, either `fileio` or `fileXio`. Having both in the binary first makes the a waste of space, and secondly could deal with problems if you start mixing by mistake `fd` from/to `fileio`/`filexio`.

How I did it:
- `rom0_info` contains some information about the `ROM0` included in the console, it was always using `fileio` for accessing the `ROM0` content, now, I have created a possibility to inject via driver the functions used to deal with IO operations.
- `osd_config` used functions from `rom0_info`, so the same strategy was created here.
- There was something wrong additionally in `osd_config`, it was using some `_libcglue_timezone_update` functions, and it shouldn't, because `libkernel.a` shouldn't have any kind of dependency, for still allowing a way of using it without `newlib`. In order to facilitate the usage of these logic to the final user, I have created 2 new functions in `ps2sdkapi.h` file, `ps2sdk_setTimezone` and `ps2sdk_setDaylightSaving` which automatically will use the proper IO library and the expected callback to `_libcglue_timezone_update`.
- `_libcglue_timezone_update` used those `osd_config` functions, so now it injects the driver with the proper IO functions. Additionally, the logic for setting the timezone was updated having as reference how `PSP` did.
- The way of setting the `_ps2sdk_XXX` functions, now have changed. Previously we set by default `fileIO` functions, and then later on, it was replaced with `fileXio` functions. Now, however, they have `NULL` value as default, and then `weak` functions called `__set_ps2sdk_XXX` pointing to `fileIO` have been created; then `strong` functions pointing to `fileXio` have been created, in the way that as soon as the user link the binary with `fileXio` automatically all the `fileio` functions will be removed from the binary. All these functions must be called before the `_ps2sd_XXX` is used. This also require to do an extra trick to make it work, https://stackoverflow.com/a/22178564
- `fileXio` EE library has been improved, it now has a specific compilation per function, and it helps to link and strip unused symbols. Other not needed functions were removed.
- A specific sample to check the timezone has been created.
- A specific sample to check `fileXio` usage has been created.
- Other minor clean/up changes.


Results:
- I have used my `filesystem` sample from `ps2_drivers` https://github.com/fjtrujy/ps2_drivers/tree/main/samples/filesystem_sample
```sh
-rwxr-xr-x  1 fjtrujy  staff  535656 Dec  6 22:06 filesystem_sample.elf
-rw-r--r--@ 1 fjtrujy  staff  549524 Dec  6 21:05 filesystem_sample_old.elf
-rw-r--r--  1 fjtrujy  staff  165720 Dec  6 22:09 filesystem_sample_old_packed.elf
-rwxr-xr-x  1 fjtrujy  staff  462900 Dec  6 22:08 filesystem_sample_old_strip.elf
-rw-r--r--  1 fjtrujy  staff  163144 Dec  6 22:10 filesystem_sample_packed.elf
-rwxr-xr-x  1 fjtrujy  staff  451508 Dec  6 22:08 filesystem_sample_strip.elf
```
It reduces `15KB` when the binary contains debug symbols, 11KB when the binary is stripped, and 2.6KB when the binary is packed.

- Let's check now OPL (I have also added `EE_CFLAGS += -fdata-sections -ffunction-sections -flto` and `EE_LDFLAGS += -fdata-sections -ffunction-sections -flto -Wl,--gc-sections`) flags:
```
WIP: I will try to test it tomorrow :(
```

Finally, I would like some of you to test those improvements, to fully assure that everything is working as expected. Especially OPL which is the most critical piece of software we actually support.