### PR TITLE
[iop]: add script to check IRX source code for unused imports

### DIFF
--- a/iop/Rules.bin.make
+++ b/iop/Rules.bin.make
@@ -15,3 +15,7 @@ all:: $(IOP_BIN)
 
 clean::
 	rm -f -r $(IOP_OBJS_DIR) $(IOP_BIN_DIR)
+
+IMPORT_CHECK_SCRIPT=$(PS2SDKSRC)/iop/check_imports.sh
+check-import::
+	exec $(IMPORT_CHECK_SCRIPT)

--- a/iop/check_imports.sh
+++ b/iop/check_imports.sh
@@ -21,14 +21,14 @@ do
   fi
 done
 
+printf " %s\n" $(pwd | xargs basename)
 if [ -f "$IOP_SRC_DIR/imports.lst" ]; then
-  
   IMPORTS=$(grep -Eo "^I_[a-zA-Z0-9_-]*" $IOP_SRC_DIR/imports.lst | sed 's/^I_//')
   #echo $IMPORTS
   U=0
   for a in $IMPORTS
   do
-      grep -r -q --include="*.c" --include="*.h" "$a" "src/"
+      grep -r -q --include="*.c" --include="*.h" "$a" "."
       if [ $? -eq 1 ];
       then
           printf "${RED}-- IMPORT ${YELLOW}$a${RED} NOT FOUND IN C SOURCE${NC}\n"

--- a/iop/check_imports.sh
+++ b/iop/check_imports.sh
@@ -1,0 +1,47 @@
+# Import checked by El_isra. this script parses a IRX module source code checking for ocurrences of every importted
+# function that was defined on imports.lst
+# ensuring that you are not wasting binary size on functions that youre not using
+RED='\033[1;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[1;32m'
+NC='\033[0m' # No Color
+RETCODE=0
+IOP_SRC_DIR=src/
+
+for i in $@
+do 
+  if [ "$i" = "--help" ]; then
+	  echo "available switches:"
+	  echo "--iop-src-dir=DIR : specify an alternative dir for parsing. by default it is 'src'. but this should be the makefile IOP_SRC_DIR"
+	  exit
+  fi
+  if [[ "$i" == --iop-src-dir=* ]]; then
+	  IOP_SRC_DIR=${i#"--iop-src-dir="}
+    echo $IOP_SRC_DIR
+  fi
+done
+
+if [ -f "$IOP_SRC_DIR/imports.lst" ]; then
+  
+  IMPORTS=$(grep -Eo "^I_[a-zA-Z0-9_-]*" $IOP_SRC_DIR/imports.lst | sed 's/^I_//')
+  #echo $IMPORTS
+  U=0
+  for a in $IMPORTS
+  do
+      grep -r -q --include="*.c" --include="*.h" "$a" "src/"
+      if [ $? -eq 1 ];
+      then
+          printf "${RED}-- IMPORT ${YELLOW}$a${RED} NOT FOUND IN C SOURCE${NC}\n"
+          U=1
+      fi
+  
+  done
+  if [ $U -eq 0 ];
+  then
+      printf "${GREEN}--- ALL IMPORTS USED AT LEAST ONCE${NC}\n"
+  fi
+else
+  echo - 'imports.lst' not found
+fi
+
+exit $RETCODE


### PR DESCRIPTION
Will allow us to reduct binary size of some critical IRX by `16*unused_import_ammount` bytes

Checking all our drivers src will be as simple as applying the following change on `iop/Rules.bin.make` and then call `make` inside `iop/`

```diff
IOP_BIN ?= $(shell basename $(CURDIR)).irx
IOP_BIN := $(IOP_BIN:%=$(IOP_BIN_DIR)%)

+IMPORT_CHECK_SCRIPT=$(PS2SDKSRC)/iop/check_imports.sh
+check-import::
+	exec $(IMPORT_CHECK_SCRIPT)

all:: $(IOP_BIN)

clean::
	rm -f -r $(IOP_OBJS_DIR) $(IOP_BIN_DIR)

-IMPORT_CHECK_SCRIPT=$(PS2SDKSRC)/iop/check_imports.sh
-check-import::
-	exec $(IMPORT_CHECK_SCRIPT)
```
a small example of the output:

![image](https://github.com/ps2dev/ps2sdk/assets/57065102/e3831afd-216f-4ead-b6f0-35f7ff1fa89a)

it will not handle some edge cases, like udptty createsema (because its using a the createMutex helper function from the intrman header)

but it is still useful
