### PR TITLE
Fix file xio functions override

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -27,7 +27,7 @@ PS2SDKAPI_OBJS = \
 	__fioOpenHelper.o __fioLseek64Helper.o __fioRenameHelper.o __fioMkdirHelper.o __fioGetstatHelper.o __fioReadlinkHelper.o __fioSymlinkHelper.o __fioDreadHelper.o \
 	_ps2sdk_close.o _ps2sdk_open.o _ps2sdk_read.o _ps2sdk_lseek.o _ps2sdk_lseek64.o _ps2sdk_write.o _ps2sdk_ioctl.o \
 	_ps2sdk_remove.o _ps2sdk_rename.o _ps2sdk_mkdir.o _ps2sdk_rmdir.o _ps2sdk_stat.o _ps2sdk_readlink.o _ps2sdk_symlink.o \
-	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o \
+	_ps2sdk_dopen.o _ps2sdk_dread.o _ps2sdk_dclose.o _ps2sdk_io_ready.o \
 	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
 	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
 	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o \

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -92,6 +92,11 @@ int (*_ps2sdk_dclose)(int fd) = NULL;
 #endif
 
 /** Setting default weak fio functions */
+#ifdef F__ps2sdk_io_ready
+__attribute__((weak))
+uint8_t _ps2sdk_io_ready = 1;
+#endif
+
 #ifdef F__set_ps2sdk_close
 __attribute__((weak))
 void _set_ps2sdk_close() {

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -21,6 +21,8 @@
 #define OSD_CONFIG_NO_LIBCDVD
 #include "osd_config.h"
 
+extern uint8_t _ps2sdk_io_ready;
+
 static inline void setPS2SDKFunctions() {
 	// Set ps2sdk functions
 	_glue_ps2sdk_open();
@@ -33,6 +35,8 @@ __attribute__((weak))
 void _libcglue_timezone_update()
 {
     /* Initialize timezone from PS2 OSD configuration */
+	if (!_ps2sdk_io_ready) return;
+	
     setPS2SDKFunctions();
 
 	_io_driver driver = { _ps2sdk_open, _ps2sdk_close, _ps2sdk_read };

--- a/ee/rpc/filexio/Makefile
+++ b/ee/rpc/filexio/Makefile
@@ -19,7 +19,7 @@ FILEXIO_RPC_OBJS = \
 	fileXioIoctl.o fileXioIoctl2.o fileXioWaitAsync.o fileXioSetBlockMode.o fileXioSetRWBufferSize.o
 
 FILEXIO_PS2SDK_OBJS = \
-	__fileXioGetstatHelper.o __fileXioDreadHelper.o \
+	__fileXioGetstatHelper.o __fileXioDreadHelper.o _ps2sdk_io_ready.o \
 	_set_ps2sdk_close.o _set_ps2sdk_open.o _set_ps2sdk_read.o _set_ps2sdk_lseek.o _set_ps2sdk_lseek64.o _set_ps2sdk_write.o _set_ps2sdk_ioctl.o \
 	_set_ps2sdk_remove.o _set_ps2sdk_rename.o _set_ps2sdk_mkdir.o _set_ps2sdk_rmdir.o _set_ps2sdk_stat.o _set_ps2sdk_readlink.o _set_ps2sdk_symlink.o \
 	_set_ps2sdk_dopen.o _set_ps2sdk_dread.o _set_ps2sdk_dclose.o

--- a/ee/rpc/filexio/samples/Makefile.sample
+++ b/ee/rpc/filexio/samples/Makefile.sample
@@ -8,9 +8,9 @@
 
 EE_BIN = filexio_sample.elf
 EE_OBJS = main.o
-EE_LIBS = -lfileXio
-EE_CFLAGS = -fdata-sections -ffunction-sections -flto
-EE_LDFLAGS = -fdata-sections -ffunction-sections -flto -Wl,--gc-sections
+EE_LIBS = -lfileXio -lpatches
+EE_CFLAGS = -g -fdata-sections -ffunction-sections
+EE_LDFLAGS = -fdata-sections -ffunction-sections -Wl,--gc-sections
 
 IRX_FILES += iomanX.irx fileXio.irx
 EE_OBJS += $(IRX_FILES:.irx=_irx.o)

--- a/ee/rpc/filexio/samples/main.c
+++ b/ee/rpc/filexio/samples/main.c
@@ -8,6 +8,8 @@
 int __iomanX_id = -1;
 int __fileXio_id = -1;
 
+int __dummy = 0;
+
 /* References to IOMANX.IRX */
 extern unsigned char iomanX_irx[] __attribute__((aligned(16)));
 extern unsigned int size_iomanX_irx;
@@ -15,6 +17,19 @@ extern unsigned int size_iomanX_irx;
 /* References to FILEXIO.IRX */
 extern unsigned char fileXio_irx[] __attribute__((aligned(16)));
 extern unsigned int size_fileXio_irx;
+
+static void reset_IOP() {
+    SifInitRpc(0);
+#if !defined(DEBUG) || defined(BUILD_FOR_PCSX2)
+    /* Comment this line if you don't wanna debug the output */
+    while (!SifIopReset(NULL, 0)) {};
+#endif
+
+    while (!SifIopSync()) {};
+    SifInitRpc(0);
+    sbv_patch_enable_lmb();
+    sbv_patch_disable_prefix_check();
+}
 
 static int loadIRXs(void) {
     /* IOMANX.IRX */
@@ -44,8 +59,12 @@ static int init_fileXio_driver() {
     return __fileXio_init_status;
 }
 
+void _libcglue_timezone_update() {}
+void _libcglue_rtc_update() {}
+
 int main(int argc, char *argv[])
 {
+    reset_IOP();
 	init_fileXio_driver();
 
 	while (1)

--- a/ee/rpc/filexio/samples/main.c
+++ b/ee/rpc/filexio/samples/main.c
@@ -59,9 +59,6 @@ static int init_fileXio_driver() {
     return __fileXio_init_status;
 }
 
-void _libcglue_timezone_update() {}
-void _libcglue_rtc_update() {}
-
 int main(int argc, char *argv[])
 {
     reset_IOP();

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -23,6 +23,11 @@
 #include "iox_stat.h"
 
 /** Setting fileXio functions */
+#ifdef F__ps2sdk_io_ready
+uint8_t __ps2sdk_fileXio_ready = 0;
+uint8_t _ps2sdk_io_ready = 0;
+#endif
+
 #ifdef F__set_ps2sdk_close
 uint8_t __ps2sdk_fileXio_close = 0;
 void _set_ps2sdk_close() {

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -108,6 +108,27 @@ static inline int _unlock(void)
 }
 
 #ifdef F_fileXioInit
+/* Symbols to help fileXio override weak methods for fileXio_ps2sdk */
+/* More info here: https://stackoverflow.com/a/22178564 */
+static void forceStrongMethods() {
+	__ps2sdk_fileXio_close = 1;
+	__ps2sdk_fileXio_open = 1;
+	__ps2sdk_fileXio_read = 1;
+	__ps2sdk_fileXio_lseek = 1;
+	__ps2sdk_fileXio_lseek64 = 1;
+	__ps2sdk_fileXio_write = 1;
+	__ps2sdk_fileXio_ioctl = 1;
+	__ps2sdk_fileXio_remove = 1;
+	__ps2sdk_fileXio_rename = 1;
+	__ps2sdk_fileXio_mkdir = 1;
+	__ps2sdk_fileXio_rmdir = 1;
+	__ps2sdk_fileXio_stat = 1;
+	__ps2sdk_fileXio_readlink = 1;
+	__ps2sdk_fileXio_symlink = 1;
+	__ps2sdk_fileXio_dopen = 1;
+	__ps2sdk_fileXio_dread = 1;
+	__ps2sdk_fileXio_dclose = 1;
+}
 int fileXioInit(void)
 {
 	int res;
@@ -125,6 +146,8 @@ int fileXioInit(void)
 	{
 		return 0;
 	}
+
+	forceStrongMethods();
 
 	sp.init_count = 1;
 	sp.max_count = 1;
@@ -332,8 +355,6 @@ int fileXioMkdir(const char* pathname, int mode)
 	int rv;
 	struct fxio_mkdir_packet *packet=(struct fxio_mkdir_packet*)__sbuff;
 
-	__ps2sdk_fileXio_mkdir = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -362,8 +383,6 @@ int fileXioRmdir(const char* pathname)
 	int rv;
 	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
 
-	__ps2sdk_fileXio_rmdir = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -391,8 +410,6 @@ int fileXioRemove(const char* pathname)
 	int rv;
 	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
 
-	__ps2sdk_fileXio_remove = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -419,8 +436,6 @@ int fileXioRename(const char* source, const char* dest)
 {
 	int rv;
 	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)__sbuff;
-
-	__ps2sdk_fileXio_rename = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -450,8 +465,6 @@ int fileXioSymlink(const char* source, const char* dest)
 	int rv;
 	struct fxio_rename_packet *packet=(struct fxio_rename_packet*)__sbuff;
 
-	__ps2sdk_fileXio_symlink = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -479,8 +492,6 @@ int fileXioReadlink(const char* source, char* buf, unsigned int buflen)
 {
 	int rv;
 	struct fxio_readlink_packet *packet=(struct fxio_readlink_packet*)__sbuff;
-
-	__ps2sdk_fileXio_readlink = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -546,8 +557,6 @@ int fileXioOpen(const char* source, int flags, ...)
 	mode = va_arg(alist, int);	//Retrieve the mode argument, regardless of whether it is expected or not.
 	va_end(alist);
 
-	__ps2sdk_fileXio_open = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -575,8 +584,6 @@ int fileXioClose(int fd)
 {
 	int rv;
 	struct fxio_close_packet *packet=(struct fxio_close_packet*)__sbuff;
-
-	__ps2sdk_fileXio_close = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -615,8 +622,6 @@ int fileXioRead(int fd, void *buf, int size)
 	int rv;
 	struct fxio_read_packet *packet=(struct fxio_read_packet*)__sbuff;
 
-	__ps2sdk_fileXio_read = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -650,8 +655,6 @@ int fileXioWrite(int fd, const void *buf, int size)
 	unsigned int miss;
 	int rv;
 	struct fxio_write_packet *packet=(struct fxio_write_packet*)__sbuff;
-
-	__ps2sdk_fileXio_write = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -696,8 +699,6 @@ int fileXioLseek(int fd, int offset, int whence)
 	int rv;
 	struct fxio_lseek_packet *packet=(struct fxio_lseek_packet*)__sbuff;
 
-	__ps2sdk_fileXio_lseek = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -730,8 +731,6 @@ s64 fileXioLseek64(int fd, s64 offset, int whence)
 	s64 rv;
 	struct fxio_lseek64_packet *packet=(struct fxio_lseek64_packet*)__sbuff;
 	struct fxio_lseek64_return_pkt *ret_packet=(struct fxio_lseek64_return_pkt*)__sbuff;
-
-	__ps2sdk_fileXio_lseek64 = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -799,8 +798,6 @@ int fileXioGetStat(const char *name, iox_stat_t *stat)
 {
 	int rv;
 	struct fxio_getstat_packet *packet=(struct fxio_getstat_packet*)__sbuff;
-
-	__ps2sdk_fileXio_stat = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -894,8 +891,6 @@ int fileXioDopen(const char *name)
 	int rv;
 	struct fxio_pathsel_packet *packet=(struct fxio_pathsel_packet*)__sbuff;
 
-	__ps2sdk_fileXio_dopen = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -922,8 +917,6 @@ int fileXioDclose(int fd)
 	int rv;
 	struct fxio_close_packet *packet=(struct fxio_close_packet*)__sbuff;
 
-	__ps2sdk_fileXio_dclose = 1;
-
 	if(fileXioInit() < 0)
 		return -ENOPKG;
 
@@ -949,8 +942,6 @@ int fileXioDread(int fd, iox_dirent_t *dirent)
 {
 	int rv;
 	struct fxio_dread_packet *packet=(struct fxio_dread_packet*)__sbuff;
-
-	__ps2sdk_fileXio_dread = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;
@@ -1034,8 +1025,6 @@ int fileXioDevctl(const char *name, int cmd, void *arg, unsigned int arglen, voi
 int fileXioIoctl(int fd, int cmd, void *arg){
 	struct fxio_ioctl_packet *packet = (struct fxio_ioctl_packet *)__sbuff;
 	int rv;
-
-	__ps2sdk_fileXio_ioctl = 1;
 
 	if(fileXioInit() < 0)
 		return -ENOPKG;

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -49,6 +49,10 @@ extern uint8_t __ps2sdk_fileXio_symlink;
 extern uint8_t __ps2sdk_fileXio_dopen;
 extern uint8_t __ps2sdk_fileXio_dread;
 extern uint8_t __ps2sdk_fileXio_dclose;
+extern uint8_t __ps2sdk_fileXio_ready;
+extern uint8_t _ps2sdk_io_ready;
+
+extern void _libcglue_timezone_update();
 
 #ifdef F___cd0
 SifRpcClientData_t __cd0;
@@ -128,6 +132,11 @@ static void forceStrongMethods() {
 	__ps2sdk_fileXio_dopen = 1;
 	__ps2sdk_fileXio_dread = 1;
 	__ps2sdk_fileXio_dclose = 1;
+	__ps2sdk_fileXio_ready = 1;
+	_ps2sdk_io_ready = 1;
+
+	// Previously it wasn't executed becasue _ps2sdk_io_ready was 0
+	_libcglue_timezone_update();
 }
 int fileXioInit(void)
 {
@@ -146,8 +155,6 @@ int fileXioInit(void)
 	{
 		return 0;
 	}
-
-	forceStrongMethods();
 
 	sp.init_count = 1;
 	sp.max_count = 1;
@@ -169,6 +176,8 @@ int fileXioInit(void)
 
 	__fileXioInited = 1;
 	__fileXioBlockMode = FXIO_WAIT;
+
+	forceStrongMethods();
 
 	return 0;
 }


### PR DESCRIPTION
I found that ELF generated still had some symbols to fio when fileXio is embedded.
Additionally I have also found that no `IO` operations can be performed before the fileXio is initied, that's why the timezone update is postponed.

Probably there are better ways to solve this, or maybe even reverting all these changes, and put it back as it was previously.