### PR TITLE
Fix pthread

### DIFF
--- a/ee/kernel/src/kernel_util.c
+++ b/ee/kernel/src/kernel_util.c
@@ -34,7 +34,7 @@ s32 WaitSemaEx(s32 semaid, int signal, u64 *timeout)
     // TODO: other values NYI
     if (signal != 1)
     {
-        return -1;
+        return -100;
     }
 
     if (timeout != NULL && *timeout == 0)
@@ -54,16 +54,11 @@ s32 WaitSemaEx(s32 semaid, int signal, u64 *timeout)
 
     ret = WaitSema(semaid);
 
-    if (ret < 0)
-    {
-        return ret;
-    }
-
     if (timerid >= 0)
     {
         ReleaseTimerAlarm(timerid);
     }
 
-    return semaid;
+    return ret;
 }
 #endif

--- a/ee/libpthreadglue/src/osal.c
+++ b/ee/libpthreadglue/src/osal.c
@@ -76,31 +76,24 @@ ps2ThreadData *__getThreadData(s32 threadHandle)
 ps2ThreadData *__getThreadData(s32 threadHandle);
 #endif
 
-static inline int SemWaitTimeout(s32 semHandle, uint32_t timeout)
+static inline int32_t SemWaitTimeout(s32 semHandle, uint32_t timeout)
 {
-    int ret;
     u64 timeoutUsec;
     u64 *timeoutPtr;
 
     if (timeout == 0) {
-        if (PollSema(semHandle) < 0) {
-            return -1;
-        }
-        return 0;
+        return PollSema(semHandle);
     }
 
     timeoutPtr = NULL;
 
     if (timeout > 0 && timeout != UINT32_MAX) {
-        timeoutUsec = timeout * 1000;
+        timeoutUsec = timeout;
         timeoutPtr = &timeoutUsec;
+        return WaitSemaEx(semHandle, 1, timeoutPtr);
     }
 
-    ret = WaitSemaEx(semHandle, 1, timeoutPtr);
-
-    if (ret < 0)
-        return -2;
-    return 0; //Wait condition satisfied.
+    return WaitSema(semHandle);
 }
 
 /* A new thread's stub entry point.  It retrieves the real entry point from the per thread control
@@ -556,13 +549,14 @@ pte_osResult pte_osMutexLock(pte_osMutexHandle handle)
 pte_osResult pte_osMutexTimedLock(pte_osMutexHandle handle, unsigned int timeoutMsecs)
 {
   pte_osResult result;
-
-  int status = SemWaitTimeout(handle, timeoutMsecs);
-  if (status < 0) {
-    // Assume that any error from SemWaitTimeout was due to a timeout
+  int32_t timeout = timeoutMsecs * 1000;
+  int status = SemWaitTimeout(handle, timeout);
+  if (status > 0) {
+    result = PTE_OS_OK;
+  } else if (status == -1) {
     result = PTE_OS_TIMEOUT;
   } else {
-    result = PTE_OS_OK;
+    result = PTE_OS_GENERAL_FAILURE;
   }
 
   return result;
@@ -626,19 +620,19 @@ pte_osResult pte_osSemaphorePost(pte_osSemaphoreHandle handle, int count)
 pte_osResult pte_osSemaphorePend(pte_osSemaphoreHandle handle, unsigned int *pTimeoutMsecs)
 {
   uint32_t timeout;
-  uint32_t result;
+  int32_t result;
   pte_osResult osResult;
   
   if (pTimeoutMsecs == NULL) {
     timeout = UINT32_MAX;
   } else {
-    timeout = *pTimeoutMsecs;
+    timeout = *pTimeoutMsecs * 1000;
   }
 
   result = SemWaitTimeout(handle, timeout);
-  if (result == 0) {
+  if (result > 0) {
     osResult = PTE_OS_OK;
-  } else if (result == -2) {
+  } else if (result == -1) {
     osResult = PTE_OS_TIMEOUT;
   } else {
     osResult = PTE_OS_GENERAL_FAILURE;
@@ -664,31 +658,27 @@ pte_osResult pte_osSemaphoreCancellablePend(pte_osSemaphoreHandle semHandle, uns
 
   clock_t start_time;
   pte_osResult result =  PTE_OS_OK;
-  unsigned int timeout;
-  unsigned char timeoutEnabled;
+  uint32_t timeout;
 
   start_time = clock();
 
   // clock() is in microseconds, timeout as passed in was in milliseconds
   if (pTimeout == NULL) {
     timeout = 0;
-    timeoutEnabled = 0;
   } else {
-    timeout = *pTimeout * 1000;
-    timeoutEnabled = 1;
+    timeout = *pTimeout;
   }
 
   while (1) {
-    int status;
+    int32_t status;
 
     /* Poll semaphore */
-    status = SemWaitTimeout(semHandle, UINT32_MAX);
-
-    if (status == 0) {
+    status = SemWaitTimeout(semHandle, 0);
+    if (status > 0) {
       /* User semaphore posted to */
       result = PTE_OS_OK;
       break;
-    } else if ((timeoutEnabled) && ((clock() - start_time) > timeout)) {
+    } else if ((pTimeout != NULL) && ((clock() - start_time) > timeout)) {
       /* Timeout expired */
       result = PTE_OS_TIMEOUT;
       break;

--- a/ee/libpthreadglue/src/osal.c
+++ b/ee/libpthreadglue/src/osal.c
@@ -179,6 +179,12 @@ pte_osResult pte_osTerminate(void) {
  * Threads
  *
  ***************************************************************************/
+
+static inline int invert_priority(int priority)
+{
+	return (pte_osThreadGetMinPriority() - priority) + pte_osThreadGetMaxPriority();
+}
+
 #ifdef F_pte_osThreadCreate
 pte_osResult pte_osThreadCreate(pte_osThreadEntryPoint entryPoint,
                                 int stackSize,
@@ -247,7 +253,7 @@ pte_osResult pte_osThreadCreate(pte_osThreadEntryPoint entryPoint,
 	eethread.stack = stack;
 	eethread.stack_size = stackSize;
 	eethread.gp_reg = &_gp;
-	eethread.initial_priority = initialPriority;
+	eethread.initial_priority = invert_priority(initialPriority);
 	threadId = CreateThread(&eethread);
   
   /* In order to emulate TLS functionality, we append the address of the TLS structure that we
@@ -403,14 +409,14 @@ int pte_osThreadGetPriority(pte_osThreadHandle threadHandle)
 
   ReferThreadStatus(threadHandle, &thinfo);
 
-  return thinfo.current_priority;
+  return invert_priority(thinfo.current_priority);
 }
 #endif
 
 #ifdef F_pte_osThreadSetPriority
 pte_osResult pte_osThreadSetPriority(pte_osThreadHandle threadHandle, int newPriority)
 {
-  ChangeThreadPriority(threadHandle, newPriority);
+  ChangeThreadPriority(threadHandle, invert_priority(newPriority));
   return PTE_OS_OK;
 }
 #endif
@@ -476,21 +482,21 @@ void pte_osThreadSleep(unsigned int msecs)
 #ifdef  F_pte_osThreadGetMinPriority
 int pte_osThreadGetMinPriority()
 {
-  return 17;
+  return pte_osThreadGetDefaultPriority() - 32;
 }
 #endif
 
 #ifdef F_pte_osThreadGetMaxPriority
 int pte_osThreadGetMaxPriority()
 {
-  return 30;
+  return pte_osThreadGetDefaultPriority() + 32;
 }
 #endif
 
 #ifdef F_pte_osThreadGetDefaultPriority
 int pte_osThreadGetDefaultPriority()
 {
-  return 18;
+  return 60;
 }
 #endif
 


### PR DESCRIPTION
Now all the test from `pthread-embedded` are passing correctly:

```
[    1.7781] Running tests...
[    1.7784] =========================
[    1.7788]    Test iteration #0
[    1.7791] =========================
[    1.7792] Reuse test #1
[    1.7836] Create test #1
[    3.7540] Create test #2
[    3.7699] Create test #3
[    3.7710] Join test #0
[    5.7705] Join test #1
[    7.8229] Join test #2
[    9.8225] Join test #3
[   10.8258] Join test #4
[   15.8258] Kill test #1
[   15.8261] Exit test #1
[   16.8247] Exit test #2
[   17.8255] Exit test #3
[   18.8262] Priority test #1
[   18.8271] Priority test #2
[   18.8408] Valid test #1
[   18.8417] Valid test #2
[   18.8418] Self test #1
[   18.8419] Self test #2
[   18.9422] Equal test #1
[   20.9421] Count test #1
[   21.9430] Delay test #1
[   21.9434] Delay test #2
[   21.9439] Once test #1
[   23.9422] Once test #2
[   25.0434] Once test #3
[   25.0612] Once test #4
[   25.0769] TSD test #1
[   25.0918] TSD test #2
[   25.0948] Detach test #1
[   26.4441] Mutex test #1
[   26.4446] Mutex test #1(e)
[   26.4453] Mutex test #1(n)
[   26.4456] Mutex test #1(r)
[   26.4457] Mutex test #2
[   26.4460] Mutex test #2(e)
[   26.4463] Mutex test #2(r)
[   26.4467] Mutex test #3
[   26.4470] Mutex test #3(e)
[   26.4473] Mutex test #3(r)
[   26.4476] Mutex test #4
[   26.4484] Mutex test #5
[   26.4485] Mutex test #6
[   28.4432] Mutex test #6e
[   28.4439] Mutex test #6es
[   28.4445] Mutex test #6n
[   30.4443] Mutex test #6r
[   30.4448] Mutex test #6rs
[   30.4452] Mutex test #6s
[   32.4451] Mutex test #7
[   33.4434] Mutex test #7e
[   33.4441] Mutex test #7n
[   34.4446] Mutex test #7r
[   34.4452] Mutex test #8
[   36.4436] Mutex test #8e
[   38.4441] Mutex test #8n
[   40.4439] Mutex test #8r
[   42.4431] Semaphore test #1
[   42.4440] Semaphore test #2
[   42.4596] Semaphore test #3
[   43.4595] Semaphore test #4
[   43.4786] Semaphore test #4t
[   43.4831] Semaphore test #5
[   48.4805] Semaphore test #6
[   53.4931] Condvar test #1
[   53.4942] Condvar test #1-1
[   53.5092] Condvar test #1-2
[   53.5597] Condvar test #2
[   54.5644] Condvar test #2-1
[   60.4995] Condvar test #3
[   60.5095] Condvar test #3-1
[   65.5114] Condvar test #3-2
[   72.5110] Condvar test #3-3
[   74.5103] Condvar test #4
[   79.5263] Condvar test #5
[   84.5264] Condvar test #6
[   85.5287] Condvar test #7
[   86.5284] Condvar test #8
[   86.7283] Condvar test #9
[   88.7290] Barrier test #1
[   88.7415] Barrier test #2
[   88.7430] Barrier test #3
[   88.7439] Barrier test #4
[   88.7789] Barrier test #5
[   92.0254] Spin test #1
[   92.0272] Spin test #2
[   92.0278] Spin test #3
[   92.0282] Spin test #4
[   93.0260] Rwlock test #1
[   93.0267] Rwlock test #2
[   93.0277] Rwlock test #2t
[   93.0283] Rwlock test #3
[   95.0262] Rwlock test #3t
[   97.0267] Rwlock test #4
[   99.0283] Rwlock test #4t
[  101.9743] Rwlock test #5
[  103.9763] Rwlock test #5t
[  105.9770] Rwlock test #6
[  109.9774] Rwlock test #6t
[  113.9774] Rwlock test #6t2
[  115.9762] Rwlock test #7
[  116.9757] Rwlock test #8
[  127.5095] Cancel test #1
[  129.5085] Cancel test #2
[  130.6093] Cancel test #3
[  130.6096] Test not run - async cancellation not supported
[  130.6097] Cancel test #4
[  132.6077] Cancel test #5
[  132.6078] Test not run - async cancellation not supported
[  132.6079] Cancel test #6a
[  132.6080] Test not run - async cancellation not supported
[  132.6080] Cancel test #6d
[  133.5083] Cleanup test #0
[  133.5085] Test not run - async cancellation not supported
[  133.5087] Cleanup test #1
[  133.5088] Test not run - async cancellation not supported
[  133.5089] Cleanup test #2
[  133.5090] Test not run - async cancellation not supported
[  133.5091] Cleanup test #3
[  133.5096] Test not run - async cancellation not supported
[  133.5098] Exception test #1
[  133.5099] Test N/A for this compiler environment.
[  133.5101] Exception test #3
[  133.5103] Test N/A for this compiler environment.
[  133.5104] Benchmark test #1
[  133.5106] =============================================================================
[  133.5111] Lock plus unlock on an unlocked mutex.
[  133.5112] 100000 iterations
[  133.5117] Test                                              Total(msec)   average(usec)
[  133.5293] Dummy call x 2                                              8           0.080
[  133.5754] Dummy call -> Interlocked with cond x 2                    48           0.480
[  133.5805] InterlockedOp x 2                                          12           0.120
[  133.8921] Simple Critical Section                                   301           3.010
[  133.8923] .............................................................................
[  133.9453] PTHREAD_MUTEX_DEFAULT                                      61           0.610
[  134.0098] PTHREAD_MUTEX_NORMAL                                       61           0.610
[  134.1607] PTHREAD_MUTEX_ERRORCHECK                                  154           1.540
[  134.3139] PTHREAD_MUTEX_RECURSIVE                                   156           1.560
[  134.3141] =============================================================================
[  134.3142] Benchmark test #2
[  134.3143] =============================================================================
[  134.3232] Lock plus unlock on a locked mutex.
[  134.3234] 10000 iterations, four locks/unlocks per iteration.
[  134.3235] Test                                              Total(msec)   average(usec)
[  178.9068] PTHREAD_MUTEX_DEFAULT                                      98           2.450
[  199.3225] PTHREAD_MUTEX_NORMAL                                       98           2.450
[  219.7375] PTHREAD_MUTEX_ERRORCHECK                                   99           2.475
[  240.1551] PTHREAD_MUTEX_RECURSIVE                                    99           2.475
[  240.1553] =============================================================================
[  240.1557] Benchmark test #3
[  240.1565] =============================================================================
[  240.1572] Trylock on a locked mutex.
[  240.1575] 100000 iterations.
[  240.1577] Test                                              Total(msec)   average(usec)
[  240.1581] .............................................................................
[  240.1897] PTHREAD_MUTEX_DEFAULT (W9x,WNT)                            38           0.380
[  240.2263] PTHREAD_MUTEX_NORMAL (W9x,WNT)                             38           0.380
[  240.2713] PTHREAD_MUTEX_ERRORCHECK (W9x,WNT)                         38           0.380
[  240.3564] PTHREAD_MUTEX_RECURSIVE (W9x,WNT)                          87           0.870
[  240.3568] =============================================================================
[  240.3569] Benchmark test #4
[  240.3571] =============================================================================
[  240.3573] Trylock plus unlock on an unlocked mutex.
[  240.3576] 100000 iterations.
[  240.3580] Test                                              Total(msec)   average(usec)
[  240.4223] PTHREAD_MUTEX_DEFAULT                                      61           0.610
[  240.4757] PTHREAD_MUTEX_NORMAL                                       62           0.620
[  240.6366] PTHREAD_MUTEX_ERRORCHECK                                  153           1.530
[  240.7891] PTHREAD_MUTEX_RECURSIVE                                   154           1.540
[  240.7892] =============================================================================
[  240.7894] Stress test #1
[  251.6403] =========================
[  251.6406]    Test iteration #1
[  251.6409] =========================
[  251.6410] Skipping Reuse test #1 (required to run first on first iteration only)
[  251.6412] Create test #1
[  253.6378] Create test #2
[  253.6569] Create test #3
[  253.6575] Join test #0
[  255.6564] Join test #1
[  257.7035] Join test #2
[  259.7049] Join test #3
[  260.7044] Join test #4
[  265.7053] Kill test #1
[  265.7055] Exit test #1
[  266.7042] Exit test #2
[  267.7043] Exit test #3
[  268.7047] Priority test #1
[  268.7051] Priority test #2
[  268.7206] Valid test #1
[  268.7210] Valid test #2
[  268.7210] Self test #1
[  268.7211] Self test #2
[  268.8218] Equal test #1
[  270.8231] Count test #1
[  271.8225] Delay test #1
[  271.8228] Delay test #2
[  271.8232] Once test #1
[  273.8227] Once test #2
[  274.9209] Once test #3
[  274.9372] Once test #4
[  274.9691] TSD test #1
[  274.9698] TSD test #2
[  274.9713] Detach test #1
[  276.3220] Mutex test #1
[  276.3223] Mutex test #1(e)
[  276.3226] Mutex test #1(n)
[  276.3228] Mutex test #1(r)
[  276.3229] Mutex test #2
[  276.3230] Mutex test #2(e)
[  276.3234] Mutex test #2(r)
[  276.3236] Mutex test #3
[  276.3239] Mutex test #3(e)
[  276.3241] Mutex test #3(r)
[  276.3243] Mutex test #4
[  276.3248] Mutex test #5
[  276.3251] Mutex test #6
[  278.3206] Mutex test #6e
[  278.3209] Mutex test #6es
[  278.3211] Mutex test #6n
[  280.3206] Mutex test #6r
[  280.3209] Mutex test #6rs
[  280.3212] Mutex test #6s
[  282.3227] Mutex test #7
[  283.3214] Mutex test #7e
[  283.3218] Mutex test #7n
[  284.3212] Mutex test #7r
[  284.3216] Mutex test #8
[  286.3364] Mutex test #8e
[  288.3362] Mutex test #8n
[  290.3361] Mutex test #8r
[  292.3370] Semaphore test #1
[  292.3379] Semaphore test #2
[  292.3393] Semaphore test #3
[  293.3386] Semaphore test #4
[  293.3526] Semaphore test #4t
[  293.3684] Semaphore test #5
[  298.3688] Semaphore test #6
[  303.3701] Condvar test #1
[  303.3714] Condvar test #1-1
[  303.3857] Condvar test #1-2
[  303.4361] Condvar test #2
[  304.4365] Condvar test #2-1
[  309.4526] Condvar test #3
[  309.4534] Condvar test #3-1
[  314.4557] Condvar test #3-2
[  321.4555] Condvar test #3-3
[  323.4675] Condvar test #4
[  328.4679] Condvar test #5
[  333.4686] Condvar test #6
[  334.4713] Condvar test #7
[  335.4721] Condvar test #8
[  335.6840] Condvar test #9
[  337.6857] Barrier test #1
[  337.6866] Barrier test #2
[  337.6873] Barrier test #3
[  337.6884] Barrier test #4
[  337.7356] Barrier test #5
[  340.9686] Spin test #1
[  340.9687] Spin test #2
[  340.9688] Spin test #3
[  340.9690] Spin test #4
[  341.9716] Rwlock test #1
[  341.9722] Rwlock test #2
[  341.9731] Rwlock test #2t
[  341.9738] Rwlock test #3
[  343.9851] Rwlock test #3t
[  345.9835] Rwlock test #4
[  347.9836] Rwlock test #4t
[  349.9839] Rwlock test #5
[  351.9850] Rwlock test #5t
[  353.9863] Rwlock test #6
[  357.9850] Rwlock test #6t
[  361.9872] Rwlock test #6t2
[  364.0004] Rwlock test #7
[  364.9995] Rwlock test #8
[  375.5334] Cancel test #1
[  377.5328] Cancel test #2
[  378.6321] Cancel test #3
[  378.6325] Test not run - async cancellation not supported
[  378.6326] Cancel test #4
[  380.6328] Cancel test #5
[  380.6330] Test not run - async cancellation not supported
[  380.6331] Cancel test #6a
[  380.6332] Test not run - async cancellation not supported
[  380.6333] Cancel test #6d
[  381.5323] Cleanup test #0
[  381.5324] Test not run - async cancellation not supported
[  381.5325] Cleanup test #1
[  381.5326] Test not run - async cancellation not supported
[  381.5327] Cleanup test #2
[  381.5328] Test not run - async cancellation not supported
[  381.5330] Cleanup test #3
[  381.5332] Test not run - async cancellation not supported
[  381.5335] Exception test #1
[  381.5338] Test N/A for this compiler environment.
[  381.5339] Exception test #3
[  381.5341] Test N/A for this compiler environment.
[  381.5343] Benchmark test #1
[  381.5344] =============================================================================
[  381.5346] Lock plus unlock on an unlocked mutex.
[  381.5348] 100000 iterations
[  381.5350] Test                                              Total(msec)   average(usec)
[  381.5384] Dummy call x 2                                              8           0.080
[  381.5854] Dummy call -> Interlocked with cond x 2                    48           0.480
[  381.6013] InterlockedOp x 2                                          12           0.120
[  381.9016] Simple Critical Section                                   300           3.000
[  381.9018] .............................................................................
[  381.9663] PTHREAD_MUTEX_DEFAULT                                      61           0.610
[  382.0211] PTHREAD_MUTEX_NORMAL                                       61           0.610
[  382.1736] PTHREAD_MUTEX_ERRORCHECK                                  154           1.540
[  382.3351] PTHREAD_MUTEX_RECURSIVE                                   156           1.560
[  382.3352] =============================================================================
[  382.3354] Benchmark test #2
[  382.3354] =============================================================================
[  382.3356] Lock plus unlock on a locked mutex.
[  382.3357] 10000 iterations, four locks/unlocks per iteration.
[  382.3358] Test                                              Total(msec)   average(usec)
[  423.0666] PTHREAD_MUTEX_DEFAULT                                   20418         510.450
[  443.5334] PTHREAD_MUTEX_NORMAL                                    20418         510.450
[  466.6144] PTHREAD_MUTEX_ERRORCHECK                                20418         510.450
[  487.0321] PTHREAD_MUTEX_RECURSIVE                                 20418         510.450
[  487.0322] =============================================================================
[  487.0324] Benchmark test #3
[  487.0325] =============================================================================
[  487.0327] Trylock on a locked mutex.
[  487.0327] 100000 iterations.
[  487.0329] Test                                              Total(msec)   average(usec)
[  487.0330] .............................................................................
[  487.0660] PTHREAD_MUTEX_DEFAULT (W9x,WNT)                            38           0.380
[  487.1139] PTHREAD_MUTEX_NORMAL (W9x,WNT)                             39           0.390
[  487.1472] PTHREAD_MUTEX_ERRORCHECK (W9x,WNT)                         38           0.380
[  487.2336] PTHREAD_MUTEX_RECURSIVE (W9x,WNT)                          88           0.880
[  487.2338] =============================================================================
[  487.2338] Benchmark test #4
[  487.2339] =============================================================================
[  487.2340] Trylock plus unlock on an unlocked mutex.
[  487.2340] 100000 iterations.
[  487.2341] Test                                              Total(msec)   average(usec)
[  487.2989] PTHREAD_MUTEX_DEFAULT                                      61           0.610
[  487.3649] PTHREAD_MUTEX_NORMAL                                       61           0.610
[  487.5154] PTHREAD_MUTEX_ERRORCHECK                                  153           1.530
[  487.6671] PTHREAD_MUTEX_RECURSIVE                                   154           1.540
[  487.6673] =============================================================================
[  487.6673] Stress test #1
[  498.4633] Tests complete!
```