### PR TITLE
EE linkfile changes

### DIFF
--- a/ee/startup/src/linkfile
+++ b/ee/startup/src/linkfile
@@ -30,8 +30,6 @@ SECTIONS {
 	PROVIDE(_etext = .);
 	PROVIDE(etext = .);
 
-	.reginfo : { *(.reginfo) }
-
 	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
 		KEEP(*crtbegin*.o(.ctors))
@@ -46,12 +44,7 @@ SECTIONS {
 		KEEP(*(.dtors))
 	}
 
-	/* Static data.  */
-	.rodata ALIGN(128): {
-		*(.rodata)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-	}
+	.reginfo : { *(.reginfo) }
 
 	.data ALIGN(128): {
 		_fdata = . ;
@@ -59,6 +52,13 @@ SECTIONS {
 		*(.data.*)
 		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
+	}
+
+	/* Static data.  */
+	.rodata ALIGN(128): {
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
 	}
 
 	.rdata ALIGN(128): { *(.rdata) }

--- a/ee/startup/src/linkfile
+++ b/ee/startup/src/linkfile
@@ -97,6 +97,10 @@ SECTIONS {
 	_end = . ;
 	PROVIDE(end = .);
 
+	.spad 0x70000000: {
+		*(.spad)
+	}
+
 	/* Symbols needed by crt0.s.  */
 	PROVIDE(_heap_size = -1);
 	PROVIDE(_stack = -1);


### PR DESCRIPTION
`.spad` section has been added for zero-initialized or uninitialized data to be located in scratchpad region.  
`.reginfo` and `.rodata` sections have been moved around.