### PR TITLE
allow romimg to access files from absolute paths

### DIFF
--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -87,10 +87,10 @@ int main(int argc, char **argv)
     if (argc >= 4 && strcmp(argv[1], "-c") == 0) {
         if ((result = CreateBlankROMImg(argv[2], &ROMImg)) == 0) {
             for (FilesAffected = 0, i = 0; i < argc - 3; i++) {
-                printf("Adding file %s... ", argv[3 + i]);
+                printf("Adding file '%s'", argv[3 + i]);
                 if ((result = AddFile(&ROMImg, argv[3 + i])) == 0)
                     FilesAffected++;
-                printf(result == 0 ? GRNBOLD"done!"DEFCOL"\n" : REDBOLD"failed!"DEFCOL"\n");
+                printf(result == 0 ? GRNBOLD" done!"DEFCOL"\n" : REDBOLD" failed!"DEFCOL"\n");
             }
 
             if (FilesAffected > 0) {
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     } else if (argc >= 4 && strcmp(argv[1], "-a") == 0) {
         if ((result = LoadROMImg(&ROMImg, argv[2])) == 0) {
             for (i = 0, FilesAffected = 0; i < argc - 3; i++) {
-                printf("Adding file %s... ", argv[3 + i]);
+                printf("Adding file '%s'", argv[3 + i]);
                 if ((result = AddFile(&ROMImg, argv[3 + i])) == 0)
                     FilesAffected++;
                 DisplayAddDeleteOperationResult(result, argv[3 + i]);

--- a/tools/romimg/src/platform.h
+++ b/tools/romimg/src/platform.h
@@ -3,3 +3,9 @@ int GetLocalhostName(char *buffer, unsigned int BufferSize);
 unsigned int GetSystemDate(void);
 unsigned int GetFileCreationDate(const char *path);
 int GetCurrentWorkingDirectory(char *buffer, unsigned int BufferSize);
+
+#if defined(_WIN32) || defined(WIN32)
+#define PATHSEP '\\'
+#else
+#define PATHSEP '/'
+#endif

--- a/tools/romimg/src/romimg.c
+++ b/tools/romimg/src/romimg.c
@@ -459,6 +459,8 @@ int AddFile(ROMIMG *ROMImg, const char *path)
 	unsigned int FileDateStamp;
 	unsigned short FileVersion;
 	if ((InputFile = fopen(path, "rb")) != NULL) {
+		const char* fname = strrchr(path, PATHSEP);
+		if (fname == NULL) fname = path; else fname++;
 		int size;
 		fseek(InputFile, 0, SEEK_END);
 		size = ftell(InputFile);
@@ -466,15 +468,15 @@ int AddFile(ROMIMG *ROMImg, const char *path)
 
 		struct FileEntry *file;
 		// Files cannot exist more than once in an image. The RESET entry is special here because all images will have a RESET entry, but it might be empty (If it has no content, allow the user to add in content).
-		if (strcmp(path, "RESET")) {
-			if (!IsFileExists(ROMImg, path)) {
+		if (strcmp(fname, "RESET")) {
+			if (!IsFileExists(ROMImg, fname)) {
 				ROMImg->NumFiles++;
 
 				if ((ROMImg->files = (ROMImg->files == NULL) ? malloc(sizeof(struct FileEntry)) : realloc(ROMImg->files, ROMImg->NumFiles * sizeof(struct FileEntry))) != NULL) {
 					file = &ROMImg->files[ROMImg->NumFiles - 1];
 					memset(&ROMImg->files[ROMImg->NumFiles - 1], 0, sizeof(struct FileEntry));
 
-					strncpy(file->RomDir.name, path, sizeof(file->RomDir.name));
+					strncpy(file->RomDir.name, fname, sizeof(file->RomDir.name));
 					file->RomDir.ExtInfoEntrySize = 0;
 
 					FileDateStamp = GetFileCreationDate(path);


### PR DESCRIPTION
With this commit:
```bash
bin/romimg -c IOPRP.IMG $HOME/SECRMAN $HOME/SECRSIF
```
Results in these contents:

```
PlayStation 2 ROM image generator v1.12
Compiled on Mar 21 2024 - 17:57:57
---------------------------------------

ROM datestamp:  2024/03/21
ROM comment:    20240321,conffile,IOPRP.IMG,isra@DESKTOP-AO7864M//mnt/c/Users/tatoc/OneDrive/Documentos/ps2sdk/tools/romimg
File list:
Name            Size
-----------------------------
RESET           0
SECRMAN         18444
SECRSIF         4548
```

before the result would have been:
```
PlayStation 2 ROM image generator v1.12
Compiled on Mar 21 2024 - 17:57:57
---------------------------------------

ROM datestamp:  2024/03/21
ROM comment:    20240321,conffile,IOPRP.IMG,isra@DESKTOP-AO7864M//mnt/c/Users/tatoc/OneDrive/Documentos/ps2sdk/tools/romimg
File list:
Name            Size
-----------------------------
RESET           0
/home/isra/SECRMAN         18444
/home/isra/SECRSIF         4548
```

in case of longer names, romimg truncated name to 32 bytes, so this change is even more useful