### PR TITLE
include debug fileXio on SDK distribution

### DIFF
--- a/iop/fs/filexio-verbose/Makefile
+++ b/iop/fs/filexio-verbose/Makefile
@@ -6,21 +6,11 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-SUBDIRS = \
-	adddrv \
-	addrom2 \
-	bdm \
-	bdmfs_fatfs \
-	bdmfs_vfat \
-	devfs \
-	fakehost \
-	fileio \
-	filexio \
-	filexio-verbose \
-	http \
-	libbdm \
-	netfs \
-	romdrv
+IOP_PAR_DIR = $(PS2SDKSRC)/iop/fs/filexio
+IOP_SRC_DIR = $(IOP_PAR_DIR)/src/
+IOP_INC_DIR = $(IOP_PAR_DIR)/src/
 
-include $(PS2SDKSRC)/Defs.make
-include $(PS2SDKSRC)/Rules.make
+IOP_BIN ?= fileXio_verbose.irx
+
+DEBUG = 1
+include $(IOP_PAR_DIR)/Makefile

--- a/iop/fs/filexio/src/fileXio_iop.c
+++ b/iop/fs/filexio/src/fileXio_iop.c
@@ -30,8 +30,8 @@
 #include <errno.h>
 #include <fileXio.h>
 
-#define MODNAME "IOX/File_Manager_Rpc"
-IRX_ID(MODNAME, 1, 2);
+#define MODNAME "fileXio"
+IRX_ID("IOX/File_Manager_Rpc", 1, 2);
 
 #define M_PRINTF(format, args...) \
     printf(MODNAME ": " format, ##args)


### PR DESCRIPTION
Useful if developer wants to track open,close,read,etc,etc while debugging without having to clone and compile PS2SDK again nor store prebuilt copy on repository.

Will also help a lot to see how path changes when passing through the libcglue path normalization