### PR TITLE
When copying filename, use filename argument of file info

### DIFF
--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -95,7 +95,7 @@ int __fioOpenHelper(_libcglue_fdman_fd_info_t *info, const char *buf, int flags,
             return -ENOMEM;
         }
         userdata->fd = iop_fd;
-        memcpy(userdata, buf, buf_len);
+        memcpy(userdata->filename, buf, buf_len);
         userdata->filename[buf_len] = '\x00';
         info->userdata = (void *)userdata;
         info->ops = is_dir ? &__fio_fdman_ops_dir : &__fio_fdman_ops_file;

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -97,7 +97,7 @@ int __fileXioOpenHelper(_libcglue_fdman_fd_info_t *info, const char *buf, int fl
             return -ENOMEM;
         }
         userdata->fd = iop_fd;
-        memcpy(userdata, buf, buf_len);
+        memcpy(userdata->filename, buf, buf_len);
         userdata->filename[buf_len] = '\x00';
         info->userdata = (void *)userdata;
         info->ops = is_dir ? &__fileXio_fdman_ops_dir : &__fileXio_fdman_ops_file;


### PR DESCRIPTION
Fixes fd being some large number (which is actually part of the file name)