### PR TITLE
Remove extra unaligned buffer as it solved using `sceSifGetOtherData`

### DIFF
--- a/common/include/fileXio.h
+++ b/common/include/fileXio.h
@@ -195,8 +195,6 @@ struct fxio_write_packet
     int fd;
     const void *buffer;
     int size;
-    unsigned int unalignedDataLen;
-    unsigned char unalignedData[64];
 };
 
 struct fxio_lseek_packet

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -615,7 +615,6 @@ int fileXioRead(int fd, void *buf, int size)
 #ifdef F_fileXioWrite
 int fileXioWrite(int fd, const void *buf, int size)
 {
-	unsigned int miss;
 	int rv;
 	struct fxio_write_packet *packet=(struct fxio_write_packet*)__sbuff;
 
@@ -625,20 +624,9 @@ int fileXioWrite(int fd, const void *buf, int size)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	if((unsigned int)buf & 0x3F)
-	{
-		miss = 64 - ((unsigned int)buf & 0x3F);
-		if(miss > (unsigned int)size) miss = size;
-	} else {
-		miss = 0;
-	}
-
 	packet->fd = fd;
 	packet->buffer = buf;
 	packet->size = size;
-	packet->unalignedDataLen = miss;
-
-	memcpy(packet->unalignedData, buf, miss);
 
 	if(!IS_UNCACHED_SEG(buf))
 		SifWriteBackDCache((void*)buf, size);

--- a/iop/fs/filexio/src/fileXio_iop.c
+++ b/iop/fs/filexio/src/fileXio_iop.c
@@ -64,7 +64,7 @@ static rests_pkt rests;
 static int fileXio_GetDeviceList_RPC(struct fileXioDevice* ee_devices, int eecount);
 static int fileXio_CopyFile_RPC(const char *src, const char *dest, int mode);
 static int fileXio_Read_RPC(int infd, char *read_buf, int read_size, void *intr_data);
-static int fileXio_Write_RPC(int outfd, const char *write_buf, int write_size, int mis,u8 *misbuf);
+static int fileXio_Write_RPC(int outfd, const char *write_buf, int write_size);
 static int fileXio_GetDir_RPC(const char* pathname, struct fileXioDirEntry dirEntry[], unsigned int req_entries);
 static int fileXio_Mount_RPC(const char* mountstring, const char* mountpoint, int flag);
 static int fileXio_chstat_RPC(char *filename, void* eeptr, int mask);
@@ -302,7 +302,7 @@ EXIT:
 	return (total);
 }
 
-static int fileXio_Write_RPC(int outfd, const char *write_buf, int write_size, int mis,u8 *misbuf)
+static int fileXio_Write_RPC(int outfd, const char *write_buf, int write_size)
 {
      SifRpcReceiveData_t rdata;
      int left;
@@ -312,20 +312,8 @@ static int fileXio_Write_RPC(int outfd, const char *write_buf, int write_size, i
 
 	left  = write_size;
 	total = 0;
-	if (mis > 0)
-      {
-		wlen=iomanX_write(outfd, misbuf, mis);
-		if (wlen != mis)
-            {
-			if (wlen > 0)
-				total += wlen;
-			return (total);
-		}
-		total += wlen;
-	}
 
-	left-=mis;
-	pos=(int)write_buf+mis;
+	pos=(int)write_buf;
 	while(left){
 		int writelen;
 		writelen = MIN(RWBufferSize, (unsigned int)left);
@@ -720,8 +708,7 @@ static void* fileXioRpc_Write(unsigned int* sbuff)
 	struct fxio_write_packet *packet=(struct fxio_write_packet*)sbuff;
 
 	M_DEBUG("Write Request fd:%d, size:%d\n", packet->fd, packet->size);
-	ret=fileXio_Write_RPC(packet->fd, packet->buffer, packet->size,
-                            packet->unalignedDataLen, packet->unalignedData);
+	ret=fileXio_Write_RPC(packet->fd, packet->buffer, packet->size);
 	sbuff[0] = ret;
 	return sbuff;
 }


### PR DESCRIPTION
When executing `fileXioWrite` we were using an extra buffer of 64 bytes for trying to solve 64 bytes alignment:
```
unsigned int unalignedDataLen;
unsigned char unalignedData[64];
```
Producing then 2 separate write calls, firstly for writing the `unalignedData` with `unalignedDataLen` and secondly for the remaining things.
This extra work is not needed at all as the un-alignement is going to be solved by the `SifRpcGetOtherData` call.

This PR is not fixing all the possible scenarios we can face with #594 , however it helps to mitigate the issue.

Cheers
