### PR TITLE
Add netinit/tcp.h

### DIFF
--- a/common/include/netinet/tcp.h
+++ b/common/include/netinet/tcp.h
@@ -1,0 +1,16 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#ifndef __PS2SDK_NETINET_TCP_H__
+#define __PS2SDK_NETINET_TCP_H__
+
+#include <ps2ip.h>
+
+#endif


### PR DESCRIPTION
Required when compiling mongoose. Saved me having to patch it.