### PR TITLE
[RFC/WIP] IOP: Provide crt0 with global constructor support

### DIFF
--- a/iop/startup/Makefile
+++ b/iop/startup/Makefile
@@ -6,15 +6,20 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-all:
+
+IOP_LIB = libdummy.a
+IOP_OBJS = crt0.o
+# disable array bounds warning for __do_global_ctors
+IOP_WARNFLAGS += -Wno-array-bounds
 
 include $(PS2SDKSRC)/Defs.make
+include $(PS2SDKSRC)/iop/Rules.lib.make
 include $(PS2SDKSRC)/iop/Rules.make
 include $(PS2SDKSRC)/iop/Rules.release
 
-clean:
-
 release:
 	@$(PRINTF) 'Installing %slinkfile into %s/iop/startup\n' $(IOP_SRC_DIR) $(PS2SDK)
+	$(ECHO) Installing $(IOP_SRC_DIR)linkfile into $(PS2SDK)/iop/startup
 	cp -f $(IOP_SRC_DIR)linkfile $(PS2SDK)/iop/startup
-
+	@$(ECHO) Installing $(IOP_OBJS_DIR)crt0.o into $(PS2DEV)/ee/mipsel-ps2-irx/lib
+	cp -f $(IOP_OBJS_DIR)crt0.o $(PS2DEV)/iop/mipsel-ps2-irx/lib

--- a/iop/startup/src/crt0.c
+++ b/iop/startup/src/crt0.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 typedef void (*func_ptr)(void);
 extern func_ptr __CTOR_END__[];
+extern func_ptr __DTOR_LIST__[];
 extern func_ptr __DTOR_END__[];
 
 static void __do_global_ctors(void)
@@ -16,12 +17,12 @@ static void __do_global_ctors(void)
 
 static void __do_global_dtors(void)
 {
-    func_ptr *p = __DTOR_END__ - 1;
+    int num = __DTOR_END__ - __DTOR_LIST__ - 1;
+    int idx = 0;
 
-    if (*(int *)p != -1) {
-        for (; *(int *)p != -1; p--) {
-            (*p)();
-        }
+    while (idx < num) {
+        idx++;
+        __DTOR_LIST__[idx]();
     }
 }
 

--- a/iop/startup/src/crt0.c
+++ b/iop/startup/src/crt0.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+typedef void (*func_ptr)(void);
+extern func_ptr __CTOR_END__[];
+extern func_ptr __DTOR_END__[];
+
+static void __do_global_ctors(void)
+{
+    func_ptr *p = __CTOR_END__ - 1;
+
+    if (*(int *)p != -1) {
+        for (; *(int *)p != -1; p--) {
+            (*p)();
+        }
+    }
+}
+
+static void __do_global_dtors(void)
+{
+    func_ptr *p = __DTOR_END__ - 1;
+
+    if (*(int *)p != -1) {
+        for (; *(int *)p != -1; p--) {
+            (*p)();
+        }
+    }
+}
+
+extern int main(int argc, char *argv[]);
+
+int _start(int argc, char *argv[])
+{
+    int ret;
+
+    if (argc >= 0) {
+        __do_global_ctors();
+        ret = main(argc, argv);
+    } else {
+        ret = main(argc, argv);
+        __do_global_dtors();
+    }
+
+    return ret;
+}


### PR DESCRIPTION
In order to make it easier to use C++ on the IOP we can provide a crt0 with support for global constructors.

Is there anything else we should provide here? Or a reason to not provide it at all?

I know there would need to be additional things required to support threadsafe statics etc. But I'd be inclined to suggest just disabling anything that requires extra support. (i.e. building with  `-fno-exceptions -fno-rtti -fno-threadsafe-statics`)