### PR TITLE
Include compressed DWARF2 debug info by default for EE and IOP buildsystem

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -35,18 +35,21 @@ EE_OPTFLAGS ?= -O2
 # Warning compiler flags
 EE_WARNFLAGS ?= -Wall -Werror
 
+# Debug information flags
+EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
+
 # These flags will generate LTO and non-LTO code in the same object file,
 # allowing the choice of using LTO or not in the final linked binary.
 EE_FATLTOFLAGS ?= -flto -ffat-lto-objects
 
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_INCS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_INCS) $(EE_CFLAGS)
 
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG
 endif
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 -$(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_INCS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 -$(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_INCS) $(EE_CXXFLAGS)
 
 # Linker flags
 # EE_LDFLAGS := $(EE_LDFLAGS)

--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -29,10 +29,13 @@ IOP_OPTFLAGS ?= -Os
 # Warning compiler flags
 IOP_WARNFLAGS ?= -Wall -Werror
 
+# Debug information flags
+IOP_DBGINFOFLAGS ?= -gdwarf-2 -gz
+
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,
 #   for finer-grained control over what goes into each IRX.
-IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
+IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
 ifeq ($(DEBUG),1)
 IOP_CFLAGS += -DDEBUG
 endif

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -31,11 +31,14 @@ EE_OPTFLAGS ?= -O2
 # Warning compiler flags
 EE_WARNFLAGS ?= -Wall
 
+# Debug information flags
+EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
+
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CFLAGS)
 
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXFLAGS)
 
 # Linker flags
 EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -31,11 +31,14 @@ EE_OPTFLAGS ?= -O2
 # Warning compiler flags
 EE_WARNFLAGS ?= -Wall
 
+# Debug information flags
+EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
+
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CFLAGS)
 
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXFLAGS)
 
 # Linker flags
 EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -30,10 +30,13 @@ IOP_OPTFLAGS ?= -Os
 # Warning compiler flags
 IOP_WARNFLAGS ?= -Wall
 
+# Debug information flags
+IOP_DBGINFOFLAGS ?= -gdwarf-2 -gz
+
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,
 #   for finer-grained control over what goes into each IRX.
-IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
+IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
 # linker flags
 IOP_LDFLAGS := -nostdlib -s $(IOP_LDFLAGS)
 


### PR DESCRIPTION
Allows `addr2line` to output line number and file path.
Will increase size of libraries and unstripped executables, but stripped and compressed executables should remain same size