### PR TITLE
Fix `rom0` access

### DIFF
--- a/ee/kernel/include/rom0_info.h
+++ b/ee/kernel/include/rom0_info.h
@@ -25,6 +25,7 @@ typedef struct {
     int (*open)(const char *name, int flags, ...);
     int (*close)(int fd);
     int (*read)(int fd, void *buf, int nbyte);
+    int openFlags;
 } _io_driver;
 
 /** check whether the PlayStation 2 is actually a DESR-XXXX machine

--- a/ee/kernel/src/osd_config.c
+++ b/ee/kernel/src/osd_config.c
@@ -38,7 +38,7 @@ typedef struct
     u8 timeFormat;
 } ConfigParamT10K;
 
-#define defaultIODriver { (void *)fioOpen, fioClose, fioRead }
+#define defaultIODriver { (void *)fioOpen, fioClose, fioRead, FIO_O_RDONLY }
 
 extern ConfigParamT10K g_t10KConfig;
 

--- a/ee/kernel/src/rom0_info.c
+++ b/ee/kernel/src/rom0_info.c
@@ -20,7 +20,7 @@
 #define NEWLIB_PORT_AWARE
 #include "fileio.h"
 
-#define defaultIODriver { (void *)fioOpen, fioClose, fioRead }
+#define defaultIODriver { (void *)fioOpen, fioClose, fioRead, FIO_O_RDONLY }
 
 extern char g_RomName[];
 
@@ -34,7 +34,7 @@ char *GetRomNameWithIODriver(char *romname, _io_driver *driver)
 {
     int fd;
 
-    fd = driver->open("rom0:ROMVER", FIO_O_RDONLY);
+    fd = driver->open("rom0:ROMVER", driver->openFlags);
     driver->read(fd, romname, 14);
     driver->close(fd);
     return romname;
@@ -54,7 +54,7 @@ int IsDESRMachineWithIODriver(_io_driver *driver)
 {
     int fd;
 
-    fd = driver->open("rom0:PSXVER", FIO_O_RDONLY);
+    fd = driver->open("rom0:PSXVER", driver->openFlags);
     if (fd > 0) {
         driver->close(fd);
         return 1;

--- a/ee/libcglue/src/cwd.c
+++ b/ee/libcglue/src/cwd.c
@@ -149,9 +149,15 @@ int __path_absolute(const char *in, char *out, int len)
 			return -1;
 	} else if(dr > 0 && in[dr - 1] == ':') {
 		/* It starts with "drive:", so it's already absoulte, however it misses the "/" after unit */
-		strncpy(out, in, dr);
-		out[dr] = '/';
-		strncpy(out + dr + 1, in + dr, len - dr - 1);
+		/* Just do it if drive: is different than rom0:, rom1:, rom2: .. rom9: */
+		if (strncmp(in, "rom", 3) == 0 && in[3] >= '0' && in[3] <= '9' && in[4] == ':') {
+			if(!__safe_strcpy(out, in, len))
+				return -1;
+		} else {
+			strncpy(out, in, dr);
+			out[dr] = '/';
+			strncpy(out + dr + 1, in + dr, len - dr - 1);
+		}
 	} else if(in[0] == '/') {
 		/* It's absolute, but missing the drive, so use cwd's drive */
 		if(strlen(__cwd) >= len)

--- a/ee/libcglue/src/timezone.c
+++ b/ee/libcglue/src/timezone.c
@@ -16,17 +16,21 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include <ps2sdkapi.h>
 #define OSD_CONFIG_NO_LIBCDVD
 #include "osd_config.h"
+
+#define posixIODriver { open, close, (int (*)(int, void *, int))read, O_RDONLY }
 
 #ifdef F__libcglue_timezone_update
 __attribute__((weak))
 void _libcglue_timezone_update()
 {
     /* Initialize timezone from PS2 OSD configuration */
-	_io_driver driver = { _ps2sdk_open, _ps2sdk_close, _ps2sdk_read };
+	_io_driver driver = posixIODriver;
 	int tzOffset = configGetTimezoneWithIODriver(&driver);
     int tzOffsetAbs = tzOffset < 0 ? -tzOffset : tzOffset;
     int hours = tzOffsetAbs / 60;
@@ -43,14 +47,14 @@ void _libcglue_timezone_update()
 
 #ifdef F_ps2sdk_setTimezone
 void ps2sdk_setTimezone(int timezone) {
-	_io_driver driver = { _ps2sdk_open, _ps2sdk_close, _ps2sdk_read };
+	_io_driver driver = posixIODriver;
 	configSetTimezoneWithIODriver(timezone, &driver, _libcglue_timezone_update);
 }
 #endif
 
 #ifdef F_ps2sdk_setDaylightSaving
 void ps2sdk_setDaylightSaving(int daylightSaving) {
-	_io_driver driver = { _ps2sdk_open, _ps2sdk_close, _ps2sdk_read };
+	_io_driver driver = posixIODriver;
 	configSetDaylightSavingEnabledWithIODriver(daylightSaving, &driver, _libcglue_timezone_update);
 }
 #endif


### PR DESCRIPTION
## Description
Thanks of the testing done by @israpps , I have faced 2 different issues when trying to do IO operation with `rom0`:
1. `rom0` can't have an `/`, and the previous code was always trying to put the `/` after the `:`, like `rom0:/ROMVER` which is wrong, now it properly does `rom0:ROMVER`
2. Additionally when using a custom IO driver for accessing roninfo.c functions, we were always hardcoding the usage of FIO flags, like `FIO_O_RDONLY`, so I added a new field to the `_io_driver` struct for saving the `openFlags`.


Not sure if there are other "units" different than `rom0` that should also skip the `/` after the `:`, please tell me if you are aware of any other drive.

Cheers.