### PR TITLE
[PS2 libretro]: Add cmake minimum dependency.

### DIFF
--- a/samples/ps2dev.cmake
+++ b/samples/ps2dev.cmake
@@ -7,6 +7,7 @@
 # Copyright (C) 2024-Present PS2DEV Team
 #
 
+cmake_minimum_required(VERSION 3.0)
 
 INCLUDE(CMakeForceCompiler)
 if(DEFINED ENV{PS2SDK})

--- a/samples/ps2dev_iop.cmake
+++ b/samples/ps2dev_iop.cmake
@@ -7,6 +7,8 @@
 # Copyright (C) 2024-Present PS2DEV Team
 #
 
+cmake_minimum_required(VERSION 3.0)
+
 INCLUDE(CMakeForceCompiler)
 if(DEFINED ENV{PS2SDK})
     SET(PS2SDK $ENV{PS2SDK})


### PR DESCRIPTION
This pr is for fixing smb2man.irx library.