### PR TITLE
add ready cb to bdm

### DIFF
--- a/common/include/usbhdfsd-common.h
+++ b/common/include/usbhdfsd-common.h
@@ -46,11 +46,13 @@ typedef struct bd_fragment {
 
 // Device status bits.
 /** CONNected */
-#define USBMASS_DEV_STAT_CONN 0x01
+#define USBMASS_DEV_STAT_CONN  0x01
 /** CONFigured */
-#define USBMASS_DEV_STAT_CONF 0x02
+#define USBMASS_DEV_STAT_CONF  0x02
+/** READY for I/O */
+#define USBMASS_DEV_STAT_READY 0x04
 /** ERRor */
-#define USBMASS_DEV_STAT_ERR  0x80
+#define USBMASS_DEV_STAT_ERR   0x80
 
 // Device events
 enum USBMASS_DEV_EV {

--- a/iop/fs/bdm/include/bdm.h
+++ b/iop/fs/bdm/include/bdm.h
@@ -18,6 +18,14 @@
 #include <irx.h>
 #include <types.h>
 
+/* Event flag bits */
+#define BDM_EVENT_CB_MOUNT     0x01
+#define BDM_EVENT_CB_UMOUNT    0x02
+#define BDM_EVENT_MOUNT        0x04
+#define BDM_EVENT_DEVICE_READY 0x08
+
+typedef void (*bdm_cb)(int event);
+
 struct block_device
 {
     // Private driver data
@@ -39,6 +47,8 @@ struct block_device
     int (*write)(struct block_device *bd, u64 sector, const void *buffer, u16 count);
     void (*flush)(struct block_device *bd);
     int (*stop)(struct block_device *bd);
+
+    bdm_cb device_ready_callback;
 };
 
 struct file_system
@@ -54,8 +64,6 @@ struct file_system
     void (*disconnect_bd)(struct block_device *bd);
 };
 
-typedef void (*bdm_cb)(int event);
-
 // Exported functions
 void bdm_connect_bd(struct block_device *bd);
 void bdm_disconnect_bd(struct block_device *bd);
@@ -63,6 +71,7 @@ void bdm_connect_fs(struct file_system *fs);
 void bdm_disconnect_fs(struct file_system *fs);
 void bdm_get_bd(struct block_device **pbd, unsigned int count);
 void bdm_RegisterCallback(bdm_cb cb);
+void bdm_on_device_ready(int event);
 
 #define bdm_IMPORTS_start DECLARE_IMPORT_TABLE(bdm, 1, 1)
 #define bdm_IMPORTS_end   END_IMPORT_TABLE
@@ -73,5 +82,6 @@ void bdm_RegisterCallback(bdm_cb cb);
 #define I_bdm_disconnect_fs    DECLARE_IMPORT(7, bdm_disconnect_fs)
 #define I_bdm_get_bd           DECLARE_IMPORT(8, bdm_get_bd)
 #define I_bdm_RegisterCallback DECLARE_IMPORT(9, bdm_RegisterCallback)
+#define I_bdm_on_device_ready  DECLARE_IMPORT(10, bdm_on_device_ready)
 
 #endif

--- a/iop/fs/bdm/src/bdm.c
+++ b/iop/fs/bdm/src/bdm.c
@@ -22,11 +22,6 @@ static bdm_cb g_cb       = NULL;
 static int bdm_event     = -1;
 static int bdm_thread_id = -1;
 
-/* Event flag bits */
-#define BDM_EVENT_CB_MOUNT  0x01
-#define BDM_EVENT_CB_UMOUNT 0x02
-#define BDM_EVENT_MOUNT     0x04
-
 void bdm_RegisterCallback(bdm_cb cb)
 {
     int i;
@@ -45,6 +40,11 @@ void bdm_RegisterCallback(bdm_cb cb)
             break;
         }
     }
+}
+
+void bdm_on_device_ready(int event)
+{
+    // do something with your device.. unlock io etc
 }
 
 void bdm_connect_bd(struct block_device *bd)

--- a/iop/fs/bdm/src/exports.tab
+++ b/iop/fs/bdm/src/exports.tab
@@ -11,6 +11,7 @@ DECLARE_EXPORT_TABLE(bdm, 1, 1)
 	DECLARE_EXPORT(bdm_disconnect_fs)
 	DECLARE_EXPORT(bdm_get_bd)
 	DECLARE_EXPORT(bdm_RegisterCallback)
+	DECLARE_EXPORT(bdm_on_device_ready)
 END_EXPORT_TABLE
 
 void _retonly() {}

--- a/iop/usb/usbmass_bd/src/include/scsi.h
+++ b/iop/usb/usbmass_bd/src/include/scsi.h
@@ -14,5 +14,6 @@ struct scsi_interface
 int scsi_init(void);
 void scsi_connect(struct scsi_interface *scsi);
 void scsi_disconnect(struct scsi_interface *scsi);
+void scsi_set_ready(struct scsi_interface *scsi);
 
 #endif

--- a/iop/usb/usbmass_bd/src/scsi.c
+++ b/iop/usb/usbmass_bd/src/scsi.c
@@ -323,6 +323,22 @@ void scsi_disconnect(struct scsi_interface *scsi)
     }
 }
 
+void scsi_set_ready(struct scsi_interface *scsi)
+{
+    int i;
+    M_DEBUG("%s\n", __func__);
+    for (i = 0; i < NUM_DEVICES; ++i) {
+        if (g_scsi_bd[i].priv == scsi) {
+            M_DEBUG("Device %s%d is now READY\n", g_scsi_bd[i].name, g_scsi_bd[i].devNr);
+            if (g_scsi_bd[i].device_ready_callback) {
+                g_scsi_bd[i].device_ready_callback(BDM_EVENT_DEVICE_READY);
+                M_DEBUG("Device is ready, invoking device ready callback\n");
+            }
+            break;
+        }
+    }
+}
+
 int scsi_init(void)
 {
     int i;
@@ -339,6 +355,8 @@ int scsi_init(void)
         g_scsi_bd[i].write = scsi_write;
         g_scsi_bd[i].flush = scsi_flush;
         g_scsi_bd[i].stop  = scsi_stop;
+
+        g_scsi_bd[i].device_ready_callback = NULL;
     }
 
     return 0;


### PR DESCRIPTION
@rickgaiser @uyjulian @fjtrujy 

So this is basically open for review more so than anything.. this coupled with [this](https://github.com/KrahJohlito/Open-PS2-Loader/commit/c1b44bf6fb9205ca60753d4eb96f51a9310be3ba) "fixes" the issue with OPL not launching from mass0 when dual USB is connected by not allowing reads in cdvdman until both devices are init see log after this change compared to before:
```
THIS COMMIT:

connecting device usb0p0
attaching to usb0p0
usbmass_bd: probe: devId=1
usbmass_bd: usb_mass_findDevice devId 1
usbmass_bd: bNumInterfaces 1
usbmass_bd: bInterfaceClass 8 bInterfaceSubClass 6 bInterfaceProusbmass_bd: connect: devId=1
usbmass_bd: usb_mass_findDevice devId 1
usbmass_bd: register Input endpoint id =4 addr=81 packetSize=64
usbmass_bd: register Output endpoint id =5 addr=02 packetSize=64
usbmass_bd: connect ok: epI=4, epO=5
usbmass_bd: Waiting... devices_initialising: 1
usbmass_bd: Detected another device initialising. Breaking wait.
usbmass_bd: setting configuration controlEp=0, confNum=1
usbmass_bd: callback: res 0, bytes 0, arg 1f2b88
usbmass_bd: setting interface controlEp=0, interface=0 altSetting=0
usbmass_bd: callback: res 0, bytes 0, arg 1f2b88
usbmass_bd: callback: res 0, bytes 1, arg 1f2ac0
usbmass_bd: usb_queue_cmd
usbmass_bd: callback: res 0, bytes 31, arg 1f2a78
usbmass_bd: callback: res 0, bytes 13, arg 1f2a40
usbmass_bd: bulk csw result: 0, csw.status: 0
usbmass_bd: Vendor: PNY
usbmass_bd: Product: USB 3.0 FD
usbmass_bd: Revision: PMAP
usbmass_bd: usb_queue_cmd
usbmass_bd: callback: res 0, bytes 31, arg 1f2a78
usbmass_bd: callback: res 0, bytes 13, arg 1f2a40
usbmass_bd: bulk csw result: 0, csw.status: 0
usbmass_bd: usb_queue_cmd
usbmass_bd: callback: res 0, bytes 31, arg 1f2a78
usbmass_bd: callback: res 0, bytes 13, arg 1f2a40
usbmass_bd: bulk csw result: 0, csw.status: 0
usbmass_bd: 0 483950591-byte logical blocks: (0MB / 512MiB)
connecting device usb1p0
Device usb0p0 is now ready. UNLOCKING...
usbmass_bd: Device 2 is now ready
usbmass_bd: Device 1 is now ready
Waiting for device...done!
sceCdRead lsn=16 sectors=1 sector_size=2048 buf=00029304
cdvdman_read lsn=16 sectors=1 buf=29304
usbmass_bd: usb_queue_cmd
sceCdSync 0 sync flag = 1
```

```
CURRENT:

connecting device usb0p0
attaching to usb0p0
Waiting for device...done!
sceCdRead lsn=16 sectors=1 sector_size=2048 buf=00024b14
cdvdman_read lsn=16 sectors=1 buf=24b14
sceCdSync 0 sync flag = 1
cdvdman_searchfile_init mediaLsnCount=1971232
sceCdLayerSearchFile \SLUS_214.19;1
cdvdman_findfile \SLUS_214.19;1 layer0
cdvdman_findfile cdvdman_filepath=\SLUS_214.19;1
cdvdman_locatefile start locating \SLUS_214.19;1, layer=0
sceCdRead lsn=261 sectors=1 sector_size=2048 buf=00024b14
cdvdman_read lsn=261 sectors=1 buf=24b14
sceCdSync 0 sync flag = 1
cdvdman_locatefile tocLBA read done
cdvdman_locatefile strcmp SLUS_214.19;1
cdvdman_locatefile strcmp SLUS_214.19;1 ☺
cdvdman_locatefile strcmp SLUS_214.19;1 FILELIST.BIN;1
cdvdman_locatefile strcmp SLUS_214.19;1 SYSTEM.CNF;1
cdvdman_locatefile strcmp SLUS_214.19;1 E419C51B
cdvdman_locatefile strcmp SLUS_214.19;1 SLUS_214.19;1
cdvdman_locatefile found file! LBA=278 size=4733144
cdvdman_findfile found \SLUS_214.19;1
open ret=0 lsn=278 size=4733144
cdrom_read size=65536b (32s) file_position=0
sceCdRead lsn=278 sectors=32 sector_size=2048 buf=001c1400
cdvdman_read lsn=278 sectors=32 buf=1c1400
sceCdSync 0 sync flag = 1

usbmass_bd: connect: devId=1
usbmass_bd: Vendor: PNY
usbmass_bd: Product: USB 3.0 FD
usbmass_bd: Revision: PMAP
connecting device usb1p0
usbmass_bd: ERROR: unable to read sector after 16 tries (sector=0x0000000000f77ad8, count=128)
cdrom_read ret=65536
Input ELF format filename = cdrom0:\SLUS_214.19;1
..cdrom_read size=65536b (32s) file_position=65536
sceCdRead lsn=310 sectors=32 sector_size=2048 buf=001d1400
cdvdman_read lsn=310 sectors=32 buf=1d1400
usbmass_bd: ERROR: unable to read sector after 16 tries (sector=BDM: bd_defrag_read: ERROR: read failed!
sceCdSync 0 sync flag = 0
cdrom_read ret=65536
.cdrom_read size=65536b (32s) file_position=131072
sceCdRead lsn=342 sectors=32 sector_size=2048 buf=001c1400
cdvdman_read lsn=342 sectors=32 buf=1c1400
BDM: bd_defrag_read: ERROR: read failed!
sceCdSync 0 sync flag = 0
cdrom_read ret=65536
sceCdRead lsn=374 sectors=32 sector_size=2048 buf=001d1400
0x0000000000f77c58, count=128)
BDM: bd_defrag_read: ERROR: read failed!
sceCdSync 0 sync flag = 0
```

Not sure if this is the best way to go about it but its the only thing I could get to work, I tried multiple different things like adding a cb to scsi_connect instead of that workaround DelayThread.. a separate thread for ready setting etc etc basically a lot of different things with no success and this finally worked..

It does add a delay which increases boot times slightly which is not ideal I know but during tests it only seemed to iterate one cycle so really it should just be a second or two difference but a full five if only one device is connected so wait cycles could probably be reduced to 2 or 3.

Anyway that is why it is open for review, if there's improvements to be made here let me know or if its just outright the wrong way to go about it; let me know because there's not much point trying to refine it if its just the wrong way to go about solving the issue.
Thanks