### PR TITLE
Improve macro `U64_2XU32`

### DIFF
--- a/iop/dev9/atad/Makefile
+++ b/iop/dev9/atad/Makefile
@@ -46,7 +46,7 @@ IOP_CFLAGS += -DATA_GAMESTAR_WORKAROUND=1
 endif
 
 ifeq ($(ATA_ENABLE_BDM),1)
-IOP_CFLAGS += -DATA_ENABLE_BDM=1 -Wno-strict-aliasing
+IOP_CFLAGS += -DATA_ENABLE_BDM=1
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
 endif
 

--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -46,8 +46,6 @@ IRX_ID(MODNAME, 2, 7);
 #define M_PRINTF(format, args...) \
     printf(MODNAME ": " format, ##args)
 
-#define U64_2XU32(val) ((u32 *)val)[1], ((u32 *)val)[0]
-
 #define BANNER  "ATA device driver %s - Copyright (c) 2003 Marcus R. Brown\n"
 #define VERSION "v1.2"
 

--- a/iop/fs/bdm/Makefile
+++ b/iop/fs/bdm/Makefile
@@ -10,7 +10,7 @@
 
 IOP_OBJS = main.o bdm.o part_driver.o part_driver_mbr.o part_driver_gpt.o imports.o exports.o
 IOP_LIB_ARCHIVES = $(PS2SDKSRC)/iop/fs/libbdm/lib/libbdm.a
-IOP_CFLAGS += -I$(PS2SDKSRC)/iop/fs/libbdm/include/ -Wno-strict-aliasing
+IOP_CFLAGS += -I$(PS2SDKSRC)/iop/fs/libbdm/include/
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make

--- a/iop/fs/bdm/src/include/module_debug.h
+++ b/iop/fs/bdm/src/include/module_debug.h
@@ -19,4 +19,15 @@
     } while (0)
 #endif
 
+// u64 when being used in a printf statement is split into two u32 values
+#define U64_2XU32(val) \
+    u32 val##_u32[2]; \
+    memcpy(val##_u32, &val, sizeof(val##_u32))
+
+#ifdef DEBUG
+#define DEBUG_U64_2XU32(val) U64_2XU32(val)
+#else
+#define DEBUG_U64_2XU32(val) do { } while (0)
+#endif
+
 #endif

--- a/iop/fs/bdm/src/part_driver.c
+++ b/iop/fs/bdm/src/part_driver.c
@@ -10,8 +10,6 @@
 
 #include "module_debug.h"
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
-
 struct partition g_part[MAX_PARTITIONS];
 struct block_device g_part_bd[MAX_PARTITIONS];
 
@@ -58,7 +56,8 @@ static int part_read(struct block_device *bd, u64 sector, void *buffer, u16 coun
 
 #ifdef DEBUG
     u64 finalSector = sector + bd->sectorOffset;
-    M_DEBUG("%s (%s %d %d) 0x%08x%08x %d\n", __func__, bd->name, bd->devNr, bd->parNr, U64_2XU32(&finalSector), count);
+    DEBUG_U64_2XU32(finalSector);
+    M_DEBUG("%s (%s %d %d) 0x%08x%08x %d\n", __func__, bd->name, bd->devNr, bd->parNr, finalSector_u32[1], finalSector_u32[0], count);
 #endif
 
     return part->bd->read(part->bd, sector + bd->sectorOffset, buffer, count);
@@ -73,7 +72,8 @@ static int part_write(struct block_device *bd, u64 sector, const void *buffer, u
 
 #ifdef DEBUG
     u64 finalSector = sector + bd->sectorOffset;
-    M_DEBUG("%s (%s %d %d) 0x%08x%08x %d\n", __func__, bd->name, bd->devNr, bd->parNr, U64_2XU32(&finalSector), count);
+    DEBUG_U64_2XU32(finalSector);
+    M_DEBUG("%s (%s %d %d) 0x%08x%08x %d\n", __func__, bd->name, bd->devNr, bd->parNr, finalSector_u32[1], finalSector_u32[0], count);
 #endif
 
     return part->bd->write(part->bd, sector + bd->sectorOffset, buffer, count);

--- a/iop/fs/bdmfs_fatfs/Makefile
+++ b/iop/fs/bdmfs_fatfs/Makefile
@@ -9,7 +9,6 @@
 # IOP_CFLAGS += -DDEBUG -DDEBUG_EXTREME
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
-IOP_CFLAGS += -Wno-strict-aliasing
 
 IOP_OBJS = ff.o ffsystem.o ffunicode.o fs_driver.o diskio.o main.o imports.o
 IOP_LIBS = -static-libgcc -lgcc

--- a/iop/fs/bdmfs_fatfs/src/ff.c
+++ b/iop/fs/bdmfs_fatfs/src/ff.c
@@ -25,8 +25,6 @@
 #include "diskio.h"		/* Declarations of device I/O functions */
 #include "module_debug.h"
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
-
 
 /*--------------------------------------------------------------------------
 
@@ -3446,10 +3444,12 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 
 	/* Find an FAT volume on the hosting drive */
 	fmt = find_volume(fs, LD2PT(vol));
-	M_DEBUG("check_fs returned %d at LBA 0x%08x%08x\n", fmt, U64_2XU32(&fs->winsect));
+	u64 winsect = fs->winsect;
+	DEBUG_U64_2XU32(winsect);
+	M_DEBUG("check_fs returned %d at LBA 0x%08x%08x\n", fmt, winsect_u32[1], winsect_u32[0]);
 	if (fmt == 4) return FR_DISK_ERR;		/* An error occurred in the disk I/O layer */
 	if (fmt >= 2) return FR_NO_FILESYSTEM;	/* No FAT volume is found */
-	bsect = fs->winsect;					/* Volume offset in the hosting physical drive */
+	bsect = winsect;					/* Volume offset in the hosting physical drive */
 
 	/* An FAT volume is found (bsect). Following code initializes the filesystem object */
 

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -28,8 +28,6 @@
 //#define DEBUG  //comment out this line when not debugging
 #include "module_debug.h"
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
-
 fatfs_fs_driver_mount_info fs_driver_mount_info[FF_VOLUMES];
 
 #define FATFS_FS_DRIVER_MOUNT_INFO_MAX ((int)(sizeof(fs_driver_mount_info) / sizeof(fs_driver_mount_info[0])))
@@ -639,9 +637,11 @@ static int get_frag_list(FIL *file, void *rdata, unsigned int rdatalen)
             // Fragment or file end
             M_DEBUG("fragment: %uc - %uc + 1\n", iClusterStart, iClusterCurrent + 1);
             if (iFragCount < iMaxFragments) {
-                f[iFragCount].sector = clst2sect(file->obj.fs, iClusterStart) + bd->sectorOffset;
+                u64 sector = clst2sect(file->obj.fs, iClusterStart) + bd->sectorOffset;
+                f[iFragCount].sector = sector;
                 f[iFragCount].count  = clst2sect(file->obj.fs, iClusterCurrent) - clst2sect(file->obj.fs, iClusterStart) + file->obj.fs->csize;
-                M_DEBUG(" - sectors: 0x%08x%08x count %u\n", U64_2XU32(&f[iFragCount].sector), f[iFragCount].count);
+                DEBUG_U64_2XU32(sector);
+                M_DEBUG(" - sectors: 0x%08x%08x count %u\n", sector_u32[1], sector_u32[0], f[iFragCount].count);
             }
             iFragCount++;
             iClusterStart = iClusterNext;

--- a/iop/fs/bdmfs_fatfs/src/include/module_debug.h
+++ b/iop/fs/bdmfs_fatfs/src/include/module_debug.h
@@ -10,4 +10,15 @@
 #define M_DEBUG(format, args...)
 #endif
 
+// u64 when being used in a printf statement is split into two u32 values
+#define U64_2XU32(val) \
+    u32 val##_u32[2]; \
+    memcpy(val##_u32, &val, sizeof(val##_u32))
+
+#ifdef DEBUG
+#define DEBUG_U64_2XU32(val) U64_2XU32(val)
+#else
+#define DEBUG_U64_2XU32(val) do { } while (0)
+#endif
+
 #endif

--- a/iop/fs/libbdm/Makefile
+++ b/iop/fs/libbdm/Makefile
@@ -6,8 +6,6 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-# IOP_CFLAGS += -DDEBUG -Wno-strict-aliasing
-
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
 
 IOP_OBJS = bd_defrag.o bd_cache.o

--- a/iop/fs/libbdm/src/bd_cache.c
+++ b/iop/fs/libbdm/src/bd_cache.c
@@ -56,7 +56,8 @@ static int _read(struct block_device *bd, u64 sector, void *buffer, u16 count)
 {
     struct bd_cache *c = bd->priv;
 
-    //M_DEBUG("%s(%d, %d)\n", __FUNCTION__, sector, count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s(0x%08x%08x, %d)\n", __FUNCTION__, sector_u32[1], sector_u32[0], count);
 
     if (count >= SECTORS_PER_BLOCK) {
         // Do a direct read
@@ -127,7 +128,8 @@ static int _write(struct block_device *bd, u64 sector, const void *buffer, u16 c
 {
     struct bd_cache *c = bd->priv;
 
-    M_DEBUG("%s(%d, %d)\n", __FUNCTION__, sector, count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s(0x%08x%08x, %d)\n", __FUNCTION__, sector_u32[1], sector_u32[0], count);
 
     _invalidate(c, sector, count);
 

--- a/iop/fs/libbdm/src/include/module_debug.h
+++ b/iop/fs/libbdm/src/include/module_debug.h
@@ -16,6 +16,15 @@
 #define M_DEBUG(format, args...) do { } while(0)
 #endif
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
+// u64 when being used in a printf statement is split into two u32 values
+#define U64_2XU32(val) \
+    u32 val##_u32[2]; \
+    memcpy(val##_u32, &val, sizeof(val##_u32))
+
+#ifdef DEBUG
+#define DEBUG_U64_2XU32(val) U64_2XU32(val)
+#else
+#define DEBUG_U64_2XU32(val) do { } while (0)
+#endif
 
 #endif

--- a/iop/iLink/IEEE1394_bd/Makefile
+++ b/iop/iLink/IEEE1394_bd/Makefile
@@ -8,7 +8,7 @@
 
 # IOP_CFLAGS += -DDEBUG
 
-IOP_CFLAGS += -mno-check-zero-division -Wno-strict-aliasing # -DSIF_CALLBACKS_12_13
+IOP_CFLAGS += -mno-check-zero-division # -DSIF_CALLBACKS_12_13
 
 IOP_INCS += -I$(PS2SDKSRC)/iop/iLink/iLinkman/include
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include

--- a/iop/iLink/IEEE1394_bd/src/imports.lst
+++ b/iop/iLink/IEEE1394_bd/src/imports.lst
@@ -34,6 +34,7 @@ stdio_IMPORTS_end
 #endif
 
 sysclib_IMPORTS_start
+I_memcpy
 I_memset
 sysclib_IMPORTS_end
 

--- a/iop/iLink/IEEE1394_bd/src/include/module_debug.h
+++ b/iop/iLink/IEEE1394_bd/src/include/module_debug.h
@@ -17,6 +17,15 @@
     } while (0)
 #endif
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
+// u64 when being used in a printf statement is split into two u32 values
+#define U64_2XU32(val) \
+    u32 val##_u32[2]; \
+    memcpy(val##_u32, &val, sizeof(val##_u32))
+
+#ifdef DEBUG
+#define DEBUG_U64_2XU32(val) U64_2XU32(val)
+#else
+#define DEBUG_U64_2XU32(val) do { } while (0)
+#endif
 
 #endif

--- a/iop/iLink/IEEE1394_bd/src/scsi.c
+++ b/iop/iLink/IEEE1394_bd/src/scsi.c
@@ -103,7 +103,8 @@ static int scsi_cmd_rw_sector(struct block_device *bd, u64 lba, const void *buff
     unsigned char comData[12]   = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
 
-    M_DEBUG("scsi_cmd_rw_sector - 0x%08x%08x %p 0x%04x\n", U64_2XU32(&lba), buffer, sectorCount);
+    DEBUG_U64_2XU32(lba);
+    M_DEBUG("scsi_cmd_rw_sector - 0x%08x%08x %p 0x%04x\n", lba_u32[1], lba_u32[0], buffer, sectorCount);
 
     // Note: LBA from bdm is 64bit but SCSI commands being used are 32bit. These need to be updated to 64bit LBA SCSI
     // commands to work with large capacity drives. For now the 32bit LBA will only support up to 2TB drives.
@@ -187,7 +188,8 @@ static int scsi_read(struct block_device *bd, u64 sector, void *buffer, u16 coun
     u16 sc_remaining            = count;
     int retries;
 
-    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, U64_2XU32(&sector), count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, sector_u32[1], sector_u32[0], count);
 
     while (sc_remaining > 0) {
         u16 sc = sc_remaining > scsi->max_sectors ? scsi->max_sectors : sc_remaining;
@@ -214,7 +216,8 @@ static int scsi_write(struct block_device *bd, u64 sector, const void *buffer, u
     u16 sc_remaining            = count;
     int retries;
 
-    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, U64_2XU32(&sector), count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, sector_u32[1], sector_u32[0], count);
 
     while (sc_remaining > 0) {
         u16 sc = sc_remaining > scsi->max_sectors ? scsi->max_sectors : sc_remaining;

--- a/iop/sio/mx4sio_bd/Makefile
+++ b/iop/sio/mx4sio_bd/Makefile
@@ -10,8 +10,6 @@ IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include -I$(PS2SDKSRC)/iop/system/sio2man/
 
 IOP_OBJS += spi_sdcard_crc7.o spi_sdcard_driver.o crc16.o ioplib.o sio2man_hook.o mx4sio.o imports.o
 
-IOP_CFLAGS += -Wno-strict-aliasing
-
 IOP_LDFLAGS = -lgcc
 
 include $(PS2SDKSRC)/Defs.make

--- a/iop/sio/mx4sio_bd/src/module_debug.h
+++ b/iop/sio/mx4sio_bd/src/module_debug.h
@@ -21,6 +21,4 @@
     } while (0)
 #endif
 
-#define U64_2XU32(val) ((u32 *)val)[1], ((u32 *)val)[0]
-
 #endif

--- a/iop/usb/usbmass_bd/Makefile
+++ b/iop/usb/usbmass_bd/Makefile
@@ -11,8 +11,6 @@
 IOP_INCS += -I$(PS2SDKSRC)/iop/usb/usbd/include
 IOP_INCS += -I$(PS2SDKSRC)/iop/fs/bdm/include
 
-IOP_CFLAGS += -Wno-strict-aliasing
-
 IOP_LDFLAGS = -lgcc
 
 IOP_OBJS = main.o usb_mass.o scsi.o imports.o

--- a/iop/usb/usbmass_bd/src/include/module_debug.h
+++ b/iop/usb/usbmass_bd/src/include/module_debug.h
@@ -18,6 +18,15 @@
     } while (0)
 #endif
 
-#define U64_2XU32(val)  ((u32*)val)[1], ((u32*)val)[0]
+// u64 when being used in a printf statement is split into two u32 values
+#define U64_2XU32(val) \
+    u32 val##_u32[2]; \
+    memcpy(val##_u32, &val, sizeof(val##_u32))
+
+#ifdef DEBUG
+#define DEBUG_U64_2XU32(val) U64_2XU32(val)
+#else
+#define DEBUG_U64_2XU32(val) do { } while (0)
+#endif
 
 #endif

--- a/iop/usb/usbmass_bd/src/scsi.c
+++ b/iop/usb/usbmass_bd/src/scsi.c
@@ -103,7 +103,8 @@ static int scsi_cmd_rw_sector(struct block_device *bd, u64 lba, const void *buff
     unsigned char comData[12]   = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
 
-    M_DEBUG("scsi_cmd_rw_sector - 0x%08x%08x %p 0x%04x\n", U64_2XU32(&lba), buffer, sectorCount);
+    DEBUG_U64_2XU32(lba);
+    M_DEBUG("scsi_cmd_rw_sector - 0x%08x%08x %p 0x%04x\n", lba_u32[1], lba_u32[0], buffer, sectorCount);
 
     // Note: LBA from bdm is 64bit but SCSI commands being used are 32bit. These need to be updated to 64bit LBA SCSI
     // commands to work with large capacity drives. For now the 32bit LBA will only support up to 2TB drives.
@@ -187,7 +188,8 @@ static int scsi_read(struct block_device *bd, u64 sector, void *buffer, u16 coun
     u16 sc_remaining            = count;
     int retries;
 
-    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, U64_2XU32(&sector), count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, sector_u32[1], sector_u32[0], count);
 
     while (sc_remaining > 0) {
         u16 sc = sc_remaining > scsi->max_sectors ? scsi->max_sectors : sc_remaining;
@@ -198,7 +200,8 @@ static int scsi_read(struct block_device *bd, u64 sector, void *buffer, u16 coun
         }
 
         if (retries == 0) {
-            M_PRINTF("ERROR: unable to read sector after %d tries (sector=0x%08x%08x, count=%d)\n", SCSI_MAX_RETRIES, U64_2XU32(&sector), count);
+            U64_2XU32(sector);
+            M_PRINTF("ERROR: unable to read sector after %d tries (sector=0x%08x%08x, count=%d)\n", SCSI_MAX_RETRIES, sector_u32[1], sector_u32[0], count);
             return -EIO;
         }
 
@@ -218,7 +221,8 @@ static int scsi_write(struct block_device *bd, u64 sector, const void *buffer, u
     void *misalign_buffer       = NULL;
     int retries;
 
-    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, U64_2XU32(&sector), count);
+    DEBUG_U64_2XU32(sector);
+    M_DEBUG("%s: sector=0x%08x%08x, count=%d\n", __func__, sector_u32[1], sector_u32[0], count);
 
     if (((uiptr)buffer & 3) != 0) {
         /* Slow misalignment workaround */
@@ -246,7 +250,8 @@ static int scsi_write(struct block_device *bd, u64 sector, const void *buffer, u
         }
 
         if (retries == 0) {
-            M_PRINTF("ERROR: unable to write sector after %d tries (sector=0x%08x%08x, count=%d)\n", SCSI_MAX_RETRIES, U64_2XU32(&sector), count);
+            U64_2XU32(sector);
+            M_PRINTF("ERROR: unable to write sector after %d tries (sector=0x%08x%08x, count=%d)\n", SCSI_MAX_RETRIES, sector_u32[1], sector_u32[0], count);
             return -EIO;
         }
 


### PR DESCRIPTION
This PR is just to change how the macro `U64_2X32` was done. 
We were forced to disable `Wno-strict-aliasing` warning, with this new approach is not needed anymore.

Cheers.