### PR TITLE
Adding tools to CI/CD

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,40 @@
+name: Tools
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os[0] }}
+    strategy:
+      matrix:
+        os: [[macos-latest, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+        debug: [all, debug]
+      fail-fast: false
+    defaults:
+     run:
+      shell: ${{ matrix.os[1] }} {0}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install MSYS2 packages
+      if: matrix.os[0] == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW32
+        install: |
+          base-devel mingw-w64-i686-gcc
+        update: true
+
+    - name: Compile tools
+      run: |
+        export PS2DEV=$PWD/ps2dev
+        export PS2SDK=$PS2DEV/ps2sdk
+        make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 clean
+        make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 ${{ matrix.debug }}
+        make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 install

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,18 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 DEBUG ?= 0
+ONLY_HOST_TOOLS ?= 0
 
 ifeq (x$(PS2SDKSRC), x)
   export PS2SDKSRC=$(shell pwd)
 endif
 
-SUBDIRS = tools common iop ee samples
+# If ONLY_HOST_TOOLS is set, only build the host tools.
+ifeq ($(ONLY_HOST_TOOLS), 1)
+  SUBDIRS = tools
+else
+  SUBDIRS = tools common iop ee samples
+endif
 
 all: build
 	@$(PRINTF) '.\n.PS2SDK Built.\n.\n'
@@ -96,11 +102,19 @@ env_release_check:
 	  exit 1; \
 	fi
 
+# Don't do anything if ONLY_HOST_TOOLS is set.
 download_dependencies:
-	$(MAKEREC) $(PS2SDKSRC)/common/external_deps all
-
+	@if test $(ONLY_HOST_TOOLS) -eq 0 ; \
+	then \
+	  $(MAKEREC) $(PS2SDKSRC)/common/external_deps all ; \
+	fi
+	
+# Don't do anything if ONLY_HOST_TOOLS is set.
 clean_dependencies:
-	$(MAKEREC) $(PS2SDKSRC)/common/external_deps clean
+	@if test $(ONLY_HOST_TOOLS) -eq 0 ; \
+	then \
+	  $(MAKEREC) $(PS2SDKSRC)/common/external_deps clean ; \
+	fi
 
 docs:
 	doxygen

--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
             if (argc == 3) {
                 char FOLDER[256] = "ext_";
                 strcat(FOLDER, argv[2]);
-#ifdef __MINGW32__
+#if defined(_WIN32) || defined(WIN32)
                 mkdir(FOLDER);
 #else
                 mkdir(FOLDER, 0755);


### PR DESCRIPTION
This PR adds the compilation of tools in the available supported systems Linux, Windows, and MacOS.

In this way now we can check if we merge something that is breaking the CI, previously, we didn't face any error till by dispatching it reached the `ps2dev` repo.

Cheers