### PR TITLE
Expose func to get IOP FD

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -29,7 +29,7 @@ GLUE_OBJS = __dummy_passwd.o __transform_errno.o __transform64_errno.o compile_t
 	_stat.o lstat.o _fstat.o access.o _fcntl.o getdents.o _lseek.o lseek64.o chdir.o mkdir.o \
 	rmdir.o _link.o _unlink.o _rename.o _getpid.o _kill.o _fork.o _wait.o _sbrk.o _gettimeofday.o _times.o ftime.o clock_getres.o clock_gettime.o clock_settime.o \
 	truncate.o symlink.o readlink.o utime.o fchown.o getrandom.o getentropy.o _isatty.o chmod.o fchmod.o fchmodat.o pathconf.o \
-	fsync.o getuid.o geteuid.o getpwuid.o getpwnam.o
+	fsync.o getuid.o geteuid.o getpwuid.o getpwnam.o ps2sdk_get_iop_fd.o
 
 LOCK_OBJS = __retarget_lock_init.o __retarget_lock_acquire.o __retarget_lock_release.o __retarget_lock_try_acquire.o __retarget_lock_close.o \
 	__retarget_lock_init_recursive.o __retarget_lock_acquire_recursive.o __retarget_lock_release_recursive.o __retarget_lock_try_acquire_recursive.o __retarget_lock_close_recursive.o

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -61,4 +61,9 @@ extern void _libcglue_rtc_update();
 typedef int64_t off64_t;
 off64_t lseek64(int fd, off64_t offset, int whence);
 
+/* The fd we provide to final user aren't actually the same than IOP's fd
+* so this function allow you to get actual IOP's fd from public fd
+*/
+int ps2sdk_get_iop_fd(int fd);
+ 
 #endif /* __PS2SDKAPI_H__ */

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -902,3 +902,14 @@ struct passwd *getpwnam(const char *name) {
 	return &__dummy_passwd;
 }
 #endif
+
+#ifdef F_ps2sdk_get_iop_fd
+int ps2sdk_get_iop_fd(int fd) {
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	return __descriptormap[fd]->descriptor;
+}
+#endif


### PR DESCRIPTION
## Description
With the new way of providing more POSIX functions, the FD that we provide to the final user is not the same as the FD given by the IOP driver, however, there are still some functions that aren't POSIX and we still need to call them directly sending the IOP's FD as `fileXioIoctl` and `fileXioIoctl2`.

This PR basically exposes a function to get the IOP FD.

Cheers.