### PR TITLE
Reducing FILENO_MAX to save static RAM space

### DIFF
--- a/ee/libcglue/src/fdman.h
+++ b/ee/libcglue/src/fdman.h
@@ -14,7 +14,7 @@
 
 #define _FDMAN_H_
 
-#define __FILENO_MAX 1024
+#define __FILENO_MAX 64
 
 #define __IS_FD_VALID(FD) \
 		( (FD >= 0) && (FD < __FILENO_MAX) && (__descriptormap[FD] != NULL) )


### PR DESCRIPTION
I think that 64 is a good number, if it is not enough, we can increase it later