### PR TITLE
[tools CI] upload built binaries and only run workflow if commiting t…

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -46,5 +46,5 @@ jobs:
       if: ${{ success() }}
       uses: actions/upload-artifact@v3
       with:
-        name: ps2sdk-tools-${{ matrix.debug }}-${{ steps.slug.outputs.sha8 }}
+        name: ps2sdk-tools-${{ matrix.debug }}-${{ matrix.os[0] }}
         path: ps2dev/ps2sdk/bin/*

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -47,4 +47,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ps2sdk-tools-${{ matrix.debug }}-${{ steps.slug.outputs.sha8 }}
-        path: $(PS2SDK)/bin/*
+        path: ps2dev/ps2sdk/bin/*

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -2,6 +2,9 @@ name: Tools
 
 on:
   push:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/tools.yml'
   pull_request:
   repository_dispatch:
     types: [run_build]
@@ -38,3 +41,10 @@ jobs:
         make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 clean
         make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 ${{ matrix.debug }}
         make -j $(getconf _NPROCESSORS_ONLN) ONLY_HOST_TOOLS=1 install
+
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ps2sdk-tools-${{ matrix.debug }}-${{ steps.slug.outputs.sha8 }}
+        path: $(PS2SDK)/bin/*


### PR DESCRIPTION
…o `tools/` or to the CI script

- allows testing binaries built by CI
- saves workflow run time if the tools folder was not touched by the push event trigger