### PR TITLE
Buildsystem improvements 240117

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ $(subdir_clean): dummy
 $(subdir_release): dummy
 	$(MAKEREC) $(patsubst release-%,%,$@) release
 
+# Directory-level parallelism has been disabled due to issues with
+# multiple Make instances running inside a directory at once
+# and causing output file corruption
+.NOTPARALLEL: $(subdir_list) $(subdir_clean) $(subdir_release)
 
 build: $(subdir_list) | env_build_check download_dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq (x$(PS2SDKSRC), x)
   export PS2SDKSRC=$(shell pwd)
 endif
 
-SUBDIRS = tools iop ee common samples
+SUBDIRS = tools common iop ee samples
 
 all: build
 	@$(PRINTF) '.\n.PS2SDK Built.\n.\n'

--- a/Rules.make
+++ b/Rules.make
@@ -24,6 +24,10 @@ $(subdir_clean): dummy
 $(subdir_release): dummy
 	$(MAKE) -C $(patsubst release-%,%,$@) release
 
+# Directory-level parallelism has been disabled due to issues with
+# multiple Make instances running inside a directory at once
+# and causing output file corruption
+.NOTPARALLEL: $(subdir_list) $(subdir_clean) $(subdir_release)
 endif
 
 all: $(subdir_list)

--- a/common/Makefile
+++ b/common/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = sbus
+SUBDIRS = external_deps sbus
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/Rules.make

--- a/common/external_deps/Makefile
+++ b/common/external_deps/Makefile
@@ -11,4 +11,7 @@ clean:
 	@$(PRINTF) 'Cleaning lwip.\n'
 	rm -rf $(LWIP) $(LWIP)_inprogress
 
+release:
+	@cd .
+
 include $(PS2SDKSRC)/Defs.make

--- a/tools/Rules.release
+++ b/tools/Rules.release
@@ -24,6 +24,9 @@ release-bin:
 	 @if test $(TOOLS_BIN) ; then \
 	    $(PRINTF) 'Installing %s to %s\n' $(TOOLS_BIN) $(PS2SDK) ; \
 	    cp -f $(TOOLS_BIN) $(RELEASE_TOOLS_DIRS) ; \
+	       for file in $(TOOLS_BIN_ALTNAMES); do \
+	          ln -sf $$(basename $(TOOLS_BIN)) $(RELEASE_TOOLS_DIRS)/$$file; \
+	       done; \
 	 fi;
 
 release: release-dirs release-bin


### PR DESCRIPTION
Mainly works around race conditions (regarding incomplete/corrupted files) by performing parallelism for a single directory at a time.