### PR TITLE
Fixing MacOS compilation

### DIFF
--- a/tools/ps2-irxgen/Makefile
+++ b/tools/ps2-irxgen/Makefile
@@ -7,6 +7,7 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 TOOLS_OBJS = ps2-irxgen.o
+TOOLS_CFLAGS += -Wno-unused-result
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/tools/Rules.bin.make

--- a/tools/romimg/src/SonyRX.c
+++ b/tools/romimg/src/SonyRX.c
@@ -4,7 +4,7 @@
 
 #include <errno.h>
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "ELF.h"

--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -5,6 +5,8 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "romimg.h"
 
@@ -141,7 +143,7 @@ int main(int argc, char **argv)
             if (argc == 3) {
                 char FOLDER[256] = "ext_";
                 strcat(FOLDER, argv[2]);
-                mkdir(FOLDER);
+                mkdir(FOLDER, 0755);
                 chdir(FOLDER);
 
                 printf("File list:\n"

--- a/tools/romimg/src/platform.c
+++ b/tools/romimg/src/platform.c
@@ -5,12 +5,12 @@
 #include <errno.h>
 #include <stdlib.h>
 #include "dprintf.h"
-#ifdef __unix__
+#if defined(_WIN32) || defined(WIN32)
+#include <windows.h>
+#else
 #include <sys/stat.h>
 #include <unistd.h>
 #include <time.h>
-#elif defined(_WIN32) || defined(WIN32)
-#include <windows.h>
 #endif
 
 #include "platform.h"

--- a/tools/romimg/src/romimg.c
+++ b/tools/romimg/src/romimg.c
@@ -5,7 +5,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 
 #include "platform.h"


### PR DESCRIPTION
The rooming tool is not compiling for the MacOS environment.

Please check that things still compile for Linux and Windows environments
@rickgaiser and @israpps 

Cheers.