### PR TITLE
input: Fix uninitialized use.

### DIFF
--- a/ee/input/src/input.c
+++ b/ee/input/src/input.c
@@ -25,7 +25,7 @@ pad_t *pad_open(unsigned int port, unsigned int slot, unsigned int mode, unsigne
 	}
 
 #ifdef _XINPUT
-	if (mtapGetConnection(pad->port))
+	if (mtapGetConnection(port))
 	{
 		// there are only four slots
 		if (slot > 3)


### PR DESCRIPTION
Ran into an error for this when building with gcc14. It looks like the right thing to do.