### PR TITLE
Disabling `_libcglue_args_parse` in `ELF Loader`

### DIFF
--- a/ee/elf-loader/src/loader/src/loader.c
+++ b/ee/elf-loader/src/loader/src/loader.c
@@ -45,6 +45,7 @@
 //--------------------------------------------------------------
    void _libcglue_init() {}
    void _libcglue_deinit() {}
+   void _libcglue_args_parse(int argc, char **argv) {}
 
    DISABLE_PATCHED_FUNCTIONS();
    DISABLE_EXTRA_TIMERS_FUNCTIONS();


### PR DESCRIPTION
## Description
This PR avoids the `_libcglue_args_parse` for saving space in the elf-loader.

Cheers