### PR TITLE
Allow manual workflow execution

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
Allows to recompile SDK without commiting to the branch. Also allows forks to run workflow on other branches without commiting to main branch