### PR TITLE
[tools] only run CI if PR changed tools dir

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -6,6 +6,9 @@ on:
       - 'tools/**'
       - '.github/workflows/tools.yml'
   pull_request:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/tools.yml'
   repository_dispatch:
     types: [run_build]
   workflow_dispatch: {}


### PR DESCRIPTION
Finishes my incomplete PR #584

I forgot you guys always add the pull request trigger. Wich causes double execution of CI on pull request when paired with `push`