### PR TITLE
fix romimg bundled on docker containers

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -23,6 +23,7 @@ release-samples:
 	$(MKDIR) -p $(SHARE_TARGET)
 	cp -f Makefile_sample $(SAMPLES_TARGET)/Makefile
 	cp -f Makefile.pref_sample $(SAMPLES_TARGET)/Makefile.pref
+	cp -f Makefile.ioprp_sample $(SAMPLES_TARGET)/Makefile.ioprp
 	cp -f Makefile.eeglobal_sample $(SAMPLES_TARGET)/Makefile.eeglobal
 	cp -f Makefile.eeglobal_cpp_sample $(SAMPLES_TARGET)/Makefile.eeglobal_cpp
 	cp -f Makefile.iopglobal_sample $(SAMPLES_TARGET)/Makefile.iopglobal

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -98,6 +98,6 @@ ifeq (_$(IOPRP_CONTENTS)_,__)
 	$(error Cannot generate IOPRP if 'IOPRP_CONTENTS' variable is empty)
 else
 	$(DIR_GUARD)
-	romimg -c $@ $<
+	romimg -C $@ $<
 endif
 

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -92,12 +92,3 @@ $(EE_ERL): $(EE_OBJS)
 $(EE_LIB): $(EE_OBJS)
 	$(DIR_GUARD)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)
-
-$(IOPRP_BIN): $(IOPRP_CONTENTS)
-ifeq (_$(IOPRP_CONTENTS)_,__)
-	$(error Cannot generate IOPRP if 'IOPRP_CONTENTS' variable is empty)
-else
-	$(DIR_GUARD)
-	romimg -C $@ $<
-endif
-

--- a/samples/Makefile.ioprp_sample
+++ b/samples/Makefile.ioprp_sample
@@ -1,0 +1,15 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+$(IOPRP_BIN): $(IOPRP_CONTENTS)
+ifeq (_$(IOPRP_CONTENTS)_,__)
+	$(error Cannot generate IOPRP if 'IOPRP_CONTENTS' variable is empty)
+else
+	$(DIR_GUARD)
+	romimg -C $@ $<
+endif

--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <ctype.h>
 
 #include "romimg.h"
 
@@ -34,13 +35,15 @@ static void DisplayROMImgDetails(const ROMIMG *ROMImg)
 
 static void DisplaySyntaxHelp(void)
 {
-    printf(REDBOLD"Syntax error"DEFCOL". Syntax:\n"
-           "ROMIMG -c <ROM image> <files>\n\tCreate ROM image\n"
+    printf("Syntax:\n"
+           "ROMIMG -c <ROM image> <files>\n\tCreate ROM image *\n"
            "ROMIMG -l <ROM image>\n\tList files in ROM image\n"
-           "ROMIMG -a <ROM image> <file(s)>\n\tAdd file(s) to ROM image\n"
+           "ROMIMG -a <ROM image> <file(s)>\n\tAdd file(s) to ROM image *\n"
            "ROMIMG -d <ROM image> <file(s)>\n\tDelete file(s) from ROM image\n"
            "ROMIMG -x <ROM image>\n\tExtract all files from ROM image\n"
-           "ROMIMG -x <ROM image> <file>\n\tExtract file from ROM image\n");
+           "ROMIMG -x <ROM image> <file>\n\tExtract file from ROM image\n"
+           "\n note*: write the switch in uppercase to perform filename transformation (eg: 'ioman.irx' > 'IOMAN')\n"
+           );
 }
 
 static void DisplayAddDeleteOperationResult(int result, const char *InvolvedFile)
@@ -80,31 +83,30 @@ int main(int argc, char **argv)
 
     if (argc < 2) {
         DisplaySyntaxHelp();
-        DPRINTF("ERROR: LESS THAN TWO ARGS PROVIDED\n");
         return EINVAL;
     }
 
-    if (argc >= 4 && strcmp(argv[1], "-c") == 0) {
+    if (argc >= 4 && strcasecmp(argv[1], "-c") == 0) {
         if ((result = CreateBlankROMImg(argv[2], &ROMImg)) == 0) {
             for (FilesAffected = 0, i = 0; i < argc - 3; i++) {
                 printf("Adding file '%s'", argv[3 + i]);
-                if ((result = AddFile(&ROMImg, argv[3 + i])) == 0)
+                if ((result = AddFile(&ROMImg, argv[3 + i], isupper(argv[1][1]))) == 0)
                     FilesAffected++;
                 printf(result == 0 ? GRNBOLD" done!"DEFCOL"\n" : REDBOLD" failed!"DEFCOL"\n");
             }
 
             if (FilesAffected > 0) {
-                printf("Writing image...");
+                printf("Writing image... ");
                 printf("%s", (result = WriteROMImg(argv[2], &ROMImg)) == 0 ? GRNBOLD"done!"DEFCOL"\n" : REDBOLD"failed!"DEFCOL"\n");
             }
             UnloadROMImg(&ROMImg);
         } else
             ERROR("(Internal fault) Can't create blank image file: %d (%s). Please report.\n", result, strerror(result));
-    } else if (argc >= 4 && strcmp(argv[1], "-a") == 0) {
+    } else if (argc >= 4 && strcasecmp(argv[1], "-a") == 0) {
         if ((result = LoadROMImg(&ROMImg, argv[2])) == 0) {
             for (i = 0, FilesAffected = 0; i < argc - 3; i++) {
                 printf("Adding file '%s'", argv[3 + i]);
-                if ((result = AddFile(&ROMImg, argv[3 + i])) == 0)
+                if ((result = AddFile(&ROMImg, argv[3 + i], isupper(argv[1][1]))) == 0)
                     FilesAffected++;
                 DisplayAddDeleteOperationResult(result, argv[3 + i]);
             }

--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
             }
             UnloadROMImg(&ROMImg);
         } else
-            ERROR("(Internal fault) Can't create blank image file: %d. Please report.\n", result);
+            ERROR("(Internal fault) Can't create blank image file: %d (%s). Please report.\n", result, strerror(result));
     } else if (argc >= 4 && strcmp(argv[1], "-a") == 0) {
         if ((result = LoadROMImg(&ROMImg, argv[2])) == 0) {
             for (i = 0, FilesAffected = 0; i < argc - 3; i++) {

--- a/tools/romimg/src/platform.c
+++ b/tools/romimg/src/platform.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include "dprintf.h"
 #if defined(_WIN32) || defined(WIN32)
 #include <windows.h>
@@ -113,4 +114,13 @@ int GetCurrentWorkingDirectory(char *buffer, unsigned int BufferSize)
 	else
 		return EIO;
 #endif
+}
+
+void upperbuff(char *temp)
+{
+    char *s = temp;
+    while (*s) {
+        *s = toupper((unsigned char) *s);
+        s++;
+    }
 }

--- a/tools/romimg/src/platform.h
+++ b/tools/romimg/src/platform.h
@@ -12,5 +12,8 @@ int GetCurrentWorkingDirectory(char *buffer, unsigned int BufferSize);
 #else
 #define PATHSEP '/'
 #endif
+#ifndef MAX_PATH
+#define MAX_PATH 4096
+#endif
 
 #endif /* __PLATFORM_H__ */

--- a/tools/romimg/src/platform.h
+++ b/tools/romimg/src/platform.h
@@ -13,8 +13,5 @@ void upperbuff(char *temp);
 #else
 #define PATHSEP '/'
 #endif
-#ifndef MAX_PATH
-#define MAX_PATH 4096
-#endif
 
 #endif /* __PLATFORM_H__ */

--- a/tools/romimg/src/platform.h
+++ b/tools/romimg/src/platform.h
@@ -6,6 +6,7 @@ int GetLocalhostName(char *buffer, unsigned int BufferSize);
 unsigned int GetSystemDate(void);
 unsigned int GetFileCreationDate(const char *path);
 int GetCurrentWorkingDirectory(char *buffer, unsigned int BufferSize);
+void upperbuff(char *temp);
 
 #if defined(_WIN32) || defined(WIN32)
 #define PATHSEP '\\'

--- a/tools/romimg/src/romimg.c
+++ b/tools/romimg/src/romimg.c
@@ -143,7 +143,7 @@ static int GetExtInfoStat(const struct ROMImgStat *ImageStat, struct RomDirFileF
 int CreateBlankROMImg(const char *filename, ROMIMG *ROMImg)
 {
 	unsigned int CommentLength;
-	char LocalhostName[32] = "\0", cwd[MAX_PATH] = "\0", UserName[32] = "\0";
+	char LocalhostName[32] = {0}, cwd[PATH_MAX] = {0}, UserName[32] = {0};
 	struct FileEntry *ResetFile;
 	struct ExtInfoFieldEntry *ExtInfoEntry;
 
@@ -158,10 +158,10 @@ int CreateBlankROMImg(const char *filename, ROMIMG *ROMImg)
 	GetLocalhostName(LocalhostName, sizeof(LocalhostName));
 	GetCurrentWorkingDirectory(cwd, sizeof(cwd));
 	/* Comment format: YYYYMMDD-XXXYYY,conffile,<filename>,<user>@<localhost>/<image path> */
-	CommentLength = IMAGE_COMMENT_BASESIZE + strlen(filename) + sizeof(LocalhostName) + sizeof(UserName) + MAX_PATH;
+	CommentLength = IMAGE_COMMENT_BASESIZE + strlen(filename) + sizeof(LocalhostName) + sizeof(UserName) + sizeof(cwd);
 	ROMImg->comment = (char *)malloc( CommentLength+1);
     if (!ROMImg->comment) return ENOMEM;
-	snprintf(ROMImg->comment, CommentLength, "%08x,conffile,%s,%s@%s/%s", ROMImg->date, filename, BUFCHK(UserName), BUFCHK(LocalhostName), cwd);
+	snprintf(ROMImg->comment, CommentLength, "%08x,conffile,%s,%s@%s/%s", ROMImg->date, filename, UserName, LocalhostName, cwd);
 
 	// Create a blank RESET file.
 	ROMImg->NumFiles = 1;
@@ -454,7 +454,7 @@ static int AddExtInfoStat(struct FileEntry *file, unsigned char type, void *data
 
 int AddFile(ROMIMG *ROMImg, const char *path, int upperconv)
 {
-    char tbuf[10] = "\0"; // we dont need a large buf, this is for filling in the filename on ROMFS
+    char tbuf[9] = "\0"; // we dont need a large buf, this is for filling in the filename on ROMFS
 	FILE *InputFile;
 	int result;
 	unsigned int FileDateStamp;

--- a/tools/romimg/src/romimg.h
+++ b/tools/romimg/src/romimg.h
@@ -68,7 +68,7 @@ int CreateBlankROMImg(const char *filename, ROMIMG *ROMImg);
 int WriteROMImg(const char *file, const ROMIMG *ROMImg);
 int LoadROMImg(ROMIMG *ROMImg, const char *path);
 void UnloadROMImg(ROMIMG *ROMImg);
-int AddFile(ROMIMG *ROMImg, const char *path);
+int AddFile(ROMIMG *ROMImg, const char *path, int upperconv);
 int DeleteFile(ROMIMG *ROMImg, const char *filename);
 int ExtractFile(const ROMIMG *ROMImg, const char *filename, const char *FileToExtract);
 int IsFileExists(const ROMIMG *ROMImg, const char *filename);


### PR DESCRIPTION
instead of relying on strlen, go straight away with max bufsize. before this change the romimg from docker would segfault while local build works like a charm

New feature, `-c` and `-a` commands will have new variants, `-C` and `-A`, these will manipulate the filename written to ROMFS removing extension and converting to uppercase

So for example
```bash
romimg -C IOPRP.IMG $PS2SDK/iop/irx/secrman.irx
```
Will register secrman.irx as `SECRMAN` on the image, this seems to be needed when the IOPRP is replacing startup IOP modules