### PR TITLE
Using relative path for the symbolic links

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,10 +26,11 @@ jobs:
           make -j $(getconf _NPROCESSORS_ONLN) clean
           make -j $(getconf _NPROCESSORS_ONLN) ${{ matrix.debug }}
           make -j $(getconf _NPROCESSORS_ONLN) install
-          ln -sf "$PS2SDK/ee/lib/libcglue.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcglue.a"
-          ln -sf "$PS2SDK/ee/lib/libpthreadglue.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libpthreadglue.a"
-          ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a"
-          ln -sf "$PS2SDK/ee/lib/libcdvd.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcdvd.a"
+          # Create symbolink links using relative paths
+          (cd $PS2DEV && ln -sf ps2sdk/ee/lib/libcglue.a ee/mips64r5900el-ps2-elf/lib/libcglue.a && cd -)
+          (cd $PS2DEV && ln -sf ps2sdk/ee/lib/libpthreadglue.a ee/mips64r5900el-ps2-elf/lib/libpthreadglue.a && cd -)
+          (cd $PS2DEV && ln -sf ps2sdk/ee/lib/libkernel.a ee/mips64r5900el-ps2-elf/lib/libkernel.a && cd -)
+          (cd $PS2DEV && ln -sf ps2sdk/ee/lib/libcdvd.a ee/mips64r5900el-ps2-elf/lib/libcdvd.a && cd -)
 
       - name: Compile samples
         if: ${{ success() }}


### PR DESCRIPTION
## Description
The previous implementation didn't work well if you moved to a different folder.