### PR TITLE
Call `_InitSys()` before newlib initialization

### DIFF
--- a/ee/startup/src/crt0.c
+++ b/ee/startup/src/crt0.c
@@ -112,12 +112,12 @@ static void _main()
     // initialize libcglue
     _libcglue_init();
 
+    // Enable interruts
+    EI();
+
     // call global constructors (weak)
     if (_init)
         _init();
-
-    // Enable interruts
-    EI();
 
     // call main
     retval = main(pa->argc, pa->argv);

--- a/ee/startup/src/crt0.c
+++ b/ee/startup/src/crt0.c
@@ -97,6 +97,9 @@ static void _main()
     // NOTE: this call can restart the application
     if (_ps2sdk_memory_init)
         _ps2sdk_memory_init();
+    
+    // Initialize the kernel (Apply necessary patches).
+    _InitSys();
 
     // Use arguments sent through start if sent (by ps2link for instance)
     pa = &args;
@@ -112,9 +115,6 @@ static void _main()
     // call global constructors (weak)
     if (_init)
         _init();
-
-    // Initialize the kernel (Apply necessary patches).
-    _InitSys();
 
     // Enable interruts
     EI();


### PR DESCRIPTION
## Description
The current implementation of `crt0.c` looks to be wrong as we are calling `_InitSys()` too late.

Within `_InitSys()` we are initialization timers, alarms, and some others.
In the existing implementation, we are calling `_InitSys()` after calling `libcglue_init` and the C++ constructors; this mean we couldn't use for instance timers on those specific functions.

This is why I think that `_InitSys` should be called way earlier, as it doesn't have any `newlib` requirement.

Cheers.