### PR TITLE
Fix usage of `CDROM` paths

### DIFF
--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -511,7 +511,7 @@ int chdir(const char *path) {
 		return -1;
 	}
 
-	strcpy(__cwd, dest);
+	strncpy(__cwd, dest, sizeof(__cwd));
 	return 0;
 }
 #endif


### PR DESCRIPTION
## Description
When normalized path, I'm checking if `drive` requires to have `/`, `\` or none for instance `mc0`, `cdrom` or `rom`

I have used the example done on OPL to check if it works as expected:
https://github.com/ps2homebrew/Open-PS2-Loader/blob/master/labs/opltestiso/ee/main.c

<img width="1097" alt="Screenshot 2024-01-05 at 17 38 57" src="https://github.com/ps2dev/ps2sdk/assets/10010409/0b05edb6-12ee-440d-9da0-973e565810f0">

Cheers.