### PR TITLE
Add dummy implementation for some missing net functions

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -169,6 +169,7 @@ SOCKET_OBJS = \
 	listen.o \
 	recv.o \
 	recvfrom.o \
+	recvmsg.o \
 	send.o \
 	sendto.o \
 	sendmsg.o \

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -171,6 +171,7 @@ SOCKET_OBJS = \
 	recvfrom.o \
 	send.o \
 	sendto.o \
+	sendmsg.o \
 	getsockopt.o \
 	setsockopt.o \
 	shutdown.o \

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -152,6 +152,7 @@ LOCK_OBJS = \
 	__locks_deinit.o
 
 NETDB_OBJS = \
+	gethostbyaddr.o \
 	gethostbyname.o \
 	gethostbyname_r.o \
 	freeaddrinfo.o \

--- a/ee/libcglue/include/netdb.h
+++ b/ee/libcglue/include/netdb.h
@@ -15,6 +15,7 @@
 #include <tcpip.h>
 
 __BEGIN_DECLS
+struct hostent *gethostbyaddr(const void *addr, int len, int type);
 struct hostent *gethostbyname(const char *name);
 int gethostbyname_r(const char *name, struct hostent *ret, char *buf, size_t buflen, struct hostent **result, int *h_errnop);
 void freeaddrinfo(struct addrinfo *ai);

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -39,6 +39,7 @@ typedef int (*_libcglue_fdman_connect_cb_t)(void *userdata, const struct sockadd
 typedef int (*_libcglue_fdman_listen_cb_t)(void *userdata, int backlog);
 typedef ssize_t (*_libcglue_fdman_recv_cb_t)(void *userdata, void *buf, size_t len, int flags);
 typedef ssize_t (*_libcglue_fdman_recvfrom_cb_t)(void *userdata, void *buf, size_t len, int flags, struct sockaddr *from, socklen_t *fromlen);
+typedef ssize_t (*_libcglue_fdman_recvmsg_cb_t)(void *userdata, struct msghdr *msg, int flags);
 typedef ssize_t (*_libcglue_fdman_send_cb_t)(void *userdata, const void *buf, size_t len, int flags);
 typedef ssize_t (*_libcglue_fdman_sendto_cb_t)(void *userdata, const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen);
 typedef ssize_t (*_libcglue_fdman_sendmsg_cb_t)(void *userdata, const struct msghdr *msg, int flags);
@@ -67,8 +68,10 @@ typedef struct _libcglue_fdman_fd_ops_
 	_libcglue_fdman_listen_cb_t listen;
 	_libcglue_fdman_recv_cb_t recv;
 	_libcglue_fdman_recvfrom_cb_t recvfrom;
+	_libcglue_fdman_recvmsg_cb_t recvmsg;
 	_libcglue_fdman_send_cb_t send;
 	_libcglue_fdman_sendto_cb_t sendto;
+	_libcglue_fdman_sendmsg_cb_t sendmsg;
 	_libcglue_fdman_getsockopt_cb_t getsockopt;
 	_libcglue_fdman_setsockopt_cb_t setsockopt;
 	_libcglue_fdman_shutdown_cb_t shutdown;

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -110,6 +110,7 @@ typedef void (*_libcglue_fdman_dns_setserver_cb_t)(u8 numdns, const ip_addr_t *d
 typedef const ip_addr_t *(*_libcglue_fdman_dns_getserver_cb_t)(u8 numdns);
 typedef int (*_libcglue_fdman_socket_cb_t)(_libcglue_fdman_fd_info_t *info, int domain, int type, int protocol);
 typedef int (*_libcglue_fdman_select_cb_t)(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+typedef struct hostent *(*_libcglue_fdman_gethostbyaddr_cb_t)(const void *addr, int len, int type);
 typedef struct hostent *(*_libcglue_fdman_gethostbyname_cb_t)(const char *name);
 typedef int (*_libcglue_fdman_gethostbyname_r_cb_t)(const char *name, struct hostent *ret, char *buf, size_t buflen, struct hostent **result, int *h_errnop);
 typedef void (*_libcglue_fdman_freeaddrinfo_cb_t)(struct addrinfo *ai);
@@ -123,6 +124,7 @@ typedef struct _libcglue_fdman_socket_ops_
 	_libcglue_fdman_dns_getserver_cb_t dns_getserver;
 	_libcglue_fdman_socket_cb_t socket;
 	_libcglue_fdman_select_cb_t select;
+	_libcglue_fdman_gethostbyaddr_cb_t gethostbyaddr;
 	_libcglue_fdman_gethostbyname_cb_t gethostbyname;
 	_libcglue_fdman_gethostbyname_r_cb_t gethostbyname_r;
 	_libcglue_fdman_freeaddrinfo_cb_t freeaddrinfo;

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -41,6 +41,7 @@ typedef ssize_t (*_libcglue_fdman_recv_cb_t)(void *userdata, void *buf, size_t l
 typedef ssize_t (*_libcglue_fdman_recvfrom_cb_t)(void *userdata, void *buf, size_t len, int flags, struct sockaddr *from, socklen_t *fromlen);
 typedef ssize_t (*_libcglue_fdman_send_cb_t)(void *userdata, const void *buf, size_t len, int flags);
 typedef ssize_t (*_libcglue_fdman_sendto_cb_t)(void *userdata, const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen);
+typedef ssize_t (*_libcglue_fdman_sendmsg_cb_t)(void *userdata, const struct msghdr *msg, int flags);
 typedef int (*_libcglue_fdman_getsockopt_cb_t)(void *userdata, int level, int optname, void *optval, socklen_t *optlen);
 typedef int (*_libcglue_fdman_setsockopt_cb_t)(void *userdata, int level, int optname, const void *optval, socklen_t optlen);
 typedef int (*_libcglue_fdman_shutdown_cb_t)(void *userdata, int how);

--- a/ee/libcglue/include/sys/socket.h
+++ b/ee/libcglue/include/sys/socket.h
@@ -680,9 +680,7 @@ int	paccept(int, struct sockaddr * __restrict, socklen_t * __restrict,
 ssize_t	recv(int, void *, size_t, int);
 ssize_t	recvfrom(int, void *__restrict, size_t, int,
 	    struct sockaddr * __restrict, socklen_t * __restrict);
-#if 0
 ssize_t	recvmsg(int, struct msghdr *, int);
-#endif
 ssize_t	send(int, const void *, size_t, int);
 ssize_t	sendto(int, const void *,
 	    size_t, int, const struct sockaddr *, socklen_t);

--- a/ee/libcglue/include/sys/socket.h
+++ b/ee/libcglue/include/sys/socket.h
@@ -89,6 +89,20 @@
 #define	SOMAXCONN	128
 #endif
 
+/*
+ * Message header for recvmsg and sendmsg calls.
+ * Used value-result for recvmsg, value only for sendmsg.
+ */
+struct msghdr {
+	void		*msg_name;	/* optional address */
+	socklen_t	msg_namelen;	/* size of address */
+	struct iovec	*msg_iov;	/* scatter/gather array */
+	int		msg_iovlen;	/* # elements in msg_iov */
+	void		*msg_control;	/* ancillary data, see below */
+	socklen_t	msg_controllen;	/* ancillary data buffer len */
+	int		msg_flags;	/* flags on received message */
+};
+
 #if 0
 #include <sys/featuretest.h>
 
@@ -672,9 +686,7 @@ ssize_t	recvmsg(int, struct msghdr *, int);
 ssize_t	send(int, const void *, size_t, int);
 ssize_t	sendto(int, const void *,
 	    size_t, int, const struct sockaddr *, socklen_t);
-#if 0
 ssize_t	sendmsg(int, const struct msghdr *, int);
-#endif
 int	setsockopt(int, int, int, const void *, socklen_t);
 int	shutdown(int, int);
 #if 0

--- a/ee/libcglue/src/netdb.c
+++ b/ee/libcglue/src/netdb.c
@@ -15,6 +15,18 @@
 
 #include "ps2sdkapi.h"
 
+#ifdef F_gethostbyaddr
+struct hostent *gethostbyaddr(const void *addr, int len, int type)
+{
+	if (_libcglue_fdman_socket_ops == NULL || _libcglue_fdman_socket_ops->gethostbyaddr == NULL)
+	{
+		return NULL;
+	}
+
+	return _libcglue_fdman_socket_ops->gethostbyaddr(addr, len, type);	
+}
+#endif
+
 #ifdef F_gethostbyname
 struct hostent *gethostbyname(const char *name)
 {

--- a/ee/libcglue/src/socket.c
+++ b/ee/libcglue/src/socket.c
@@ -194,6 +194,26 @@ ssize_t	recvfrom(int fd, void *buf, size_t len, int flags, struct sockaddr *from
 }
 #endif
 
+#ifdef F_recvmsg
+ssize_t recvmsg(int fd, struct msghdr *msg, int flags)
+{
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	_libcglue_fdman_fd_info_t *fdinfo;
+
+	fdinfo = &(__descriptormap[fd]->info);
+	if (fdinfo->ops == NULL || fdinfo->ops->recvmsg == NULL)
+	{
+		errno = ENOSYS;
+		return -1;
+	}
+	return __transform_errno(fdinfo->ops->recvmsg(fdinfo->userdata, msg, flags));
+}
+#endif
+
 #ifdef F_send
 ssize_t	send(int fd, const void *buf, size_t len, int flags)
 {

--- a/ee/libcglue/src/socket.c
+++ b/ee/libcglue/src/socket.c
@@ -234,6 +234,26 @@ ssize_t	sendto(int fd, const void *buf, size_t len, int flags, const struct sock
 }
 #endif
 
+#ifdef F_sendmsg
+ssize_t sendmsg(int fd, const struct msghdr *msg, int flags)
+{
+	if (!__IS_FD_VALID(fd)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	_libcglue_fdman_fd_info_t *fdinfo;
+
+	fdinfo = &(__descriptormap[fd]->info);
+	if (fdinfo->ops == NULL || fdinfo->ops->sendmsg == NULL)
+	{
+		errno = ENOSYS;
+		return -1;
+	}
+	return __transform_errno(fdinfo->ops->sendmsg(fdinfo->userdata, msg, flags));
+}
+#endif
+
 #ifdef F_getsockopt
 int	getsockopt(int fd, int level, int optname, void *optval, socklen_t *optlen)
 {

--- a/ee/network/tcpip/src/ps2ip_ps2sdk.c
+++ b/ee/network/tcpip/src/ps2ip_ps2sdk.c
@@ -240,6 +240,11 @@ int __ps2ipeeSendtoHelper(void *userdata, const void *dataptr, size_t size, int 
     return res;
 }
 
+int __ps2ipeeSendmsgHelper(void *userdata, const struct msghdr *msg, int flags) {
+    // TODO
+    return -1;
+}
+
 int __ps2ipeeIoctlHelper(void *userdata, int cmd, void *argp)
 {
     int fd, res;

--- a/ee/network/tcpip/src/ps2ip_ps2sdk.c
+++ b/ee/network/tcpip/src/ps2ip_ps2sdk.c
@@ -202,6 +202,12 @@ int __ps2ipeeRecvfromHelper(void *userdata, void *mem, size_t len, int flags, st
     return res;
 }
 
+int __ps2ipeeRecvmsgHelper(void *userdata, struct msghdr *msg, int flags)
+{
+    // TODO
+    return -1;
+}
+
 int __ps2ipeeSendHelper(void *userdata, const void *dataptr, size_t size, int flags)
 {
     int fd, res;
@@ -402,6 +408,7 @@ struct hostent *ps2ip_gethostbyaddr(const void *addr, int len, int type) {
     return NULL;
 }
 
+
 void __ps2ipeeOpsInitializeImpl(void)
 {
     memset(&__ps2ipee_fdman_socket_ops, 0, sizeof(__ps2ipee_fdman_socket_ops));
@@ -434,8 +441,10 @@ void __ps2ipeeOpsInitializeImpl(void)
     __ps2ipee_fdman_ops_socket.listen = __ps2ipeeListenHelper;
     __ps2ipee_fdman_ops_socket.recv = __ps2ipeeRecvHelper;
     __ps2ipee_fdman_ops_socket.recvfrom = __ps2ipeeRecvfromHelper;
+    __ps2ipee_fdman_ops_socket.recvmsg = __ps2ipeeRecvmsgHelper;
     __ps2ipee_fdman_ops_socket.send = __ps2ipeeSendHelper;
     __ps2ipee_fdman_ops_socket.sendto = __ps2ipeeSendtoHelper;
+    __ps2ipee_fdman_ops_socket.sendmsg = __ps2ipeeSendmsgHelper;
     __ps2ipee_fdman_ops_socket.ioctl = __ps2ipeeIoctlHelper;
     __ps2ipee_fdman_ops_socket.getsockname = __ps2ipeeGetsocknameHelper;
     __ps2ipee_fdman_ops_socket.getpeername = __ps2ipeeGetpeernameHelper;

--- a/ee/network/tcpip/src/ps2ip_ps2sdk.c
+++ b/ee/network/tcpip/src/ps2ip_ps2sdk.c
@@ -392,6 +392,11 @@ int __ps2ipeeWriteHelper(void *userdata, const void *mem, int len)
     return res;
 }
 
+struct hostent *ps2ip_gethostbyaddr(const void *addr, int len, int type) {
+    // TODO
+    return NULL;
+}
+
 void __ps2ipeeOpsInitializeImpl(void)
 {
     memset(&__ps2ipee_fdman_socket_ops, 0, sizeof(__ps2ipee_fdman_socket_ops));
@@ -401,6 +406,7 @@ void __ps2ipeeOpsInitializeImpl(void)
     __ps2ipee_fdman_socket_ops.dns_getserver = dns_getserver;
     __ps2ipee_fdman_socket_ops.socket = __ps2ipeeSocketHelper;
     __ps2ipee_fdman_socket_ops.select = lwip_select;
+    __ps2ipee_fdman_socket_ops.gethostbyaddr = ps2ip_gethostbyaddr;
     __ps2ipee_fdman_socket_ops.gethostbyname = lwip_gethostbyname;
     __ps2ipee_fdman_socket_ops.gethostbyname_r = lwip_gethostbyname_r;
     __ps2ipee_fdman_socket_ops.freeaddrinfo = lwip_freeaddrinfo;

--- a/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
+++ b/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
@@ -201,6 +201,12 @@ int __ps2ipcRecvfromHelper(void *userdata, void *mem, size_t len, int flags, str
     return res;
 }
 
+int __ps2ipcRecvmsgHelper(void *userdata, struct msghdr *msg, int flags)
+{
+    // TODO
+    return -1;
+}
+
 int __ps2ipcSendHelper(void *userdata, const void *dataptr, size_t len, int flags)
 {
     int fd, res;
@@ -367,6 +373,7 @@ void __ps2ipcOpsInitializeImpl(void)
     __ps2ipc_fdman_ops_socket.listen = __ps2ipcListenHelper;
     __ps2ipc_fdman_ops_socket.recv = __ps2ipcRecvHelper;
     __ps2ipc_fdman_ops_socket.recvfrom = __ps2ipcRecvfromHelper;
+    __ps2ipc_fdman_ops_socket.recvmsg = __ps2ipcRecvmsgHelper;
     __ps2ipc_fdman_ops_socket.send = __ps2ipcSendHelper;
     __ps2ipc_fdman_ops_socket.sendto = __ps2ipcSendtoHelper;
     __ps2ipc_fdman_ops_socket.sendmsg = __ps2ipcSendmsgHelper;

--- a/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
+++ b/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
@@ -239,6 +239,12 @@ int __ps2ipcSendtoHelper(void *userdata, const void *dataptr, size_t len, int fl
     return res;
 }
 
+int __ps2ipcSendmsgHelper(void *userdata, const struct msghdr *msg, int flags) {
+    // TODO
+    return -1;
+}
+
+
 int __ps2ipcIoctlHelper(void *userdata, int cmd, void *argp)
 {
     int fd, res;
@@ -363,6 +369,7 @@ void __ps2ipcOpsInitializeImpl(void)
     __ps2ipc_fdman_ops_socket.recvfrom = __ps2ipcRecvfromHelper;
     __ps2ipc_fdman_ops_socket.send = __ps2ipcSendHelper;
     __ps2ipc_fdman_ops_socket.sendto = __ps2ipcSendtoHelper;
+    __ps2ipc_fdman_ops_socket.sendmsg = __ps2ipcSendmsgHelper;
     __ps2ipc_fdman_ops_socket.ioctl = __ps2ipcIoctlHelper;
     __ps2ipc_fdman_ops_socket.getsockname = __ps2ipcGetsocknameHelper;
     __ps2ipc_fdman_ops_socket.getpeername = __ps2ipcGetpeernameHelper;

--- a/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
+++ b/ee/rpc/tcpips/src/ps2ipc_ps2sdk.c
@@ -334,6 +334,11 @@ int __ps2ipcSetsockoptHelper(void *userdata, int level, int optname, const void 
     return res;
 }
 
+struct hostent *ps2ipc_gethostbyaddr(const void *addr, int len, int type) {
+    // TODO
+    return NULL;
+}
+
 void __ps2ipcOpsInitializeImpl(void)
 {
     memset(&__ps2ipc_fdman_socket_ops, 0, sizeof(__ps2ipc_fdman_socket_ops));
@@ -343,6 +348,7 @@ void __ps2ipcOpsInitializeImpl(void)
     __ps2ipc_fdman_socket_ops.dns_getserver = ps2ipc_dns_getserver;
     __ps2ipc_fdman_socket_ops.socket = __ps2ipcSocketHelper;
     __ps2ipc_fdman_socket_ops.select = ps2ipc_select;
+    __ps2ipc_fdman_socket_ops.gethostbyaddr = ps2ipc_gethostbyaddr;
     __ps2ipc_fdman_socket_ops.gethostbyname = ps2ipc_gethostbyname;
 
     memset(&__ps2ipc_fdman_ops_socket, 0, sizeof(__ps2ipc_fdman_ops_socket));


### PR DESCRIPTION
## Description

In this PR we are adding dummy implementation for IOP and EE driver for:
- `gethostbyaddr`
- `sndmsg`
- `recvmsg`