### PR TITLE
crt0: Fix bss init routine

### DIFF
--- a/ee/startup/src/crt0.c
+++ b/ee/startup/src/crt0.c
@@ -43,21 +43,21 @@ static struct sargs_start *args_start;
 void __start(struct sargs_start *pargs)
 {
     asm volatile(
-   		"# Clear bss area"
-   		"la   $2, _fbss"
-   		"la   $3, _end"
-		"1:"
-   		"sltu   $1, $2, $3"
-   		"beq   $1, $0, 2f"
-   		"nop"
-   		"sq   $0, ($2)"
-   		"addiu   $2, $2, 16"
-   		"j   1b"
-   		"nop"
-		"2:"
-		"                       \n"
+        "# Clear bss area       \n"
+        "la   $2, _fbss         \n"
+        "la   $3, _end          \n"
+        "1:                     \n"
+        "sltu   $1, $2, $3      \n"
+        "beq   $1, $0, 2f       \n"
+        "nop                    \n"
+        "sq   $0, ($2)          \n"
+        "addiu   $2, $2, 16     \n"
+        "j   1b                 \n"
+        "nop                    \n"
+        "2:                     \n"
+        "                       \n"
         "# Save first argument  \n"
-        "la     $2, %0 \n"
+        "la     $2, %0          \n"
         "sw     $4, ($2)        \n"
         "                       \n"
         "# SetupThread          \n"
@@ -71,10 +71,10 @@ void __start(struct sargs_start *pargs)
         "syscall                \n"
         "move   $sp, $2         \n"
         "                       \n"
-        "# Jump to _main      	\n"
-        "j      %2           \n"
-		: /* No outputs. */
-		: "R"(args_start), "R"(args), "Csy"(_main));
+        "# Jump to _main        \n"
+        "j      %2              \n"
+        : /* No outputs. */
+        : "R"(args_start), "R"(args), "Csy"(_main));
 }
 
 /*
@@ -95,14 +95,14 @@ static void _main()
     // NOTE: this call can restart the application
     if (_ps2sdk_memory_init)
         _ps2sdk_memory_init();
-    
+
     // Use arguments sent through start if sent (by ps2link for instance)
     pa = &args;
     if (args.argc == 0 && args_start != NULL && args_start->args.argc != 0)
         pa = &args_start->args;
 
     // call libcglue argument parsing
-	_libcglue_args_parse(pa->argc, pa->argv);
+    _libcglue_args_parse(pa->argc, pa->argv);
 
     // initialize libcglue
     _libcglue_init();
@@ -133,7 +133,7 @@ static void _main()
 
 noreturn void _exit(int status)
 {
-	// call global destructors (weak)
+    // call global destructors (weak)
     if (_fini)
         _fini();
 


### PR DESCRIPTION
There was a severe issue where the bss segment was not properly being zeroed.
This caused major issues when using ps2link reset. IE: graph vram allocations not being reset, or `setenv` crashing after a soft reset. 

I originally thought these were two different issues, but newlib uses a static local variable to track if it has previously allocated https://github.com/ps2dev/newlib/blob/ee-v4.4.0/newlib/libc/stdlib/setenv_r.c#L56
Obviously, if you soft reset the system without marking this flag as zero, the next time it tries to use this no-longer-allocated memory, you would get a crash.

TLDR: This fixes globals not being set to zero, which in turn fixes probably that bug you've been chasing for weeks.
