### PR TITLE
Cleaning up FatFS dependency

### DIFF
--- a/iop/fs/bdmfs_fatfs/Makefile
+++ b/iop/fs/bdmfs_fatfs/Makefile
@@ -9,7 +9,7 @@
 # IOP_CFLAGS += -DDEBUG -DDEBUG_EXTREME
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
-IOP_CFLAGS += -Wno-error -Wno-strict-aliasing
+IOP_CFLAGS += -Wno-strict-aliasing
 
 IOP_OBJS = ff.o ffsystem.o ffunicode.o fs_driver.o diskio.o main.o imports.o
 IOP_LIBS = -static-libgcc -lgcc

--- a/iop/fs/bdmfs_fatfs/src/diskio.c
+++ b/iop/fs/bdmfs_fatfs/src/diskio.c
@@ -10,24 +10,24 @@
 #include <bdm.h>
 #include <cdvdman.h>
 
-#include "ff.h"     /* Obtains integer types */
-#include "diskio.h" /* Declarations of disk functions */
+#include "ff.h"			/* Obtains integer types */
+#include "diskio.h"		/* Declarations of disk functions */
+#include "fs_driver.h"  /* Declarations of fs driver functions */
 
-#include "fs_driver.h"
 
 /*-----------------------------------------------------------------------*/
 /* Get Drive Status                                                      */
 /*-----------------------------------------------------------------------*/
 
-DSTATUS disk_status(
-    BYTE pdrv /* Physical drive number to identify the drive */
+DSTATUS disk_status (
+	BYTE pdrv		/* Physical drive nmuber to identify the drive */
 )
 {
-    int result;
+	int result;
 
-    result = (fatfs_fs_driver_get_mounted_bd_from_index(pdrv) == NULL) ? (STA_NOINIT | STA_NODISK) : 0;
+	result = (fatfs_fs_driver_get_mounted_bd_from_index(pdrv) == NULL) ? (STA_NOINIT | STA_NODISK) : 0;
 
-    return result;
+	return result;
 }
 
 
@@ -36,15 +36,15 @@ DSTATUS disk_status(
 /* Inidialize a Drive                                                    */
 /*-----------------------------------------------------------------------*/
 
-DSTATUS disk_initialize(
-    BYTE pdrv /* Physical drive nmuber to identify the drive */
+DSTATUS disk_initialize (
+	BYTE pdrv				/* Physical drive nmuber to identify the drive */
 )
 {
-    int result;
+	int result;
 
-    result = (fatfs_fs_driver_get_mounted_bd_from_index(pdrv) == NULL) ? (STA_NOINIT | STA_NODISK) : 0;
+	result = (fatfs_fs_driver_get_mounted_bd_from_index(pdrv) == NULL) ? (STA_NOINIT | STA_NODISK) : 0;
 
-    return result;
+	return result;
 }
 
 
@@ -53,25 +53,25 @@ DSTATUS disk_initialize(
 /* Read Sector(s)                                                        */
 /*-----------------------------------------------------------------------*/
 
-DRESULT disk_read(
-    BYTE pdrv,    /* Physical drive nmuber to identify the drive */
-    BYTE *buff,   /* Data buffer to store read data */
-    LBA_t sector, /* Start sector in LBA */
-    UINT count    /* Number of sectors to read */
+DRESULT disk_read (
+	BYTE pdrv,		/* Physical drive nmuber to identify the drive */
+	BYTE *buff,		/* Data buffer to store read data */
+	LBA_t sector,	/* Start sector in LBA */
+	UINT count		/* Number of sectors to read */
 )
 {
-    DRESULT res;
-    struct block_device *mounted_bd;
+	DRESULT res;
+	struct block_device *mounted_bd;
 
-    mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
+	mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
 
-    if (mounted_bd == NULL) {
-        return RES_NOTRDY;
-    }
+	if (mounted_bd == NULL) {
+		return RES_NOTRDY;
+	}
 
-    res = mounted_bd->read(mounted_bd, sector, buff, count);
+	res = mounted_bd->read(mounted_bd, sector, buff, count);
 
-    return (res == count) ? RES_OK : RES_ERROR;
+	return (res == count) ? RES_OK : RES_ERROR;
 }
 
 
@@ -82,25 +82,25 @@ DRESULT disk_read(
 
 #if FF_FS_READONLY == 0
 
-DRESULT disk_write(
-    BYTE pdrv,        /* Physical drive nmuber to identify the drive */
-    const BYTE *buff, /* Data to be written */
-    LBA_t sector,     /* Start sector in LBA */
-    UINT count        /* Number of sectors to write */
+DRESULT disk_write (
+	BYTE pdrv,			/* Physical drive nmuber to identify the drive */
+	const BYTE *buff,	/* Data to be written */
+	LBA_t sector,		/* Start sector in LBA */
+	UINT count			/* Number of sectors to write */
 )
 {
-    DRESULT res;
-    struct block_device *mounted_bd;
+	DRESULT res;
+	struct block_device *mounted_bd;
 
-    mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
+	mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
 
-    if (mounted_bd == NULL) {
-        return RES_NOTRDY;
-    }
+	if (mounted_bd == NULL) {
+		return RES_NOTRDY;
+	}
 
-    res = mounted_bd->write(mounted_bd, sector, buff, count);
+	res = mounted_bd->write(mounted_bd, sector, buff, count);
 
-    return (res == count) ? RES_OK : RES_ERROR;
+	return (res == count) ? RES_OK : RES_ERROR;
 }
 
 #endif
@@ -110,60 +110,62 @@ DRESULT disk_write(
 /* Miscellaneous Functions                                               */
 /*-----------------------------------------------------------------------*/
 
-DRESULT disk_ioctl(
-    BYTE pdrv, /* Physical drive nmuber (0..) */
-    BYTE cmd,  /* Control code */
-    void *buff /* Buffer to send/receive control data */
+DRESULT disk_ioctl (
+	BYTE pdrv,		/* Physical drive nmuber (0..) */
+	BYTE cmd,		/* Control code */
+	void *buff		/* Buffer to send/receive control data */
 )
 {
-    struct block_device *mounted_bd;
+	struct block_device *mounted_bd;
 
-    mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
+	mounted_bd = fatfs_fs_driver_get_mounted_bd_from_index(pdrv);
 
-    if (mounted_bd == NULL) {
-        return RES_NOTRDY;
-    }
+	if (mounted_bd == NULL) {
+		return RES_NOTRDY;
+	}
 
-    switch (cmd) {
-        case CTRL_SYNC:
-            mounted_bd->flush(mounted_bd);
-            break;
-        case GET_SECTOR_COUNT:
-            *(unsigned int *)buff = mounted_bd->sectorCount;
-            break;
-        case GET_SECTOR_SIZE:
-            *(unsigned int *)buff = mounted_bd->sectorSize;
-            break;
-        case GET_BLOCK_SIZE:
-            *(unsigned int *)buff = 0;
-            break;
-    }
+	switch (cmd) {
+		case CTRL_SYNC:
+			mounted_bd->flush(mounted_bd);
+			break;
+		case GET_SECTOR_COUNT:
+			*(unsigned int *)buff = mounted_bd->sectorCount;
+			break;
+		case GET_SECTOR_SIZE:
+			*(unsigned int *)buff = mounted_bd->sectorSize;
+			break;
+		case GET_BLOCK_SIZE:
+			*(unsigned int *)buff = 0;
+			break;
+		default:
+			return RES_PARERR;
+	}
 
-    return RES_OK;
+	return RES_OK;
 }
 
 DWORD get_fattime(void)
 {
-    // ps2 specific routine to get time and date
-    int year, month, day, hour, minute, sec;
-    sceCdCLOCK cdtime;
+	// ps2 specific routine to get time and date
+	int year, month, day, hour, minute, sec;
+	sceCdCLOCK cdtime;
 
-    if (sceCdReadClock(&cdtime) != 0 && cdtime.stat == 0) {
-        sec = btoi(cdtime.second);
-        minute = btoi(cdtime.minute);
-        hour = btoi(cdtime.hour);
-        day = btoi(cdtime.day);
-        month = btoi(cdtime.month & 0x7F); // Ignore century bit (when an old CDVDMAN is used).
-        year = btoi(cdtime.year) + 2000;
-    } else {
-        year = 2005;
-        month = 1;
-        day = 6;
-        hour = 14;
-        minute = 12;
-        sec = 10;
-    }
+	if (sceCdReadClock(&cdtime) != 0 && cdtime.stat == 0) {
+		sec = btoi(cdtime.second);
+		minute = btoi(cdtime.minute);
+		hour = btoi(cdtime.hour);
+		day = btoi(cdtime.day);
+		month = btoi(cdtime.month & 0x7F); // Ignore century bit (when an old CDVDMAN is used).
+		year = btoi(cdtime.year) + 2000;
+	} else {
+		year = 2005;
+		month = 1;
+		day = 6;
+		hour = 14;
+		minute = 12;
+		sec = 10;
+	}
 
-    /* Pack date and time into a DWORD variable */
-    return ((DWORD)(year - 1980) << 25) | ((DWORD)month << 21) | ((DWORD)day << 16) | ((DWORD)hour << 11) | ((DWORD)minute << 5) | ((DWORD)sec >> 1);
+	/* Pack date and time into a DWORD variable */
+	return ((DWORD)(year - 1980) << 25) | ((DWORD)month << 21) | ((DWORD)day << 16) | ((DWORD)hour << 11) | ((DWORD)minute << 5) | ((DWORD)sec >> 1);
 }

--- a/iop/fs/bdmfs_fatfs/src/ff.c
+++ b/iop/fs/bdmfs_fatfs/src/ff.c
@@ -3289,6 +3289,9 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 
 
 	fmt = check_fs(fs, 0);				/* Load sector 0 and check if it is an FAT VBR as SFD format */
+#if !FF_FS_MBR
+	return fmt;	/* No MBR available to check the partitioning */
+#endif
 	if (fmt != 2 && (fmt >= 3 || part == 0)) return fmt;	/* Returns if it is an FAT VBR as auto scan, not a BS or disk error */
 
 	/* Sector 0 is not an FAT VBR or forced partition number wants a partition */
@@ -3325,6 +3328,8 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 	} while (part == 0 && fmt >= 2 && ++i < 4);
 	return fmt;
 }
+
+
 
 
 /*-----------------------------------------------------------------------*/
@@ -3387,8 +3392,8 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 	if (SS(fs) > FF_MAX_SS || SS(fs) < FF_MIN_SS || (SS(fs) & (SS(fs) - 1))) return FR_DISK_ERR;
 #endif
 
-	/* Check for a valid file system on the device. */
-	fmt = check_fs(fs, 0);
+	/* Find an FAT volume on the drive */
+	fmt = find_volume(fs, LD2PT(vol));
 	M_DEBUG("check_fs returned %d at LBA 0x%08x%08x\n", fmt, U64_2XU32(&fs->winsect));
 	if (fmt == 4) return FR_DISK_ERR;		/* An error occured in the disk I/O layer */
 	if (fmt >= 2) return FR_NO_FILESYSTEM;	/* No FAT volume is found */

--- a/iop/fs/bdmfs_fatfs/src/ffsystem.c
+++ b/iop/fs/bdmfs_fatfs/src/ffsystem.c
@@ -55,29 +55,6 @@ int ff_cre_syncobj (	/* 1:Function succeeded, 0:Could not create the sync object
 	FF_SYNC_t* sobj		/* Pointer to return the created sync object */
 )
 {
-#if 0
-	/* Win32 */
-	*sobj = CreateMutex(NULL, FALSE, NULL);
-	return (int)(*sobj != INVALID_HANDLE_VALUE);
-
-	/* uITRON */
-//	T_CSEM csem = {TA_TPRI,1,1};
-//	*sobj = acre_sem(&csem);
-//	return (int)(*sobj > 0);
-
-	/* uC/OS-II */
-//	OS_ERR err;
-//	*sobj = OSMutexCreate(0, &err);
-//	return (int)(err == OS_NO_ERR);
-
-	/* FreeRTOS */
-//	*sobj = xSemaphoreCreateMutex();
-//	return (int)(*sobj != NULL);
-
-	/* CMSIS-RTOS */
-//	*sobj = osMutexCreate(&Mutex[vol]);
-//	return (int)(*sobj != NULL);
-#endif
 	/* IOP kernel */
     iop_sema_t sp;
 
@@ -105,28 +82,8 @@ int ff_del_syncobj (	/* 1:Function succeeded, 0:Could not delete due to an error
 	FF_SYNC_t sobj		/* Sync object tied to the logical drive to be deleted */
 )
 {
-#if 0
-	/* Win32 */
-	return (int)CloseHandle(sobj);
-
-	/* uITRON */
-//	return (int)(del_sem(sobj) == E_OK);
-
-	/* uC/OS-II */
-//	OS_ERR err;
-//	OSMutexDel(sobj, OS_DEL_ALWAYS, &err);
-//	return (int)(err == OS_NO_ERR);
-
-	/* FreeRTOS */
-//  vSemaphoreDelete(sobj);
-//	return 1;
-
-	/* CMSIS-RTOS */
-//	return (int)(osMutexDelete(sobj) == osOK);
-#endif
 	/* IOP kernel */
-    if (sobj >= 0) {
-        DeleteSema(sobj);
+    if (DeleteSema(sobj) == 0) {
         return 1;
     }
     return 0;
@@ -144,26 +101,12 @@ int ff_req_grant (	/* 1:Got a grant to access the volume, 0:Could not get a gran
 	FF_SYNC_t sobj	/* Sync object to wait */
 )
 {
-#if 0
-	/* Win32 */
-	return (int)(WaitForSingleObject(sobj, FF_FS_TIMEOUT) == WAIT_OBJECT_0);
-
-	/* uITRON */
-//	return (int)(wai_sem(sobj) == E_OK);
-
-	/* uC/OS-II */
-//	OS_ERR err;
-//	OSMutexPend(sobj, FF_FS_TIMEOUT, &err));
-//	return (int)(err == OS_NO_ERR);
-
-	/* FreeRTOS */
-//	return (int)(xSemaphoreTake(sobj, FF_FS_TIMEOUT) == pdTRUE);
-
-	/* CMSIS-RTOS */
-//	return (int)(osMutexWait(sobj, FF_FS_TIMEOUT) == osOK);
-#endif
-	WaitSema(sobj);
-	return 1;
+	/* IOP kernel */
+	/* TODO: Use the timeout value from the configuration file */
+	if (WaitSema(sobj) == 0) {
+		return 1;
+	}
+	return 0;
 }
 
 
@@ -177,22 +120,7 @@ void ff_rel_grant (
 	FF_SYNC_t sobj	/* Sync object to be signaled */
 )
 {
-#if 0
-	/* Win32 */
-	ReleaseMutex(sobj);
-
-	/* uITRON */
-//	sig_sem(sobj);
-
-	/* uC/OS-II */
-//	OSMutexPost(sobj);
-
-	/* FreeRTOS */
-//	xSemaphoreGive(sobj);
-
-	/* CMSIS-RTOS */
-//	osMutexRelease(sobj);
-#endif
+	/* IOP kernel */
 	SignalSema(sobj);
 }
 

--- a/iop/fs/bdmfs_fatfs/src/include/ff.h
+++ b/iop/fs/bdmfs_fatfs/src/include/ff.h
@@ -345,6 +345,8 @@ TCHAR* f_gets (TCHAR* buff, int len, FIL* fp);						/* Get a string from the fil
 #define f_rmdir(path) f_unlink(path)
 #define f_unmount(path) f_mount(0, path, 0)
 
+
+
 LBA_t clst2sect (	/* !=0:Sector number, 0:Failed (invalid cluster#) */
 	FATFS* fs,		/* Filesystem object */
 	DWORD clst		/* Cluster# to be converted */
@@ -354,7 +356,6 @@ DWORD get_fat (		/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFFF:Clust
 	FFOBJID* obj,	/* Corresponding object */
 	DWORD clst		/* Cluster number to get the value */
 );
-
 
 /*--------------------------------------------------------------*/
 /* Additional user defined functions                            */

--- a/iop/fs/bdmfs_fatfs/src/include/ffconf.h
+++ b/iop/fs/bdmfs_fatfs/src/include/ffconf.h
@@ -278,9 +278,6 @@
 /* #include <somertos.h>	// O/S definitions */
 #define FF_FS_REENTRANT	1
 #define FF_FS_TIMEOUT	1000
-#if 0
-#define FF_SYNC_t		HANDLE
-#endif
 #define FF_SYNC_t		int
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
@@ -300,5 +297,7 @@
 /  included somewhere in the scope of ff.h. */
 
 
+#define FF_FS_MBR 0
+/* This option switches support for MBR partition table. (0:Disable or 1:Enable) */
 
 /*--- End of configuration options ---*/


### PR DESCRIPTION
## Description
The main scope of this PR is to have better control over the changes we are doing over the FatFS dependency.
I have created this [FatFS repo](https://github.com/fjtrujy/FatFs) which basically contains one commit per release of FatFs done.
Additionally, I have created a separate branch, [`iop-r0.14b`](https://github.com/fjtrujy/FatFs/tree/iop-r0.14b) where I have applied current `ps2sdk` changes there to visually see better what are custom changes done by our needs in one single [commit](https://github.com/fjtrujy/FatFs/commit/7b11bf0552be728a809614f861773a9a294ef30f).

The majority of the changes that this PR has are related to code style (to match the original code), additionally some other tiny improvements have been done:
- All warnings have been solved and module `bdmfs_fatfs` now compiles wit `-Werror`
- Created `FF_FS_MBR` flag to disable `MBR` on the `find_volume` function (more info [here](https://discord.com/channels/@me/701786950440452236/1230621623342600222)) in this way we keep current logic in a cleaner way
- Remove examples about how to implement semaphores in other systems.
- Improve return errors in `ffsystem.c` for semaphores
- Add TODO message to use a timeout for `WaitSema`
- Minor clean-ups

I plan to do more PRs about FatFS in the incoming days, to upgrade to the latest version and maybe other improvements.

Cheers