### PR TITLE
build: assigned include dirs and lib dirs the correct way

### DIFF
--- a/samples/ps2dev.cmake
+++ b/samples/ps2dev.cmake
@@ -28,8 +28,12 @@ SET(CMAKE_SYSTEM_PROCESSOR mips)
 SET(CMAKE_C_COMPILER mips64r5900el-ps2-elf-gcc)
 SET(CMAKE_CXX_COMPILER mips64r5900el-ps2-elf-g++)
 
-SET(EE_CFLAGS "-I$ENV{PS2SDK}/ee/include -I$ENV{PS2SDK}/common/include -I$ENV{PS2SDK}/ports/include -D_EE -DPS2 -D__PS2__ -O2 -G0" CACHE STRING "EE C compiler flags" FORCE)
-SET(EE_LDFLAGS "-L$ENV{PS2SDK}/ee/lib -L$ENV{PS2DEV}/gsKit/lib -L$ENV{PS2SDK}/ports/lib -Wl,-zmax-page-size=128 -T$ENV{PS2SDK}/ee/startup/linkfile" CACHE STRING "EE linker flags" FORCE)
+INCLUDE_DIRECTORIES($ENV{PS2SDK}/ee/include $ENV{PS2SDK}/common/include $ENV{PS2SDK}/ports/include)
+LINK_DIRECTORIES($ENV{PS2SDK}/ee/lib $ENV{PS2DEV}/gsKit/lib $ENV{PS2SDK}/ports/lib)
+ADD_DEFINITIONS(-D_EE -DPS2 -D__PS2__)
+
+SET(EE_CFLAGS "-O2 -G0" CACHE STRING "EE C compiler flags" FORCE)
+SET(EE_LDFLAGS "-Wl,-zmax-page-size=128 -T$ENV{PS2SDK}/ee/startup/linkfile" CACHE STRING "EE linker flags" FORCE)
 
 SET(CMAKE_TARGET_INSTALL_PREFIX $ENV{PS2DEV}/ports)
 

--- a/samples/ps2dev_iop.cmake
+++ b/samples/ps2dev_iop.cmake
@@ -36,11 +36,13 @@ EXECUTE_PROCESS(COMMAND ${CMAKE_C_COMPILER} -dumpversion
     OUTPUT_VARIABLE IOP_CC_VERSION)
 
 SET(IOP_ASFLAGS_TARGET "-mcpu=r3000")
+
 INCLUDE_DIRECTORIES($ENV{PS2SDK}/iop/include $ENV{PS2SDK}/common/include $ENV{PS2SDK}/ports_iop/include)
+LINK_DIRECTORIES($ENV{PS2SDK}/iop/lib $ENV{PS2SDK}/ports_iop/lib)
 ADD_DEFINITIONS(-D_IOP -DPS2 -D__PS2__)
 
 SET(IOP_CFLAGS "${IOP_CFLAGS_TARGET} -O2 -G0 -fno-builtin" CACHE STRING "IOP C compiler flags" FORCE)
-SET(IOP_LDFLAGS "${IOP_LDFLAGS_TARGET} -T$ENV{PS2SDK}/iop/startup/linkfile -L$ENV{PS2SDK}/iop/lib -L$ENV{PS2SDK}/ports_iop/lib -Wl,-zmax-page-size=128 -nostdlib -Os -Wall" CACHE STRING "IOP linker flags" FORCE)
+SET(IOP_LDFLAGS "${IOP_LDFLAGS_TARGET} -T$ENV{PS2SDK}/iop/startup/linkfile -Wl,-zmax-page-size=128 -nostdlib -Os -Wall" CACHE STRING "IOP linker flags" FORCE)
 SET(IOP_ASFLAGS "${IOP_ASFLAGS_TARGET} -EL -G0" CACHE STRING "IOP assembler flags" FORCE)
 
 SET(CMAKE_C_FLAGS_INIT ${IOP_CFLAGS})


### PR DESCRIPTION
 - this allows to build libpng correctly without error of mismatching zlib version