### PR TITLE
Improve Dummy Implementation and not implemented functions in drivers.

### DIFF
--- a/ee/iopreboot/src/imgdrv/src/imgdrv.c
+++ b/ee/iopreboot/src/imgdrv/src/imgdrv.c
@@ -22,7 +22,6 @@
 IRX_ID(MODNAME, 1, 1);
 
 // Function prototypes
-static int imgdrv_dummy(void);
 static int imgdrv_read(iop_file_t *f, void *buf, int size);
 static int imgdrv_lseek(iop_file_t *f, int offset, int whence);
 
@@ -41,14 +40,14 @@ typedef struct _iop_device_ops_short
 } iop_device_ops_short_t;
 
 static iop_device_ops_short_t imgdrv_ops = {
-    (void *)&imgdrv_dummy, // init
-    (void *)&imgdrv_dummy, // deinit
-    NULL,                  // format
-    (void *)&imgdrv_dummy, // open
-    (void *)&imgdrv_dummy, // close
-    &imgdrv_read,          // read
-    NULL,                  // write
-    &imgdrv_lseek,         // lseek
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    NOT_SUPPORTED, // open
+    NOT_SUPPORTED, // close
+    &imgdrv_read, // read
+    NOT_SUPPORTED, // write
+    &imgdrv_lseek, // lseek
 };
 
 #define MAX_IMAGES 2
@@ -67,11 +66,6 @@ static iop_device_t img_device = {
 int _start(int argc, char *argv[])
 {
     return (AddDrv(&img_device) < 0) ? MODULE_NO_RESIDENT_END : MODULE_RESIDENT_END;
-}
-
-static int imgdrv_dummy(void)
-{
-    return 0;
 }
 
 static int imgdrv_read(iop_file_t *f, void *buf, int size)

--- a/iop/arcade/accdvd/src/cddrv.c
+++ b/iop/arcade/accdvd/src/cddrv.c
@@ -18,26 +18,26 @@ static int cddrv_read(iop_file_t *io, void *buf, int cnt);
 static int cddrv_write(iop_file_t *io, void *buf, int cnt);
 static int cddrv_lseek(iop_file_t *io, int offset, int whence);
 static int cddrv_ioctl(iop_file_t *io, int cmd, void *arg);
-static int cddrv_dummy();
 
 static iop_device_ops_t Cddrv_ops = {
-	&cddrv_adddrv,
-	&cddrv_deldrv,
-	&cddrv_dummy,
-	&cddrv_open,
-	&cddrv_close,
-	&cddrv_read,
-	&cddrv_write,
-	&cddrv_lseek,
-	&cddrv_ioctl,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy,
-	&cddrv_dummy};
+	&cddrv_adddrv, // init
+	&cddrv_deldrv, // deinit
+	NOT_SUPPORTED, // format
+	&cddrv_open, // open
+	&cddrv_close, // close
+	&cddrv_read, // read
+	&cddrv_write, // write
+	&cddrv_lseek, // lseek
+	&cddrv_ioctl, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
+};
 
 static iop_device_t Cddrv = {"cdrom", 16u, 0u, "ATAPI_C/DVD-ROM", &Cddrv_ops};
 
@@ -155,11 +155,6 @@ static int cddrv_ioctl(iop_file_t *io, int cmd, void *arg)
 	(void)cmd;
 	(void)arg;
 
-	return -EINVAL;
-}
-
-static int cddrv_dummy()
-{
 	return -EINVAL;
 }
 

--- a/iop/arcade/acuart/src/tty.c
+++ b/iop/arcade/acuart/src/tty.c
@@ -5,8 +5,6 @@
 int acUartWrite(void *buf, int count);
 int acUartRead(void *buf, int count);
 
-int dummy() {return -ENOTSUP;}
-
 static int acuart_read(iop_file_t *f, void *buffer, int size) {
     (void)f;
     return acUartRead(buffer, size);
@@ -17,23 +15,23 @@ static int acuart_write(iop_file_t *f, void *buffer, int size) {
 }
 
 static iop_device_ops_t uart_ops = {
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    &acuart_read,
-    &acuart_write,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
-    (void *)&dummy,
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    NOT_SUPPORTED, // open
+    NOT_SUPPORTED, // close
+    &acuart_read, // read
+    &acuart_write, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
 };
 
 #define DEVNAME "tty"

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -418,29 +418,24 @@ static int fio_getstat(iop_file_t *fd, const char *name, io_stat_t *stat)
     return ret;
 }
 
-static int cdfs_dummy() {
-    DPRINTF("CDFS: dummy function called\n\n");
-    return -EIO;
-}
-
 static iop_device_ops_t fio_ops = {
-    &fio_init,
-    &fio_deinit,
-    (void *)&cdfs_dummy,
-    &fio_open,
-    &fio_close,
-    &fio_read,
-    &fio_write,
-    &fio_lseek,
-    (void *)&cdfs_dummy,
-    (void *)&cdfs_dummy,
-    (void *)&cdfs_dummy,
-    (void *)&cdfs_dummy,
-    &fio_openDir,
-    &fio_closeDir,
-    &fio_dread,
-    &fio_getstat,
-    (void *)&cdfs_dummy,
+    &fio_init, // init
+    &fio_deinit, // deinit
+    NOT_SUPPORTED, // format
+    &fio_open, // open
+    &fio_close, // close
+    &fio_read, // read
+    &fio_write, // write
+    &fio_lseek, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    &fio_openDir, // dopen
+    &fio_closeDir, // dclose
+    &fio_dread, // dread
+    &fio_getstat, // getstat
+    NOT_SUPPORTED, // chstat
 };
 
 static iop_device_t fio_driver = {

--- a/iop/cdvd/xesdrv/src/xesdrv.c
+++ b/iop/cdvd/xesdrv/src/xesdrv.c
@@ -28,8 +28,6 @@ static int esdrv_df_devctl(
 	iomanX_iop_file_t *f, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 static int
 esdrv_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-static int esdrv_df_null();
-static s64 esdrv_df_null_long();
 static int
 esioctl2_func_1(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 static int
@@ -221,33 +219,33 @@ struct DevctlCmdTbl_t
 };
 
 static iomanX_iop_device_ops_t DvrFuncTbl = {
-	&esdrv_df_init,
-	&esdrv_df_exit,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	&esdrv_df_ioctl,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null_long,
-	&esdrv_df_devctl,
-	(void *)&esdrv_df_null,
-	(void *)&esdrv_df_null,
-	&esdrv_df_ioctl2,
+	&esdrv_df_init, // init
+	&esdrv_df_exit, // deinit
+	NOT_SUPPORTED, // format
+	NOT_SUPPORTED, // open
+	NOT_SUPPORTED, // close
+	NOT_SUPPORTED, // read
+	NOT_SUPPORTED, // write
+	NOT_SUPPORTED, // lseek
+	&esdrv_df_ioctl, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
+	NOT_SUPPORTED, // rename
+	NOT_SUPPORTED, // chdir
+	NOT_SUPPORTED, // sync
+	NOT_SUPPORTED, // mount
+	NOT_SUPPORTED, // umount
+	NOT_SUPPORTED_S64, // lseek64
+	&esdrv_df_devctl, // devctl
+	NOT_SUPPORTED, // symlink
+	NOT_SUPPORTED, // readlink
+	&esdrv_df_ioctl2, // ioctl2
 };
 static iomanX_iop_device_t ESDRV = {
 	.name = "es_drv",
@@ -370,16 +368,6 @@ esdrv_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, v
 	WaitSema(sema_id);
 	SignalSema(sema_id);
 	return -EINVAL;
-}
-
-static int esdrv_df_null()
-{
-	return -EUNSUP;
-}
-
-static s64 esdrv_df_null_long()
-{
-	return -EUNSUP;
 }
 
 static void EsAcsSetAaryptorIoMode(void)

--- a/iop/debug/iop_sbusdbg/src/sbus_tty.c
+++ b/iop/debug/iop_sbusdbg/src/sbus_tty.c
@@ -27,8 +27,6 @@ Of course this requires that the EE-side code accept this command and output the
 
 extern void sbus_tty_puts(const char *str);
 
-static int ttyfs_error() { return -EPERM; }
-
 static int ttyfs_init()
 {
     //DBG_puts("SIOTTY: FS Init()\n");
@@ -96,23 +94,23 @@ static int ttyfs_write(iop_file_t *file, void *ptr, int size) {
 
 static iop_device_ops_t fsd_ops =
 {
-    &ttyfs_init,
-    &ttyfs_deinit,
-    (void *)&ttyfs_error,
-    &ttyfs_open,
-    &ttyfs_close,
-	(void *)&ttyfs_error,
-    &ttyfs_write,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-	&ttyfs_dopen,
-    &ttyfs_close,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
+    &ttyfs_init, // init
+    &ttyfs_deinit, // deinit
+    NOT_SUPPORTED, // format
+    &ttyfs_open, // open
+    &ttyfs_close, // close
+    NOT_SUPPORTED, // read
+    &ttyfs_write, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    &ttyfs_dopen, // dopen
+    &ttyfs_close, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
 };
 
 static iop_device_t tty_fsd =

--- a/iop/debug/ppctty/src/tty.c
+++ b/iop/debug/ppctty/src/tty.c
@@ -26,8 +26,6 @@ static int tty_sema = -1;
 
 extern void tty_puts(const char *str);
 
-static int ttyfs_error() { return -EPERM; }
-
 static int ttyfs_init()
 {
     DPRINTF("FS Init()\n");
@@ -44,33 +42,6 @@ static int ttyfs_deinit()
     DPRINTF("FS Deinit()\n");
     DeleteSema(tty_sema);
 	return 0;
-}
-
-static int ttyfs_open(iop_file_t *file, const char *name, int flags)
-{
-    (void)file;
-    (void)name;
-    (void)flags;
-
-    DPRINTF("FS Open()\n");
-	return 0;
-}
-
-static int ttyfs_dopen(iop_file_t *file, const char *name)
-{
-    (void)file;
-    (void)name;
-
-    DPRINTF("FS Dopen()\n");
-    return 0;
-}
-
-static int ttyfs_close(iop_file_t *file)
-{
-    (void)file;
-
-    DPRINTF("FS Close()\n");
-    return(0);
 }
 
 static int ttyfs_write(iop_file_t *file, void *ptr, int size) {
@@ -103,23 +74,23 @@ static int ttyfs_write(iop_file_t *file, void *ptr, int size) {
 
 static iop_device_ops_t fsd_ops =
 {
-    &ttyfs_init,
-    &ttyfs_deinit,
-    (void *)&ttyfs_error,
-    &ttyfs_open,
-    &ttyfs_close,
-	(void *)&ttyfs_error,
-    &ttyfs_write,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-	&ttyfs_dopen,
-    &ttyfs_close,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
-    (void *)&ttyfs_error,
+    &ttyfs_init, // init
+    &ttyfs_deinit, // deinit
+    NOT_SUPPORTED, // format
+    NOT_SUPPORTED, // open
+    NOT_SUPPORTED, // close
+    NOT_SUPPORTED, // read
+    &ttyfs_write, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
 };
 
 static iop_device_t tty_fsd =

--- a/iop/dev9/dev9/src/ps2dev9.c
+++ b/iop/dev9/dev9/src/ps2dev9.c
@@ -122,11 +122,6 @@ static int expbay_init(int sema_attr);
 
 extern struct irx_export_table _exp_dev9;
 
-static int dev9x_dummy(void)
-{
-    return 0;
-}
-
 static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, unsigned int arglen, void *buf, unsigned int buflen)
 {
     (void)f;
@@ -153,33 +148,33 @@ static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, un
 
 static iop_device_ops_t dev9x_ops =
     {
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        &dev9x_devctl,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
-        (void *)&dev9x_dummy,
+        DUMMY_IMPLEMENTATION, // init
+        DUMMY_IMPLEMENTATION, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        NOT_SUPPORTED, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dev9x_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        NOT_SUPPORTED, // ioctl2
 };
 
 static iop_device_t dev9x_device =

--- a/iop/dvrp/dvr/src/dvr.c
+++ b/iop/dvrp/dvr/src/dvr.c
@@ -33,8 +33,6 @@ extern int dvr_df_exit(iomanX_iop_device_t *dev);
 extern int dvr_df_ioctl(iomanX_iop_file_t *f, int cmd, void *param);
 extern int dvr_df_devctl(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvr_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-extern int dvr_df_null();
-extern s64 dvr_df_null_long();
 extern int dvrioctl2_rec_start(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_rec_pause(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_rec_stop(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
@@ -112,33 +110,33 @@ struct DevctlCmdTbl_t
 
 static iomanX_iop_device_ops_t DvrFuncTbl =
     {
-        &dvr_df_init,
-        &dvr_df_exit,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        &dvr_df_ioctl,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null_long,
-        &dvr_df_devctl,
-        (void *)&dvr_df_null,
-        (void *)&dvr_df_null,
-        &dvr_df_ioctl2,
+        &dvr_df_init, // init
+        &dvr_df_exit, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        &dvr_df_ioctl, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dvr_df_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        &dvr_df_ioctl2, // ioctl2
     };
 char TEVENT_BUF[6144];
 char *tevent_p;
@@ -284,16 +282,6 @@ int dvr_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen,
     WaitSema(sema_id);
     SignalSema(sema_id);
     return -EINVAL;
-}
-
-int dvr_df_null()
-{
-    return -EUNSUP;
-}
-
-s64 dvr_df_null_long()
-{
-    return -EUNSUP;
 }
 
 int dvrioctl2_rec_start(

--- a/iop/dvrp/dvrav/src/dvrav.c
+++ b/iop/dvrp/dvrav/src/dvrav.c
@@ -32,8 +32,6 @@ extern int dvrav_df_exit(iomanX_iop_device_t *dev);
 extern int dvrav_df_ioctl(iomanX_iop_file_t *f, int cmd, void *param);
 extern int dvrav_df_devctl(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrav_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-extern int dvrav_df_null();
-extern s64 dvrav_df_null_long();
 extern int avioctl2_select_position(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int avioctl2_get_position(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int avioctl2_position_up(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
@@ -111,33 +109,33 @@ struct DevctlCmdTbl_t
 
 static iomanX_iop_device_ops_t DvrFuncTbl =
     {
-        &dvrav_df_init,
-        &dvrav_df_exit,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        &dvrav_df_ioctl,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null_long,
-        &dvrav_df_devctl,
-        (void *)&dvrav_df_null,
-        (void *)&dvrav_df_null,
-        &dvrav_df_ioctl2,
+        &dvrav_df_init, // init
+        &dvrav_df_exit, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        &dvrav_df_ioctl, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dvrav_df_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        &dvrav_df_ioctl2, // ioctl2
     };
 static iomanX_iop_device_t DVRAV = {
     .name = "dvr_av",
@@ -282,16 +280,6 @@ int dvrav_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int argle
     WaitSema(sema_id);
     SignalSema(sema_id);
     return -EINVAL;
-}
-
-int dvrav_df_null()
-{
-    return -EUNSUP;
-}
-
-s64 dvrav_df_null_long()
-{
-    return -EUNSUP;
 }
 
 int avioctl2_get_tun_offset(

--- a/iop/dvrp/dvrdv/src/dvrdv.c
+++ b/iop/dvrp/dvrdv/src/dvrdv.c
@@ -32,8 +32,6 @@ extern int dvrdv_df_exit(iomanX_iop_device_t *dev);
 extern int dvrdv_df_ioctl(iomanX_iop_file_t *f, int cmd, void *param);
 extern int dvrdv_df_devctl(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrdv_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-extern int dvrdv_df_null();
-extern s64 dvrdv_df_null_long();
 extern int dvrioctl2_dv_dubb_start(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_dv_dubb_stop(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_dv_dubb_rec_start(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
@@ -56,33 +54,33 @@ struct DevctlCmdTbl_t
 };
 static iomanX_iop_device_ops_t DvrFuncTbl =
     {
-        &dvrdv_df_init,
-        &dvrdv_df_exit,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        &dvrdv_df_ioctl,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null_long,
-        &dvrdv_df_devctl,
-        (void *)&dvrdv_df_null,
-        (void *)&dvrdv_df_null,
-        &dvrdv_df_ioctl2,
+        &dvrdv_df_init, // init
+        &dvrdv_df_exit, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        &dvrdv_df_ioctl, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dvrdv_df_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        &dvrdv_df_ioctl2, // ioctl2
     };
 static iomanX_iop_device_t DVR = {
     .name = "dvr_dv",
@@ -231,16 +229,6 @@ int dvrdv_df_ioctl2(
     WaitSema(sema_id);
     SignalSema(sema_id);
     return -EINVAL;
-}
-
-int dvrdv_df_null()
-{
-    return -EUNSUP;
-}
-
-s64 dvrdv_df_null_long()
-{
-    return -EUNSUP;
 }
 
 int dvrioctl2_dv_dubb_start(

--- a/iop/dvrp/dvrfile/src/dvrfile.c
+++ b/iop/dvrp/dvrfile/src/dvrfile.c
@@ -203,33 +203,33 @@ static int dvrf_translator_df_umount(iomanX_iop_file_t *f, const char *fsname)
 }
 
 static iomanX_iop_device_ops_t dvrf_translator_functbl = {
-    dvrf_df_init,
-    dvrf_df_exit,
-    dvrf_translator_df_format,
-    dvrf_translator_df_open,
-    dvrf_df_close,
-    dvrf_df_read,
-    dvrf_df_write,
-    dvrf_df_lseek,
-    dvrf_df_ioctl,
-    dvrf_translator_df_remove,
-    dvrf_translator_df_mkdir,
-    dvrf_translator_df_rmdir,
-    dvrf_translator_df_dopen,
-    dvrf_df_dclose,
-    dvrf_df_dread,
-    dvrf_translator_df_getstat,
-    dvrf_translator_df_chstat,
-    dvrf_translator_df_rename,
-    dvrf_translator_df_chdir,
-    dvrf_translator_df_sync,
-    dvrf_translator_df_mount,
-    dvrf_translator_df_umount,
-    dvrf_df_lseek64,
-    dvrf_translator_df_devctl,
-    dvrf_translator_df_symlink,
-    dvrf_translator_df_readlink,
-    dvrf_df_ioctl2,
+    dvrf_df_init, // init
+    dvrf_df_exit, // deinit
+    dvrf_translator_df_format, // format
+    dvrf_translator_df_open, // open
+    dvrf_df_close, // close
+    dvrf_df_read, // read
+    dvrf_df_write, // write
+    dvrf_df_lseek, // lseek
+    dvrf_df_ioctl, // ioctl
+    dvrf_translator_df_remove, // remove
+    dvrf_translator_df_mkdir, // mkdir
+    dvrf_translator_df_rmdir, // rmdir
+    dvrf_translator_df_dopen, // dopen
+    dvrf_df_dclose, // dclose
+    dvrf_df_dread, // dread
+    dvrf_translator_df_getstat, // getstat
+    dvrf_translator_df_chstat, // chstat
+    dvrf_translator_df_rename, // rename
+    dvrf_translator_df_chdir, // chdir
+    dvrf_translator_df_sync, // sync
+    dvrf_translator_df_mount, // mount
+    dvrf_translator_df_umount, // umount
+    dvrf_df_lseek64, // lseek64
+    dvrf_translator_df_devctl, // devctl
+    dvrf_translator_df_symlink, // symlink
+    dvrf_translator_df_readlink, // readlink
+    dvrf_df_ioctl2, // ioctl2
 };
 
 #define GEN_TRANSLATION_FUNCS(basefuncname, basedevname, shouldbswapformatarg, drvname) \

--- a/iop/dvrp/dvripl/src/dvripl.c
+++ b/iop/dvrp/dvripl/src/dvripl.c
@@ -34,40 +34,38 @@ extern int dvripl_df_exit(iomanX_iop_device_t *dev);
 extern int dvripl_df_ioctl(iomanX_iop_file_t *f, int cmd, void *param);
 extern int dvripl_df_devctl(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvripl_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-extern int dvripl_df_null();
-extern s64 dvripl_df_null_long();
 extern int iplioctl2_update(iomanX_iop_file_t *a1, int cmd, void *arg);
 extern void dvr_ready(int a1, void *a2);
 
 static iomanX_iop_device_ops_t DvrFuncTbl =
     {
-        &dvripl_df_init,
-        &dvripl_df_exit,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_ioctl,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_null_long,
-        &dvripl_df_devctl,
-        &dvripl_df_null,
-        &dvripl_df_null,
-        &dvripl_df_ioctl2,
+        &dvripl_df_init, // init
+        &dvripl_df_exit, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        &dvripl_df_ioctl, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dvripl_df_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        &dvripl_df_ioctl2, // ioctl2
     };
 s32 dvr_ready_flag;
 static iomanX_iop_device_t DVRMAN = {
@@ -198,16 +196,6 @@ int dvripl_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int argl
     WaitSema(sema_id);
     SignalSema(sema_id);
     return -EINVAL;
-}
-
-int dvripl_df_null()
-{
-    return -EUNSUP;
-}
-
-s64 dvripl_df_null_long()
-{
-    return -EUNSUP;
 }
 
 int iplioctl2_update(iomanX_iop_file_t *a1, int cmd, void *arg)

--- a/iop/dvrp/dvrmisc/src/dvrmisc.c
+++ b/iop/dvrp/dvrmisc/src/dvrmisc.c
@@ -33,8 +33,6 @@ extern int dvrmisc_df_exit(iomanX_iop_device_t *dev);
 extern int dvrmisc_df_ioctl(iomanX_iop_file_t *f, int cmd, void *param);
 extern int dvrmisc_df_devctl(iomanX_iop_file_t *a1, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrmisc_df_ioctl2(iomanX_iop_file_t *f, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
-extern int dvrmisc_df_null();
-extern s64 dvrmisc_df_null_long();
 extern int dvrioctl2_nop(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_version(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 extern int dvrioctl2_led_hdd_rec(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
@@ -95,33 +93,33 @@ struct DevctlCmdTbl_t
 };
 static iomanX_iop_device_ops_t DvrFuncTbl =
     {
-        &dvrmisc_df_init,
-        &dvrmisc_df_exit,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_ioctl,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null_long,
-        &dvrmisc_df_devctl,
-        &dvrmisc_df_null,
-        &dvrmisc_df_null,
-        &dvrmisc_df_ioctl2,
+        &dvrmisc_df_init, // init
+        &dvrmisc_df_exit, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+        &dvrmisc_df_ioctl, // ioctl
+        NOT_SUPPORTED, // remove
+        NOT_SUPPORTED, // mkdir
+        NOT_SUPPORTED, // rmdir
+        NOT_SUPPORTED, // dopen
+        NOT_SUPPORTED, // dclose
+        NOT_SUPPORTED, // dread
+        NOT_SUPPORTED, // getstat
+        NOT_SUPPORTED, // chstat
+        NOT_SUPPORTED, // rename
+        NOT_SUPPORTED, // chdir
+        NOT_SUPPORTED, // sync
+        NOT_SUPPORTED, // mount
+        NOT_SUPPORTED, // umount
+        NOT_SUPPORTED_S64, // lseek64
+        &dvrmisc_df_devctl, // devctl
+        NOT_SUPPORTED, // symlink
+        NOT_SUPPORTED, // readlink
+        &dvrmisc_df_ioctl2, // ioctl2
     };
 static iomanX_iop_device_t DVRMISC = {
     .name = "dvr_misc",
@@ -274,16 +272,6 @@ int dvrmisc_df_ioctl2(
     WaitSema(sema_id);
     SignalSema(sema_id);
     return -EINVAL;
-}
-
-int dvrmisc_df_null()
-{
-    return -EUNSUP;
-}
-
-s64 dvrmisc_df_null_long()
-{
-    return -EUNSUP;
 }
 
 int dvrioctl2_nop(iomanX_iop_file_t *a1, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen)

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -261,24 +261,6 @@ static DIR *fs_find_free_dir_structure(void)
 }
 
 //---------------------------------------------------------------------------
-static int fs_dummy(void)
-{
-    M_DEBUG("%s\n", __func__);
-
-    return -EIO;
-}
-
-//---------------------------------------------------------------------------
-static int fs_init(iop_device_t *driver)
-{
-    M_DEBUG("%s\n", __func__);
-
-    (void)driver;
-
-    return 1;
-}
-
-//---------------------------------------------------------------------------
 static int fs_open(iop_file_t *fd, const char *name, int flags, int mode)
 {
     M_DEBUG("%s: %s flags=%X mode=%X\n", __func__, name, flags, mode);
@@ -800,33 +782,33 @@ static int fs_devctl(iop_file_t *fd, const char *name, int cmd, void *arg, unsig
 }
 
 static iop_device_ops_t fs_functarray = {
-    &fs_init,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    &fs_open,
-    &fs_close,
-    &fs_read,
-    &fs_write,
-    &fs_lseek,
-    &fs_ioctl,
-    &fs_remove,
-    &fs_mkdir,
-    &fs_remove,
-    &fs_dopen,
-    &fs_dclose,
-    &fs_dread,
-    &fs_getstat,
-    (void *)&fs_dummy,
-    &fs_rename,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    &fs_lseek64,
-    &fs_devctl,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    &fs_ioctl2,
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    &fs_open, // open
+    &fs_close, // close
+    &fs_read, // read
+    &fs_write, // write
+    &fs_lseek, // lseek
+    &fs_ioctl, // ioctl
+    &fs_remove, // remove
+    &fs_mkdir, // mkdir
+    &fs_remove, // rmdir
+    &fs_dopen, // dopen
+    &fs_dclose, // dclose
+    &fs_dread, // dread
+    &fs_getstat, // getstat
+    NOT_SUPPORTED, // chstat
+    &fs_rename, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    &fs_lseek64, // lseek64
+    &fs_devctl, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    &fs_ioctl2, // ioctl2
 };
 static iop_device_t fs_driver = {
     "mass",

--- a/iop/fs/devfs/src/devfs.c
+++ b/iop/fs/devfs/src/devfs.c
@@ -325,36 +325,6 @@ devfs_device_t *devfs_find_deviceid(HDEV hDev)
    return NULL;
 }
 
-/** Dummy ioman handler
- * @returns Always returns -1
- */
-int devfs_dummy(void)
-
-{
-   printf("devfs_dummy\n");
-   return -EPERM;
-}
-
-/** ioman init handler
- * @returns Always returns 0
- */
-int devfs_init(iop_device_t *dev)
-
-{
-   printf("devfs_init dev=%p\n", dev);
-   return 0;
-}
-
-/** ioman deinit handler
- * @returns Always returns 0
- */
-int devfs_deinit(iop_device_t *dev)
-
-{
-   printf("devfs_deinit dev=%p\n", dev);
-   return 0;
-}
-
 /** ioman open handler
  * @oaram file: Pointer to the ioman file structure
  * @param name: Name of file to open
@@ -1010,33 +980,33 @@ int devfs_getstat(iop_file_t *file, const char *name, iox_stat_t *stat)
 }
  
 static iop_device_ops_t devfs_ops = {
-  &devfs_init,
-  &devfs_deinit,
-  (void *)&devfs_dummy,
-  &devfs_open,
-  &devfs_close,
-  &devfs_read,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  &devfs_ioctl,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  &devfs_dopen,
-  &devfs_dclose,
-  &devfs_dread,
-  &devfs_getstat,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  (void *)&devfs_dummy,
-  &devfs_ioctl2,
+  DUMMY_IMPLEMENTATION, // init
+  DUMMY_IMPLEMENTATION, // deinit
+  NOT_SUPPORTED, // format
+  &devfs_open, // open
+  &devfs_close, // close
+  &devfs_read, // read
+  NOT_SUPPORTED, // write
+  NOT_SUPPORTED, // lseek
+  &devfs_ioctl, // ioctl
+  NOT_SUPPORTED, // remove
+  NOT_SUPPORTED, // mkdir
+  NOT_SUPPORTED, // rmdir
+  &devfs_dopen, // dopen
+  &devfs_dclose, // dclose
+  &devfs_dread, // dread
+  &devfs_getstat, // getstat
+  NOT_SUPPORTED, // chstat
+  NOT_SUPPORTED, // rename
+  NOT_SUPPORTED, // chdir
+  NOT_SUPPORTED, // sync
+  NOT_SUPPORTED, // mount
+  NOT_SUPPORTED, // umount
+  NOT_SUPPORTED_S64, // lseek64
+  NOT_SUPPORTED, // devctl
+  NOT_SUPPORTED, // symlink
+  NOT_SUPPORTED, // readlink
+  &devfs_ioctl2, // ioctl2
 };
 
 static iop_device_t devfs_device = {

--- a/iop/fs/eromdrv/src/eromdrv.c
+++ b/iop/fs/eromdrv/src/eromdrv.c
@@ -42,9 +42,7 @@ typedef struct erom_fdpriv_
 	u32 m_xordata_size;
 } erom_fdpriv_t;
 
-static int erom_nulldev(void);
 static int erom_op_close(iop_file_t *f);
-static int erom_op_write(iop_file_t *f, void *ptr, int size);
 static int erom_op_lseek(iop_file_t *f, int pos, int mode);
 static int erom_op_open(iop_file_t *f, const char *name, int mode);
 static int erom_op_read(iop_file_t *f, void *ptr, int size);
@@ -54,23 +52,23 @@ static erom_info_t *get_erom_info(const u32 *erom_start, const u32 *erom_end, er
 static const erom_dentry_t *get_direntry_by_name(erom_info_t *info, const char *name);
 
 static iop_device_ops_t erom_devops = {
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	erom_op_open,
-	erom_op_close,
-	erom_op_read,
-	erom_op_write,
-	erom_op_lseek,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
-	(void *)erom_nulldev,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	erom_op_open, // open
+	erom_op_close, // close
+	erom_op_read, // read
+	NOT_SUPPORTED, // write
+	erom_op_lseek, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
 };
 
 static iop_device_t erom_dev = {
@@ -85,11 +83,6 @@ static erom_fdpriv_t erom_fdpriv;
 static erom_info_t erom_info;
 static const erom_dentry_t *erom_dentry;
 
-static int erom_nulldev(void)
-{
-	return 0;
-}
-
 static int erom_op_close(iop_file_t *f)
 {
 	(void)f;
@@ -97,15 +90,6 @@ static int erom_op_close(iop_file_t *f)
 		return -EBADF;
 	erom_dentry = NULL;
 	return 0;
-}
-
-static int erom_op_write(iop_file_t *f, void *ptr, int size)
-{
-	(void)f;
-	(void)ptr;
-	(void)size;
-
-	return -EIO;
 }
 
 static int erom_op_lseek(iop_file_t *f, int pos, int mode)

--- a/iop/fs/fakehost/src/fakehost.c
+++ b/iop/fs/fakehost/src/fakehost.c
@@ -104,27 +104,6 @@ int realfd( iop_io_file_t *f )
 	return (int) f->privdata;
 }
 
-/** Dummy function, for where needed.
- * @ingroup fakehost
- */
-int dummy()
-{
-	M_DEBUG("dummy function called\n");
-	return -EIO;
-}
-
-/** Initialise fs driver.
- * @ingroup fakehost
- *
- * @param driver  io_device pointer to device
- * @return Status (0=successful).
- */
-int fd_initialize( iop_io_device_t *driver)
-{
-	M_PRINTF( "initializing '%s' file driver.\n", driver->name );
-	return 0;
-}
-
 /** Handle open request.
  * @ingroup fakehost
  *
@@ -197,23 +176,23 @@ int fd_lseek( iop_io_file_t *fd, int offset, int whence)
 
 // Function array for fileio structure.
 static iop_io_device_ops_t functions = {
-	&fd_initialize,
-	(void *)&dummy,
-	(void *)&dummy,
-	&fd_open,
-	&fd_close,
-	&fd_read,
-	(void *)&dummy,
-	&fd_lseek,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
-	(void *)&dummy,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	&fd_open, // open
+	&fd_close, // close
+	&fd_read, // read
+	NOT_SUPPORTED, // write
+	&fd_lseek, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
 };
 
 // FileIO structure.

--- a/iop/fs/http/src/ps2http.c
+++ b/iop/fs/http/src/ps2http.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <ioman_mod.h>
 #include <sysmem.h>
+#include <ioman.h>
 
 #include "ps2ip.h"
 
@@ -348,24 +349,6 @@ const char *resolveAddress( struct sockaddr_in *server, const char * url, char *
 }
 
 /**
- * Any calls we don't implement calls dummy.
- */
-int httpDummy()
-{
-	M_PRINTF("dummy function called\n");
-	return -EIO;
-}
-
-int httpInitialize(iop_io_device_t *driver)
-{
-	(void)driver;
-
-	M_PRINTF("filesystem driver initialized\n");
-
-	return 0;
-}
-
-/**
  * Open has the most work to do in the file driver.  It must:
  *
  *  1. Find a free file Handle.
@@ -500,23 +483,23 @@ int httpLseek(iop_io_file_t *f, int offset, int mode)
 
 
 static iop_io_device_ops_t ps2httpOps = {
-	&httpInitialize,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	&httpOpen,
-	&httpClose,
-	&httpRead,
-	(void *)&httpDummy,
-	&httpLseek,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
-	(void *)&httpDummy,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	&httpOpen, // open
+	&httpClose, // close
+	&httpRead, // read
+	NOT_SUPPORTED, // write
+	&httpLseek, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
 };
 
 static iop_io_device_t ps2httpDev = {

--- a/iop/fs/romdrv/src/romdrv.c
+++ b/iop/fs/romdrv/src/romdrv.c
@@ -42,34 +42,32 @@ static struct RomFileSlot fileSlots[ROMDRV_MAX_FILES];
 
 /* Function prototypes */
 static int init(void);
-static int romUnsupported(void);
-static int romInit(iop_device_t *device);
 static int romOpen(iop_file_t *fd, const char *path, int mode);
 static int romClose(iop_file_t *);
 static int romRead(iop_file_t *fd, void *buffer, int size);
-static int romWrite(iop_file_t *fd, void *buffer, int size);
 static int romLseek(iop_file_t *fd, int offset, int whence);
 static struct RomImg *romGetImageStat(const void *start, const void *end, struct RomImg *ImageStat);
 static struct RomdirFileStat *GetFileStatFromImage(const struct RomImg *ImageStat, const char *filename, struct RomdirFileStat *stat);
 
 static iop_device_ops_t ops = {
-    &romInit,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    &romOpen,
-    &romClose,
-    &romRead,
-    &romWrite,
-    &romLseek,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported,
-    (void *)&romUnsupported};
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    &romOpen, // open
+    &romClose, // close
+    &romRead, // read
+    NOT_SUPPORTED, // write
+    &romLseek, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
+};
 
 static iop_device_t DeviceOps = {
     "rom",
@@ -107,18 +105,6 @@ static int init(void)
     memset(fileSlots, 0, sizeof(fileSlots));
     // Add DEV2 (Boot ROM) as rom0. Unlike ROMDRV v1.1, the code for DEV1 is in the ADDDRV module.
     romGetImageStat((const void *)0xbfc00000, (const void *)0xbfc40000, &images[0]);
-    return 0;
-}
-
-static int romUnsupported(void)
-{
-    return 0;
-}
-
-static int romInit(iop_device_t *device)
-{
-    (void)device;
-
     return 0;
 }
 
@@ -263,15 +249,6 @@ static int romRead(iop_file_t *fd, void *buffer, int size)
     slot->offset += size;
 
     return size;
-}
-
-static int romWrite(iop_file_t *fd, void *buffer, int size)
-{
-    (void)fd;
-    (void)buffer;
-    (void)size;
-
-    return -EIO;
 }
 
 static int romLseek(iop_file_t *fd, int offset, int whence)

--- a/iop/fs/subfile/src/subfile.c
+++ b/iop/fs/subfile/src/subfile.c
@@ -16,7 +16,6 @@
 IRX_ID(MODNAME, 2, 1);
 // Based on the module from PBPX-95216
 
-static int subfile_op_nulldev(void);
 static int subfile_op_open(iop_file_t *f, const char *name, int mode);
 static int subfile_op_close(iop_file_t *f);
 static int subfile_op_read(iop_file_t *f, void *ptr, int size);
@@ -31,23 +30,23 @@ typedef struct subfile_priv_fd_
 } subfile_priv_fd_t;
 
 static iop_device_ops_t subfile_devops = {
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	subfile_op_open,
-	subfile_op_close,
-	subfile_op_read,
-	(void *)subfile_op_nulldev,
-	subfile_op_lseek,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
-	(void *)subfile_op_nulldev,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	subfile_op_open, // open
+	subfile_op_close, // close
+	subfile_op_read, // read
+	NOT_SUPPORTED, // write
+	subfile_op_lseek, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
 };
 static iop_device_t subfile_dev = {
 	"subfile",
@@ -158,11 +157,6 @@ static int subfile_op_open(iop_file_t *f, const char *name, int mode)
 	subfile_info[i].m_curpos = 0;
 	CpuResumeIntr(state);
 	f->privdata = &subfile_info[i];
-	return 0;
-}
-
-static int subfile_op_nulldev(void)
-{
 	return 0;
 }
 

--- a/iop/fs/vfat/src/fs_driver.c
+++ b/iop/fs/vfat/src/fs_driver.c
@@ -228,14 +228,6 @@ static void fs_reset(void)
 static int fs_inited = 0;
 
 //---------------------------------------------------------------------------
-static int fs_dummy(void)
-{
-    M_DEBUG("%s\n", __func__);
-
-    return -EIO;
-}
-
-//---------------------------------------------------------------------------
 static int fs_init(iop_device_t *driver)
 {
     (void)driver;
@@ -839,7 +831,7 @@ int fs_ioctl(iop_file_t *fd, int cmd, void *data)
             break;
 #endif
         default:
-            ret = fs_dummy();
+            ret = -EIO;
     }
 
     _fs_unlock();
@@ -993,7 +985,7 @@ static int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, 
             break;
         }
         default:
-            ret = fs_dummy();
+            ret = -EIO;;
     }
 
     _fs_unlock();
@@ -1003,40 +995,40 @@ static int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, 
 
 #ifndef WIN32
 static iop_device_ops_t fs_functarray = {
-    &fs_init,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    &fs_open,
-    &fs_close,
-    &fs_read,
-    &fs_write,
-    &fs_lseek,
-    &fs_ioctl,
-    &fs_remove,
-    &fs_mkdir,
-    &fs_rmdir,
-    &fs_dopen,
-    &fs_dclose,
-    &fs_dread,
-    &fs_getstat,
-    (void *)&fs_dummy,
-    &fs_rename,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
+    &fs_init, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    &fs_open, // open
+    &fs_close, // close
+    &fs_read, // read
+    &fs_write, // write
+    &fs_lseek, // lseek
+    &fs_ioctl, // ioctl
+    &fs_remove, // remove
+    &fs_mkdir, // mkdir
+    &fs_rmdir, // rmdir
+    &fs_dopen, // dopen
+    &fs_dclose, // dclose
+    &fs_dread, // dread
+    &fs_getstat, // getstat
+    NOT_SUPPORTED, // chstat
+    &fs_rename, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    NOT_SUPPORTED_S64, // lseek64
 #ifndef BUILDING_IEEE1394_DISK
-    &fs_devctl,
+    &fs_devctl, // devctl
 #else
-    (void *)&fs_dummy,
+    NOT_SUPPORTED, // devctl
 #endif /* BUILDING_IEEE1394_DISK */
-    (void *)&fs_dummy,
-    (void *)&fs_dummy,
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
 #if !defined(BUILDING_IEEE1394_DISK) && !defined(BUILDING_USBHDFSD)
-    &fs_ioctl2,
+    &fs_ioctl2, // ioctl2
 #else
-    (void *)&fs_dummy,
+    NOT_SUPPORTED, // ioctl2
 #endif /* BUILDING_IEEE1394_DISK */
 };
 static iop_device_t fs_driver = {

--- a/iop/hdd/apa/src/hdd.c
+++ b/iop/hdd/apa/src/hdd.c
@@ -39,33 +39,33 @@ IRX_ID("hdd_driver", APA_MODVER_MAJOR, APA_MODVER_MINOR);
 #endif
 
 static iomanX_iop_device_ops_t hddOps={
-	&hddInit,
-	&hddDeinit,
-	&hddFormat,
-	&hddOpen,
-	&hddClose,
-	&hddRead,
-	&hddWrite,
-	&hddLseek,
-	(void*)&hddUnsupported,
-	&hddRemove,
-	(void*)&hddUnsupported,
-	(void*)&hddUnsupported,
-	&hddDopen,
-	&hddClose,
-	&hddDread,
-	&hddGetStat,
-	(void*)&hddUnsupported,
-	&hddReName,
-	(void*)&hddUnsupported,
-	(void*)&hddUnsupported,
-	hddMount,
-	hddUmount,
-	(void*)&hddUnsupported,
-	&hddDevctl,
-	(void*)&hddUnsupported,
-	(void*)&hddUnsupported,
-	&hddIoctl2,
+	&hddInit, // init
+	&hddDeinit, // deinit
+	&hddFormat, // format
+	&hddOpen, // open
+	&hddClose, // close
+	&hddRead, // read
+	&hddWrite, // write
+	&hddLseek, // lseek
+	NOT_SUPPORTED, // ioctl
+	&hddRemove, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	&hddDopen, // dopen
+	&hddClose, // dclose
+	&hddDread, // dread
+	&hddGetStat, // getstat
+	NOT_SUPPORTED, // chstat
+	&hddReName, // rename
+	NOT_SUPPORTED, // chdir
+	NOT_SUPPORTED, // sync
+	hddMount, // mount
+	hddUmount, // umount
+	NOT_SUPPORTED_S64, // lseek64
+	&hddDevctl, // devctl
+	NOT_SUPPORTED, // symlink
+	NOT_SUPPORTED, // readlink
+	&hddIoctl2, // ioctl2
 };
 static iomanX_iop_device_t hddFioDev={
 	"hdd",

--- a/iop/hdd/apa/src/hdd_fio.c
+++ b/iop/hdd/apa/src/hdd_fio.c
@@ -1171,10 +1171,3 @@ int hddUmount(iomanX_iop_file_t *f, const char *fsname)
     return rv;
 }
 #endif
-
-int hddUnsupported(iomanX_iop_file_t *f)
-{
-	(void)f;
-
-	return -EPERM;
-}

--- a/iop/hdd/apa/src/hdd_fio.h
+++ b/iop/hdd/apa/src/hdd_fio.h
@@ -31,10 +31,8 @@ int hddDevctl(iomanX_iop_file_t *f, const char *devname, int cmd, void *arg, uns
 int hddMount(iomanX_iop_file_t *f, const char *fsname, const char *devname, int flag, void *arg, int arglen);
 int hddUmount(iomanX_iop_file_t *f, const char *fsname);
 #else
-#define hddMount ((void*)&hddUnsupported)
-#define hddUmount ((void*)&hddUnsupported)
+#define hddMount NOT_SUPPORTED
+#define hddUmount NOT_SUPPORTED
 #endif
-
-int hddUnsupported(iomanX_iop_file_t *f);
 
 #endif /* _HDD_FIO_H */

--- a/iop/hdd/fsck/src/fsck.c
+++ b/iop/hdd/fsck/src/fsck.c
@@ -894,12 +894,6 @@ fsck_thread_end:
     SetEventFlag(fsckEventFlagID, 1);
 }
 
-// 0x0000264c
-static int FsckUnsupported(void)
-{
-    return 0;
-}
-
 // 0x00000340
 static int fsckCheckBitmap(pfs_mount_t *mount, void *buffer)
 {
@@ -1217,33 +1211,34 @@ static int FsckIoctl2(iomanX_iop_file_t *fd, int cmd, void *arg, unsigned int ar
 }
 
 static iomanX_iop_device_ops_t FsckDeviceOps = {
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    NULL,
-    &FsckOpen,
-    &FsckClose,
-    NULL,
-    NULL,
-    NULL,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    (void *)&FsckUnsupported,
-    &FsckIoctl2};
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    &FsckOpen, // open
+    &FsckClose, // close
+    NOT_SUPPORTED, // read
+    NOT_SUPPORTED, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
+    NOT_SUPPORTED, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    NOT_SUPPORTED_S64, // lseek64
+    NOT_SUPPORTED, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    &FsckIoctl2, // ioctl2
+};
 
 static iomanX_iop_device_t FsckDevice = {
     "fsck",

--- a/iop/hdd/fssk/src/fssk.c
+++ b/iop/hdd/fssk/src/fssk.c
@@ -562,11 +562,6 @@ end2:
     SetEventFlag(fsskEventFlagID, 1);
 }
 
-static int FsskUnsupported(void)
-{
-    return 0;
-}
-
 static int FsskOpen(iomanX_iop_file_t *fd, const char *name, int flags, int mode)
 {
     int blockfd, result;
@@ -720,33 +715,34 @@ static int FsskIoctl2(iomanX_iop_file_t *fd, int cmd, void *arg, unsigned int ar
 }
 
 static iomanX_iop_device_ops_t FsskDeviceOps = {
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    NULL,
-    &FsskOpen,
-    &FsskClose,
-    NULL,
-    NULL,
-    NULL,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    (void *)&FsskUnsupported,
-    &FsskIoctl2};
+    DUMMY_IMPLEMENTATION, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    &FsskOpen, // open
+    &FsskClose, // close
+    NOT_SUPPORTED, // read
+    NOT_SUPPORTED, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
+    NOT_SUPPORTED, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    NOT_SUPPORTED_S64, // lseek64
+    NOT_SUPPORTED, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    &FsskIoctl2, // ioctl2
+};
 
 static iomanX_iop_device_t FsskDevice = {
     "fssk",

--- a/iop/hdd/hdck/src/hdck.c
+++ b/iop/hdd/hdck/src/hdck.c
@@ -27,40 +27,40 @@ IRX_ID("hdck", APA_MODVER_MAJOR, APA_MODVER_MINOR);
 
 // Function prototypes
 static int HdckInit(iomanX_iop_device_t *device);
-static int HdckUnsupported(void);
 static int HdckDevctl(iomanX_iop_file_t *fd, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen);
 
 static u8 IOBuffer[128 * 512];
 static u8 IOBuffer2[128 * 512];
 
 static iomanX_iop_device_ops_t HdckDeviceOps = {
-    &HdckInit,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    (void *)&HdckUnsupported,
-    &HdckDevctl,
-    NULL,
-    NULL,
-    NULL};
+    &HdckInit, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    NOT_SUPPORTED, // open
+    NOT_SUPPORTED, // close
+    NOT_SUPPORTED, // read
+    NOT_SUPPORTED, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
+    NOT_SUPPORTED, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    NOT_SUPPORTED_S64, // lseek64
+    &HdckDevctl, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    NOT_SUPPORTED, // ioctl2
+};
 
 static iomanX_iop_device_t HdckDevice = {
     "hdck",
@@ -96,11 +96,6 @@ static struct HdckPrivateData PrivateData = {
     0,
     0,
     0};
-
-static int HdckUnsupported(void)
-{
-    return -EPERM;
-}
 
 static int HdckInit(iomanX_iop_device_t *device)
 {

--- a/iop/hdd/hdsk/src/hdsk.c
+++ b/iop/hdd/hdsk/src/hdsk.c
@@ -592,11 +592,6 @@ static int HdskInit(iomanX_iop_device_t *device)
     return 0;
 }
 
-static int HdskUnsupported(void)
-{
-    return -EPERM;
-}
-
 int BitmapUsed;
 u32 TotalCopied;
 struct hdskBitmap hdskBitmap[HDSK_BITMAP_SIZE];
@@ -729,33 +724,33 @@ static int HdskDevctl(iomanX_iop_file_t *fd, const char *name, int cmd, void *ar
 }
 
 static iomanX_iop_device_ops_t HdskDeviceOps = {
-    &HdskInit,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    &HdskDevctl,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
-    (void *)&HdskUnsupported,
+    &HdskInit, // init
+    DUMMY_IMPLEMENTATION, // deinit
+    NOT_SUPPORTED, // format
+    NOT_SUPPORTED, // open
+    NOT_SUPPORTED, // close
+    NOT_SUPPORTED, // read
+    NOT_SUPPORTED, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
+    NOT_SUPPORTED, // rename
+    NOT_SUPPORTED, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    NOT_SUPPORTED_S64, // lseek64
+    &HdskDevctl, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    NOT_SUPPORTED, // ioctl2
 };
 
 static iomanX_iop_device_t HdskDevice = {

--- a/iop/hdd/pfs/src/pfs.c
+++ b/iop/hdd/pfs/src/pfs.c
@@ -36,33 +36,33 @@ IRX_ID("pfs_driver", PFS_MAJOR, PFS_MINOR);
 //	Globals
 
 static iomanX_iop_device_ops_t pfsOps = {
-	&pfsFioInit,
-	&pfsFioDeinit,
-	&pfsFioFormat,
-	&pfsFioOpen,
-	&pfsFioClose,
-	&pfsFioRead,
-	&pfsFioWrite,
-	&pfsFioLseek,
-	&pfsFioIoctl,
-	&pfsFioRemove,
-	&pfsFioMkdir,
-	&pfsFioRmdir,
-	&pfsFioDopen,
-	&pfsFioClose,
-	&pfsFioDread,
-	&pfsFioGetstat,
-	&pfsFioChstat,
-	&pfsFioRename,
-	&pfsFioChdir,
-	&pfsFioSync,
-	&pfsFioMount,
-	&pfsFioUmount,
-	&pfsFioLseek64,
-	&pfsFioDevctl,
-	&pfsFioSymlink,
-	&pfsFioReadlink,
-	&pfsFioIoctl2,
+	&pfsFioInit, // init
+	&pfsFioDeinit, // deinit
+	&pfsFioFormat, // format
+	&pfsFioOpen, // open
+	&pfsFioClose, // close
+	&pfsFioRead, // read
+	&pfsFioWrite, // write
+	&pfsFioLseek, // lseek
+	&pfsFioIoctl, // ioctl
+	&pfsFioRemove, // remove
+	&pfsFioMkdir, // mkdir
+	&pfsFioRmdir, // rmdir
+	&pfsFioDopen, // dopen
+	&pfsFioClose, // dclose
+	&pfsFioDread, // dread
+	&pfsFioGetstat, // getstat
+	&pfsFioChstat, // chstat
+	&pfsFioRename, // rename
+	&pfsFioChdir, // chdir
+	&pfsFioSync, // sync
+	&pfsFioMount, // mount
+	&pfsFioUmount, // umount
+	&pfsFioLseek64, // lseek64
+	&pfsFioDevctl, // devctl
+	&pfsFioSymlink, // symlink
+	&pfsFioReadlink, // readlink
+	&pfsFioIoctl2, // ioctl2
 };
 
 static iomanX_iop_device_t pfsFioDev = {

--- a/iop/kernel/include/ioman.h
+++ b/iop/kernel/include/ioman.h
@@ -16,6 +16,7 @@
 #ifndef __IOMAN_H__
 #define __IOMAN_H__
 
+#include <errno.h>
 #include <types.h>
 #include <irx.h>
 #include <io_common.h>
@@ -69,6 +70,15 @@ typedef struct _iop_device {
 	const char *desc;
 	struct _iop_device_ops *ops;
 } iop_device_t;
+
+static inline int not_supported_int(void) {return -ENOTSUP;}
+static inline signed long long not_supported_s64(void) {return -ENOTSUP;}
+static inline int dummy_implementation_int(void) { return 0; }
+static inline signed long long dummy_implementation_s64(void) { return 0; }
+#define NOT_SUPPORTED (void*)&not_supported_int
+#define NOT_SUPPORTED_S64 (void*)&not_supported_s64
+#define DUMMY_IMPLEMENTATION (void*)&dummy_implementation_int
+#define DUMMY_IMPLEMENTATION_S64 (void*)&dummy_implementation_s64
 
 typedef struct _iop_device_ops {
 	int	(*init)(iop_device_t *);

--- a/iop/kernel/include/iomanX.h
+++ b/iop/kernel/include/iomanX.h
@@ -20,6 +20,7 @@
 #ifdef _IOP
 #include <irx.h>
 #endif
+#include <errno.h>
 #include <stdarg.h>
 #include <io_common.h>
 #include <iox_stat.h>
@@ -86,6 +87,14 @@ typedef struct _iomanX_iop_device {
 	const char *desc;
 	struct _iomanX_iop_device_ops *ops;
 } iomanX_iop_device_t;
+static inline int not_supported_int(void) {return -ENOTSUP;}
+static inline signed long long not_supported_s64(void) {return -ENOTSUP;}
+static inline int dummy_implementation_int(void) { return 0; }
+static inline signed long long dummy_implementation_s64(void) { return 0; }
+#define NOT_SUPPORTED (void*)&not_supported_int
+#define NOT_SUPPORTED_S64 (void*)&not_supported_s64
+#define DUMMY_IMPLEMENTATION (void*)&dummy_implementation_int
+#define DUMMY_IMPLEMENTATION_S64 (void*)&dummy_implementation_s64
 
 typedef struct _iomanX_iop_device_ops {
 	int	(*init)(iomanX_iop_device_t *);

--- a/iop/network/smbman/src/smb_fio.c
+++ b/iop/network/smbman/src/smb_fio.c
@@ -26,33 +26,34 @@ int smbman_io_sema;
 
 // driver ops func tab
 static iop_device_ops_t smbman_ops = {
-    &smb_init,
-    &smb_deinit,
-    (void *)&smb_dummy,
-    &smb_open,
-    &smb_close,
-    &smb_read,
-    &smb_write,
-    &smb_lseek,
-    (void *)&smb_dummy,
-    &smb_remove,
-    &smb_mkdir,
-    &smb_rmdir,
-    &smb_dopen,
-    &smb_dclose,
-    &smb_dread,
-    &smb_getstat,
-    (void *)&smb_dummy,
-    &smb_rename,
-    &smb_chdir,
-    (void *)&smb_dummy,
-    (void *)&smb_dummy,
-    (void *)&smb_dummy,
-    &smb_lseek64,
-    &smb_devctl,
-    (void *)&smb_dummy,
-    (void *)&smb_dummy,
-    (void *)&smb_dummy};
+    &smb_init, // init
+    &smb_deinit, // deinit
+    NOT_SUPPORTED, // format
+    &smb_open, // open
+    &smb_close, // close
+    &smb_read, // read
+    &smb_write, // write
+    &smb_lseek, // lseek
+    NOT_SUPPORTED, // ioctl
+    &smb_remove, // remove
+    &smb_mkdir, // mkdir
+    &smb_rmdir, // rmdir
+    &smb_dopen, // dopen
+    &smb_dclose, // dclose
+    &smb_dread, // dread
+    &smb_getstat, // getstat
+    NOT_SUPPORTED, // chstat
+    &smb_rename, // rename
+    &smb_chdir, // chdir
+    NOT_SUPPORTED, // sync
+    NOT_SUPPORTED, // mount
+    NOT_SUPPORTED, // umount
+    &smb_lseek64, // lseek64
+    &smb_devctl, // devctl
+    NOT_SUPPORTED, // symlink
+    NOT_SUPPORTED, // readlink
+    NOT_SUPPORTED, // ioctl2
+};
 
 // driver descriptor
 static iop_device_t smbdev = {
@@ -204,12 +205,6 @@ static void keepalive_thread(void *args)
 
         SignalSema(smbman_io_sema);
     }
-}
-
-//--------------------------------------------------------------
-int smb_dummy(void)
-{
-    return -EIO;
 }
 
 //--------------------------------------------------------------

--- a/iop/network/smbman/src/smb_fio.h
+++ b/iop/network/smbman/src/smb_fio.h
@@ -8,7 +8,6 @@
 
 // smb driver ops functions prototypes
 int smb_initdev(void);
-int smb_dummy(void);
 int smb_init(iop_device_t *iop_dev);
 int smb_deinit(iop_device_t *dev);
 int smb_open(iop_file_t *f, const char *filename, int flags, int mode);

--- a/iop/network/udptty/src/udptty.c
+++ b/iop/network/udptty/src/udptty.c
@@ -41,27 +41,26 @@ static int tty_init(iop_device_t *device);
 static int tty_deinit(iop_device_t *device);
 static int tty_stdout_fd(void);
 static int tty_write(iop_file_t *file, void *buf, size_t size);
-static int tty_error(void);
 
 /* device ops */
 static iop_device_ops_t tty_ops = {
-    tty_init,
-    tty_deinit,
-    (void *)tty_error,
-    (void *)tty_stdout_fd,
-    (void *)tty_stdout_fd,
-    (void *)tty_error,
-    (void *)tty_write,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
+    tty_init, // init
+    tty_deinit, // deinit
+    NOT_SUPPORTED, // format
+    (void *)tty_stdout_fd, // open
+    (void *)tty_stdout_fd, // close
+    NOT_SUPPORTED, // read
+    (void *)tty_write, // write
+    NOT_SUPPORTED, // lseek
+    NOT_SUPPORTED, // ioctl
+    NOT_SUPPORTED, // remove
+    NOT_SUPPORTED, // mkdir
+    NOT_SUPPORTED, // rmdir
+    NOT_SUPPORTED, // dopen
+    NOT_SUPPORTED, // dclose
+    NOT_SUPPORTED, // dread
+    NOT_SUPPORTED, // getstat
+    NOT_SUPPORTED, // chstat
 };
 
 /* device descriptor */
@@ -279,9 +278,4 @@ static int tty_write(iop_file_t *file, void *buf, size_t size)
     SignalSema(tty_sema);
 
     return res;
-}
-
-static int tty_error(void)
-{
-    return -EIO;
 }

--- a/iop/system/ioman/src/ioman.c
+++ b/iop/system/ioman/src/ioman.c
@@ -36,6 +36,8 @@ IRX_ID("IO/File_Manager", 1, 1);
 
 #include "errno.h"
 
+#include <ioman.h>
+
 #define MAX_DEVICES 16
 #define MAX_FILES   16
 
@@ -50,29 +52,24 @@ static int should_print_known_devices = 1;
 extern struct irx_export_table _exp_ioman;
 #endif
 
-static int tty_noop()
-{
-	return 0;
-}
-
 iop_io_device_ops_t tty_dev_operations = {
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
-	&tty_noop,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	NOT_SUPPORTED, // open
+	NOT_SUPPORTED, // close
+	NOT_SUPPORTED, // read
+	NOT_SUPPORTED, // write
+	NOT_SUPPORTED, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
 };
 
 iop_io_device_t tty_device = {

--- a/iop/system/iomanx/src/iomanX.c
+++ b/iop/system/iomanx/src/iomanX.c
@@ -85,33 +85,33 @@ struct ioman_dev_listentry
 static int showdrvflag = 1;
 #ifndef IOMANX_ENABLE_LEGACY_IOMAN_HOOK
 static iomanX_iop_device_ops_t dev_tty_dev_operations = {
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	(void *)&tty_noop,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
+	DUMMY_IMPLEMENTATION, // init
+	DUMMY_IMPLEMENTATION, // deinit
+	NOT_SUPPORTED, // format
+	NOT_SUPPORTED, // open
+	NOT_SUPPORTED, // close
+	NOT_SUPPORTED, // read
+	NOT_SUPPORTED, // write
+	NOT_SUPPORTED, // lseek
+	NOT_SUPPORTED, // ioctl
+	NOT_SUPPORTED, // remove
+	NOT_SUPPORTED, // mkdir
+	NOT_SUPPORTED, // rmdir
+	NOT_SUPPORTED, // dopen
+	NOT_SUPPORTED, // dclose
+	NOT_SUPPORTED, // dread
+	NOT_SUPPORTED, // getstat
+	NOT_SUPPORTED, // chstat
+	NOT_SUPPORTED, // rename
+	NOT_SUPPORTED, // chdir
+	NOT_SUPPORTED, // sync
+	NOT_SUPPORTED, // mount
+	NOT_SUPPORTED, // umount
+	NOT_SUPPORTED_S64, // lseek64
+	NOT_SUPPORTED, // devctl
+	NOT_SUPPORTED, // symlink
+	NOT_SUPPORTED, // readlink
+	NOT_SUPPORTED, // ioctl2
 };
 static iomanX_iop_device_t dev_tty = {
 	"tty",
@@ -1080,13 +1080,6 @@ static const char *parsefile(const char *path, iomanX_iop_device_t **p_device, i
 }
 
 // Unofficial: unused "io request for unsupported operation" func removed
-
-#ifndef IOMANX_ENABLE_LEGACY_IOMAN_HOOK
-static int tty_noop(void)
-{
-	return 0;
-}
-#endif
 
 int iomanX_AddDrv(iomanX_iop_device_t *device)
 {

--- a/iop/usb/keyboard/src/ps2kbd.c
+++ b/iop/usb/keyboard/src/ps2kbd.c
@@ -979,12 +979,6 @@ void ps2kbd_ioctl_setrepeatrate(u32 rate)
   kbd_repeatrate = rate;
 }
 
-int fio_dummy()
-{
-  //printf("fio_dummy()\n");
-  return -EIO;
-}
-
 int fio_init(iop_device_t *driver)
 {
   (void)driver;
@@ -1119,23 +1113,23 @@ int fio_close(iop_file_t *f)
 static iop_device_ops_t fio_ops =
 
   {
-    &fio_init,
-    (void *)&fio_dummy,
-    &fio_format,
-    &fio_open,
-    &fio_close,
-    &fio_read,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    &fio_ioctl,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
-    (void *)&fio_dummy,
+  &fio_init, // init
+  DUMMY_IMPLEMENTATION, // deinit
+  &fio_format, // format
+  &fio_open, // open
+  &fio_close, // close
+  &fio_read, // read
+  NOT_SUPPORTED, // write
+  NOT_SUPPORTED, // lseek
+  &fio_ioctl, // ioctl
+  NOT_SUPPORTED, // remove
+  NOT_SUPPORTED, // mkdir
+  NOT_SUPPORTED, // rmdir
+  NOT_SUPPORTED, // dopen
+  NOT_SUPPORTED, // dclose
+  NOT_SUPPORTED, // dread
+  NOT_SUPPORTED, // getstat
+  NOT_SUPPORTED, // chstat
   };
 
 static iop_device_t kbd_filedrv = {


### PR DESCRIPTION
## Description
This PR is for improving drive implementation, especially trying to identify those specific drivers that require a concrete value to be returned.

So far I have created another macro `DUMMY_IMPLEMENTATION` which just do:
```h
int dummy_implementation_int(void) { return 0; }
```

This PR needs to be reviewed carefully as it has several changes, let me enumerate them:
- `init` and `deinit` functions now always used either a custom function or a `DUMMY_IMPLEMENTATION`
- All the functions that were `return 0;` were replaced to `NOT_SUPPORTED` (the ones that required `s64` as return are using `NOT_SUPPORTED_S64`).
- In the driver definition every single function has now a comment, which helps us to read the driver better.
- Several functions were removed and replaced with `DUMMY_IMPLEMENTATION` or `NOT_SUPPORTED`.
- In general I think it is a super good approach to return `NOT_IMPLEMENTED` for all these functions that aren't doing anything.

This PR as it is right now will raise most probably several issues, so the main scope of this PR is to identify together in each driver what are the specific functions that require concrete `DUMMY_IMPLEMENTATION` rather than `NOT_SUPPORTED`.

Please help me to identify them and then put a clear comment with the reason.

To test with OPL could be a good test, however, we need to keep in mind that, if it is not working maybe it is because OPL code itself needs to be updated.

Here you have all the drivers, the functions, and the previous and new value.
So far we have the next different kind of drivers:
- `iop_device_ops_short_t`
- `iop_device_ops_t`
- `iomanX_iop_device_ops_t`

- [ ] `ee/iopreboot/src/imgdrv/src/imgdrv.c`
```c
static iop_device_ops_short_t imgdrv_ops = {
    DUMMY_IMPLEMENTATION, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => NULL
    NOT_SUPPORTED, // open => OK
    NOT_SUPPORTED, // close => OK
    &imgdrv_read, // read => OK
    NOT_SUPPORTED, // write => NULL
    &imgdrv_lseek, // lseek => OK
};
```

- [ ] `iop/arcade/accdvd/src/cddrv.c`
```c
static iop_device_ops_t Cddrv_ops = {
	&cddrv_adddrv, // init => OK
	&cddrv_deldrv, // deinit => OK
	NOT_SUPPORTED, // format => EINVAL
	&cddrv_open, // open => OK
	&cddrv_close, // close => OK
	&cddrv_read, // read => OK
	&cddrv_write, // write => OK
	&cddrv_lseek, // lseek => OK
	&cddrv_ioctl, // ioctl => OK
	NOT_SUPPORTED, // remove => EINVAL
	NOT_SUPPORTED, // mkdir => EINVAL
	NOT_SUPPORTED, // rmdir => EINVAL
	NOT_SUPPORTED, // dopen => EINVAL
	NOT_SUPPORTED, // dclose => EINVAL
	NOT_SUPPORTED, // dread => EINVAL
	NOT_SUPPORTED, // getstat => EINVAL
	NOT_SUPPORTED, // chstat => EINVAL
};
```

- [ ] `iop/arcade/acuart/src/tty.c`
```c
static iop_device_ops_t uart_ops = {
    DUMMY_IMPLEMENTATION, // init => ENOTSUP
    DUMMY_IMPLEMENTATION, // deinit => ENOTSUP
    NOT_SUPPORTED, // format => OK
    NOT_SUPPORTED, // open => OK
    NOT_SUPPORTED, // close => OK
    &acuart_read, // read => OK
    &acuart_write, // write => OK
    NOT_SUPPORTED, // lseek => OK
    NOT_SUPPORTED, // ioctl => OK
    NOT_SUPPORTED, // remove => OK
    NOT_SUPPORTED, // mkdir => OK
    NOT_SUPPORTED, // rmdir => OK
    NOT_SUPPORTED, // dopen => OK
    NOT_SUPPORTED, // dclose => OK
    NOT_SUPPORTED, // dread => OK
    NOT_SUPPORTED, // getstat => OK
    NOT_SUPPORTED, // chstat => OK
};
```

- [ ] `iop/cdvd/cdfs/src/main.c`
```c
static iop_device_ops_t fio_ops = {
    &fio_init, // init => OK
    &fio_deinit, // deinit => OK
    NOT_SUPPORTED, // format => EIO
    &fio_open, // open => OK
    &fio_close, // close => OK
    &fio_read, // read => OK
    &fio_write, // write => OK
    &fio_lseek, // lseek => OK
    NOT_SUPPORTED, // ioctl => EIO
    NOT_SUPPORTED, // remove => EIO
    NOT_SUPPORTED, // mkdir => EIO
    NOT_SUPPORTED, // rmdir => EIO
    &fio_openDir, // dopen => OK
    &fio_closeDir, // dclose => OK
    &fio_dread, // dread => OK
    &fio_getstat, // getstat => OK
    NOT_SUPPORTED, // chstat => EIO
};
```

- [X] `iop/cdvd/xesdrv/src/xesdrv.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl = {
	&esdrv_df_init, // init => OK
	&esdrv_df_exit, // deinit => OK
	NOT_SUPPORTED, // format => OK
	NOT_SUPPORTED, // open => OK
	NOT_SUPPORTED, // close => OK
	NOT_SUPPORTED, // read => OK
	NOT_SUPPORTED, // write => OK
	NOT_SUPPORTED, // lseek => OK
	&esdrv_df_ioctl, // ioctl => OK
	NOT_SUPPORTED, // remove => OK
	NOT_SUPPORTED, // mkdir => OK
	NOT_SUPPORTED, // rmdir => OK
	NOT_SUPPORTED, // dopen => OK
	NOT_SUPPORTED, // dclose => OK
	NOT_SUPPORTED, // dread => OK
	NOT_SUPPORTED, // getstat => OK
	NOT_SUPPORTED, // chstat => OK
	NOT_SUPPORTED, // rename => OK
	NOT_SUPPORTED, // chdir => OK
	NOT_SUPPORTED, // sync => OK
	NOT_SUPPORTED, // mount => OK
	NOT_SUPPORTED, // umount => OK
	NOT_SUPPORTED_S64, // lseek64 => OK
	&esdrv_df_devctl, // devctl => OK
	NOT_SUPPORTED, // symlink => OK
	NOT_SUPPORTED, // readlink => OK
	&esdrv_df_ioctl2, // ioctl2 => OK
};
```

- [ ] `iop/debug/iop_sbusdbg/src/sbus_tty.c`
```c
static iop_device_ops_t fsd_ops =
{
    &ttyfs_init, // init => OK
    &ttyfs_deinit, // deinit => OK
    NOT_SUPPORTED, // format => EPERM
    &ttyfs_open, // open => OK
    &ttyfs_close, // close => OK
    NOT_SUPPORTED, // read => EPERM
    &ttyfs_write, // write => OK
    NOT_SUPPORTED, // lseek => EPERM
    NOT_SUPPORTED, // ioctl => EPERM
    NOT_SUPPORTED, // remove => EPERM
    NOT_SUPPORTED, // mkdir => EPERM
    NOT_SUPPORTED, // rmdir => EPERM
    &ttyfs_dopen, // dopen => OK
    &ttyfs_close, // dclose => OK
    NOT_SUPPORTED, // dread => EPERM
    NOT_SUPPORTED, // getstat => EPERM
    NOT_SUPPORTED, // chstat => EPERM
};
```
- [ ] `iop/debug/ppctty/src/tty.c`
```c
static iop_device_ops_t fsd_ops =
{
    &ttyfs_init, // init => OK
    &ttyfs_deinit, // deinit => OK
    NOT_SUPPORTED, // format => EPERM
    NOT_SUPPORTED, // open => EPERM
    NOT_SUPPORTED, // close => EPERM
    NOT_SUPPORTED, // read => EPERM
    &ttyfs_write, // write => OK
    NOT_SUPPORTED, // lseek => EPERM
    NOT_SUPPORTED, // ioctl => EPERM
    NOT_SUPPORTED, // remove => EPERM
    NOT_SUPPORTED, // mkdir => EPERM
    NOT_SUPPORTED, // rmdir => EPERM
    NOT_SUPPORTED, // dopen => EPERM
    NOT_SUPPORTED, // dclose => EPERM
    NOT_SUPPORTED, // dread => EPERM
    NOT_SUPPORTED, // getstat => EPERM
    NOT_SUPPORTED, // chstat => EPERM
};
```
- [ ] `iop/dev9/dev9/src/ps2dev9.c`
```c
static iop_device_ops_t dev9x_ops =
    {
        DUMMY_IMPLEMENTATION, // init => 0
        DUMMY_IMPLEMENTATION, // deinit => 0
        NOT_SUPPORTED, // format => 0
        NOT_SUPPORTED, // open => 0
        NOT_SUPPORTED, // close => 0
        NOT_SUPPORTED, // read => 0
        NOT_SUPPORTED, // write => 0
        NOT_SUPPORTED, // lseek => 0
        NOT_SUPPORTED, // ioctl => 0
        NOT_SUPPORTED, // remove => 0
        NOT_SUPPORTED, // mkdir => 0
        NOT_SUPPORTED, // rmdir => 0
        NOT_SUPPORTED, // dopen => 0
        NOT_SUPPORTED, // dclose => 0
        NOT_SUPPORTED, // dread => 0
        NOT_SUPPORTED, // getstat => 0
        NOT_SUPPORTED, // chstat => 0
        NOT_SUPPORTED, // rename => 0
        NOT_SUPPORTED, // chdir => 0
        NOT_SUPPORTED, // sync => 0
        NOT_SUPPORTED, // mount => 0
        NOT_SUPPORTED, // umount => 0
        NOT_SUPPORTED_S64, // lseek64 => 0
        &dev9x_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => 0
        NOT_SUPPORTED, // readlink => 0
        NOT_SUPPORTED, // ioctl2 => 0
};
```
- [X]  `iop/dvrp/dvr/src/dvr.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl =
    {
        &dvr_df_init, // init => OK
        &dvr_df_exit, // deinit => OK
        NOT_SUPPORTED, // format => OK
        NOT_SUPPORTED, // open => OK
        NOT_SUPPORTED, // close => OK
        NOT_SUPPORTED, // read => OK
        NOT_SUPPORTED, // write => OK
        NOT_SUPPORTED, // lseek => OK
        &dvr_df_ioctl, // ioctl => OK
        NOT_SUPPORTED, // remove => OK
        NOT_SUPPORTED, // mkdir => OK
        NOT_SUPPORTED, // rmdir => OK
        NOT_SUPPORTED, // dopen => OK
        NOT_SUPPORTED, // dclose => OK
        NOT_SUPPORTED, // dread => OK
        NOT_SUPPORTED, // getstat => OK
        NOT_SUPPORTED, // chstat => OK
        NOT_SUPPORTED, // rename => OK
        NOT_SUPPORTED, // chdir => OK
        NOT_SUPPORTED, // sync => OK
        NOT_SUPPORTED, // mount => OK
        NOT_SUPPORTED, // umount => OK
        NOT_SUPPORTED_S64, // lseek64 => OK
        &dvr_df_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => OK
        NOT_SUPPORTED, // readlink => OK
        &dvr_df_ioctl2, // ioctl2 => OK
};
```
- [X] `iop/dvrp/dvrav/src/dvrav.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl =
    {
        &dvrav_df_init, // init => OK
        &dvrav_df_exit, // deinit => OK
        NOT_SUPPORTED, // format => OK
        NOT_SUPPORTED, // open => OK
        NOT_SUPPORTED, // close => OK
        NOT_SUPPORTED, // read => OK
        NOT_SUPPORTED, // write => OK
        NOT_SUPPORTED, // lseek => OK
        &dvrav_df_ioctl, // ioctl => OK
        NOT_SUPPORTED, // remove => OK
        NOT_SUPPORTED, // mkdir => OK
        NOT_SUPPORTED, // rmdir => OK
        NOT_SUPPORTED, // dopen => OK
        NOT_SUPPORTED, // dclose => OK
        NOT_SUPPORTED, // dread => OK
        NOT_SUPPORTED, // getstat => OK
        NOT_SUPPORTED, // chstat => OK
        NOT_SUPPORTED, // rename => OK
        NOT_SUPPORTED, // chdir => OK
        NOT_SUPPORTED, // sync => OK
        NOT_SUPPORTED, // mount => OK
        NOT_SUPPORTED, // umount => OK
        NOT_SUPPORTED_S64, // lseek64 => OK
        &dvrav_df_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => OK
        NOT_SUPPORTED, // readlink => OK
        &dvrav_df_ioctl2, // ioctl2 => OK
};
```
- [X]  `iop/dvrp/dvrdv/src/dvrdv.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl =
    {
        &dvrdv_df_init, // init => OK
        &dvrdv_df_exit, // deinit => OK
        NOT_SUPPORTED, // format => OK
        NOT_SUPPORTED, // open => OK
        NOT_SUPPORTED, // close => OK
        NOT_SUPPORTED, // read => OK
        NOT_SUPPORTED, // write => OK
        NOT_SUPPORTED, // lseek => OK
        &dvrdv_df_ioctl, // ioctl => OK
        NOT_SUPPORTED, // remove => OK
        NOT_SUPPORTED, // mkdir => OK
        NOT_SUPPORTED, // rmdir => OK
        NOT_SUPPORTED, // dopen => OK
        NOT_SUPPORTED, // dclose => OK
        NOT_SUPPORTED, // dread => OK
        NOT_SUPPORTED, // getstat => OK
        NOT_SUPPORTED, // chstat => OK
        NOT_SUPPORTED, // rename => OK
        NOT_SUPPORTED, // chdir => OK
        NOT_SUPPORTED, // sync => OK
        NOT_SUPPORTED, // mount => OK
        NOT_SUPPORTED, // umount => OK
        NOT_SUPPORTED_S64, // lseek64 => OK
        &dvrdv_df_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => OK
        NOT_SUPPORTED, // readlink => OK
        &dvrdv_df_ioctl2, // ioctl2 => OK
};
```
- [X] `iop/dvrp/dvrfile/src/dvrfile.c`
```c
static iomanX_iop_device_ops_t dvrf_translator_functbl = {
    dvrf_df_init, // init => OK
    dvrf_df_exit, // deinit => OK
    dvrf_translator_df_format, // format => OK
    dvrf_translator_df_open, // open => OK
    dvrf_df_close, // close => OK
    dvrf_df_read, // read => OK
    dvrf_df_write, // write => OK
    dvrf_df_lseek, // lseek => OK
    dvrf_df_ioctl, // ioctl => OK
    dvrf_translator_df_remove, // remove => OK
    dvrf_translator_df_mkdir, // mkdir => OK
    dvrf_translator_df_rmdir, // rmdir => OK
    dvrf_translator_df_dopen, // dopen => OK
    dvrf_df_dclose, // dclose => OK
    dvrf_df_dread, // dread => OK
    dvrf_translator_df_getstat, // getstat => OK
    dvrf_translator_df_chstat, // chstat => OK
    dvrf_translator_df_rename, // rename => OK
    dvrf_translator_df_chdir, // chdir => OK
    dvrf_translator_df_sync, // sync => OK
    dvrf_translator_df_mount, // mount => OK
    dvrf_translator_df_umount, // umount => OK
    dvrf_df_lseek64, // lseek64 => OK
    dvrf_translator_df_devctl, // devctl => OK
    dvrf_translator_df_symlink, // symlink => OK
    dvrf_translator_df_readlink, // readlink => OK
    dvrf_df_ioctl2, // ioctl2 => OK
};
```
- [X] `iop/dvrp/dvripl/src/dvripl.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl =
    {
        &dvripl_df_init, // init => OK
        &dvripl_df_exit, // deinit => OK
        NOT_SUPPORTED, // format => OK
        NOT_SUPPORTED, // open => OK
        NOT_SUPPORTED, // close => OK
        NOT_SUPPORTED, // read => OK
        NOT_SUPPORTED, // write => OK
        NOT_SUPPORTED, // lseek => OK
        &dvripl_df_ioctl, // ioctl => OK
        NOT_SUPPORTED, // remove => OK
        NOT_SUPPORTED, // mkdir => OK
        NOT_SUPPORTED, // rmdir => OK
        NOT_SUPPORTED, // dopen => OK
        NOT_SUPPORTED, // dclose => OK
        NOT_SUPPORTED, // dread => OK
        NOT_SUPPORTED, // getstat => OK
        NOT_SUPPORTED, // chstat => OK
        NOT_SUPPORTED, // rename => OK
        NOT_SUPPORTED, // chdir => OK
        NOT_SUPPORTED, // sync => OK
        NOT_SUPPORTED, // mount => OK
        NOT_SUPPORTED, // umount => OK
        NOT_SUPPORTED_S64, // lseek64 => OK
        &dvripl_df_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => OK
        NOT_SUPPORTED, // readlink => OK
        &dvripl_df_ioctl2, // ioctl2 => OK
};
```
- [X] `iop/dvrp/dvrmisc/src/dvrmisc.c`
```c
static iomanX_iop_device_ops_t DvrFuncTbl =
    {
        &dvrmisc_df_init, // init => OK
        &dvrmisc_df_exit, // deinit => OK
        NOT_SUPPORTED, // format => OK
        NOT_SUPPORTED, // open => OK
        NOT_SUPPORTED, // close => OK
        NOT_SUPPORTED, // read => OK
        NOT_SUPPORTED, // write => OK
        NOT_SUPPORTED, // lseek => OK
        &dvrmisc_df_ioctl, // ioctl => OK
        NOT_SUPPORTED, // remove => OK
        NOT_SUPPORTED, // mkdir => OK
        NOT_SUPPORTED, // rmdir => OK
        NOT_SUPPORTED, // dopen => OK
        NOT_SUPPORTED, // dclose => OK
        NOT_SUPPORTED, // dread => OK
        NOT_SUPPORTED, // getstat => OK
        NOT_SUPPORTED, // chstat => OK
        NOT_SUPPORTED, // rename => OK
        NOT_SUPPORTED, // chdir => OK
        NOT_SUPPORTED, // sync => OK
        NOT_SUPPORTED, // mount => OK
        NOT_SUPPORTED, // umount => OK
        NOT_SUPPORTED_S64, // lseek64 => OK
        &dvrmisc_df_devctl, // devctl => OK
        NOT_SUPPORTED, // symlink => OK
        NOT_SUPPORTED, // readlink => OK
        &dvrmisc_df_ioctl2, // ioctl2 => OK
    };
```
- [ ] `iop/fs/bdmfs_fatfs/src/fs_driver.c`
```c
static iop_device_ops_t fs_functarray = {
    DUMMY_IMPLEMENTATION, // init => 1
    DUMMY_IMPLEMENTATION, // deinit => EOI
    NOT_SUPPORTED, // format => OK
    &fs_open, // open => OK
    &fs_close, // close => OK
    &fs_read, // read => OK
    &fs_write, // write => OK
    &fs_lseek, // lseek => OK
    &fs_ioctl, // ioctl => OK
    &fs_remove, // remove => OK
    &fs_mkdir, // mkdir => OK
    &fs_remove, // rmdir => OK
    &fs_dopen, // dopen => OK
    &fs_dclose, // dclose => OK
    &fs_dread, // dread => OK
    &fs_getstat, // getstat => OK
    NOT_SUPPORTED, // chstat => EOI
    &fs_rename, // rename => OK
    NOT_SUPPORTED, // chdir => EOI
    NOT_SUPPORTED, // sync => EOI
    NOT_SUPPORTED, // mount => EOI
    NOT_SUPPORTED, // umount => EOI
    &fs_lseek64, // lseek64 => OK
    &fs_devctl, // devctl => OK
    NOT_SUPPORTED, // symlink => EOI
    NOT_SUPPORTED, // readlink => EOI
    &fs_ioctl2, // ioctl2 => OK
};
```
- [ ] `iop/fs/devfs/src/devfs.c`
```c
static iop_device_ops_t devfs_ops = {
    DUMMY_IMPLEMENTATION, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => EPERM
    &devfs_open, // open => OK
    &devfs_close, // close => OK
    &devfs_read, // read => OK
    NOT_SUPPORTED, // write => EPERM
    NOT_SUPPORTED, // lseek => EPERM
    &devfs_ioctl, // ioctl => OK
    NOT_SUPPORTED, // remove => EPERM
    NOT_SUPPORTED, // mkdir => EPERM
    NOT_SUPPORTED, // rmdir => EPERM
    &devfs_dopen, // dopen => OK
    &devfs_dclose, // dclose => OK
    &devfs_dread, // dread => OK
    &devfs_getstat, // getstat => OK
    NOT_SUPPORTED, // chstat => EPERM
    NOT_SUPPORTED, // rename => EPERM
    NOT_SUPPORTED, // chdir => EPERM
    NOT_SUPPORTED, // sync => EPERM
    NOT_SUPPORTED, // mount => EPERM
    NOT_SUPPORTED, // umount => EPERM
    NOT_SUPPORTED_S64, // lseek64 => EPERM
    NOT_SUPPORTED, // devctl => EPERM
    NOT_SUPPORTED, // symlink => EPERM
    NOT_SUPPORTED, // readlink => EPERM
    &devfs_ioctl2, // ioctl2 => OK
  };
```
- [ ] `iop/fs/eromdrv/src/eromdrv.c`
```c
  static iop_device_ops_t erom_devops = {
	DUMMY_IMPLEMENTATION, // init => OK
	DUMMY_IMPLEMENTATION, // deinit => OK
	NOT_SUPPORTED, // format => 0
	erom_op_open, // open => OK
	erom_op_close, // close => OK
	erom_op_read, // read => OK
	NOT_SUPPORTED, // write => EOI
	erom_op_lseek, // lseek => OK
	NOT_SUPPORTED, // ioctl => 0
	NOT_SUPPORTED, // remove => 0
	NOT_SUPPORTED, // mkdir => 0
	NOT_SUPPORTED, // rmdir => 0
	NOT_SUPPORTED, // dopen => 0
	NOT_SUPPORTED, // dclose => 0
	NOT_SUPPORTED, // dread => 0
	NOT_SUPPORTED, // getstat => 0
	NOT_SUPPORTED, // chstat => 0
};
```
- [ ] `iop/fs/fakehost/src/fakehost.c`
```c
static iop_io_device_ops_t functions = {
	DUMMY_IMPLEMENTATION, // init
	DUMMY_IMPLEMENTATION, // deinit
	NOT_SUPPORTED, // format
	&fd_open, // open
	&fd_close, // close
	&fd_read, // read
	NOT_SUPPORTED, // write
	&fd_lseek, // lseek
	NOT_SUPPORTED, // ioctl
	NOT_SUPPORTED, // remove
	NOT_SUPPORTED, // mkdir
	NOT_SUPPORTED, // rmdir
	NOT_SUPPORTED, // dopen
	NOT_SUPPORTED, // dclose
	NOT_SUPPORTED, // dread
	NOT_SUPPORTED, // getstat
	NOT_SUPPORTED, // chstat
};
```
- [ ] `iop/fs/http/src/ps2http.c`
```c
static iop_io_device_ops_t ps2httpOps = {
	DUMMY_IMPLEMENTATION, // init => OK
	DUMMY_IMPLEMENTATION, // deinit => OK
	NOT_SUPPORTED, // format => EOI
	&httpOpen, // open => OK
	&httpClose, // close => OK
	&httpRead, // read => OK
	NOT_SUPPORTED, // write => EOI
	&httpLseek, // lseek => OK
	NOT_SUPPORTED, // ioctl => EOI
	NOT_SUPPORTED, // remove => EOI
	NOT_SUPPORTED, // mkdir => EOI
	NOT_SUPPORTED, // rmdir => EOI
	NOT_SUPPORTED, // dopen => EOI
	NOT_SUPPORTED, // dclose => EOI
	NOT_SUPPORTED, // dread => EOI
	NOT_SUPPORTED, // getstat => EOI
	NOT_SUPPORTED, // chstat => EOI
};
```
- [ ] `iop/fs/romdrv/src/romdrv.c`
```c
static iop_device_ops_t ops = {
    DUMMY_IMPLEMENTATION, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => 0
    &romOpen, // open => OK
    &romClose, // close => OK
    &romRead, // read => OK
    NOT_SUPPORTED, // write => 0
    &romLseek, // lseek => OK
    NOT_SUPPORTED, // ioctl => 0
    NOT_SUPPORTED, // remove => 0
    NOT_SUPPORTED, // mkdir => 0
    NOT_SUPPORTED, // rmdir => 0
    NOT_SUPPORTED, // dopen => 0
    NOT_SUPPORTED, // dclose => 0
    NOT_SUPPORTED, // dread => 0
    NOT_SUPPORTED, // getstat => 0
    NOT_SUPPORTED, // chstat => 0
};
```
- [ ] `iop/fs/subfile/src/subfile.c`
```c
static iop_device_ops_t subfile_devops = {
	DUMMY_IMPLEMENTATION, // init => OK
	DUMMY_IMPLEMENTATION, // deinit => OK
	NOT_SUPPORTED, // format => 0
	subfile_op_open, // open => OK
	subfile_op_close, // close => OK
	subfile_op_read, // read => OK
	NOT_SUPPORTED, // write => 0
	subfile_op_lseek, // lseek => OK
	NOT_SUPPORTED, // ioctl => 0
	NOT_SUPPORTED, // remove => 0
	NOT_SUPPORTED, // mkdir => 0
	NOT_SUPPORTED, // rmdir => 0
	NOT_SUPPORTED, // dopen => 0
	NOT_SUPPORTED, // dclose => 0
	NOT_SUPPORTED, // dread => 0
	NOT_SUPPORTED, // getstat => 0
	NOT_SUPPORTED, // chstat => 0
};
```
- [ ] `iop/fs/vfat/src/fs_driver.c`
```c
static iop_device_ops_t fs_functarray = {
    &fs_init, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => EOI
    &fs_open, // open => OK
    &fs_close, // close => OK
    &fs_read, // read => OK
    &fs_write, // write => OK
    &fs_lseek, // lseek => OK
    &fs_ioctl, // ioctl => OK
    &fs_remove, // remove => OK
    &fs_mkdir, // mkdir => OK
    &fs_rmdir, // rmdir => OK
    &fs_dopen, // dopen => OK
    &fs_dclose, // dclose => OK
    &fs_dread, // dread => OK
    &fs_getstat, // getstat => OK
    NOT_SUPPORTED, // chstat => EOI
    &fs_rename, // rename => OK
    NOT_SUPPORTED, // chdir => EOI
    NOT_SUPPORTED, // sync => EOI
    NOT_SUPPORTED, // mount => EOI
    NOT_SUPPORTED, // umount => EOI
    NOT_SUPPORTED_S64, // lseek64 => EOI
#ifndef BUILDING_IEEE1394_DISK
    &fs_devctl, // devctl => OK
#else
    NOT_SUPPORTED, // devctl => EOI
#endif /* BUILDING_IEEE1394_DISK */
    NOT_SUPPORTED, // symlink => EOI
    NOT_SUPPORTED, // readlink => EOI
#if !defined(BUILDING_IEEE1394_DISK) && !defined(BUILDING_USBHDFSD)
    &fs_ioctl2, // ioctl2 => OK
#else
    NOT_SUPPORTED, // ioctl2 => EOI
#endif /* BUILDING_IEEE1394_DISK */
};
```
- [ ] `iop/hdd/apa/src/hdd.c`
```c
static iomanX_iop_device_ops_t hddOps={
	&hddInit, // init => OK
	&hddDeinit, // deinit => OK
	&hddFormat, // format => OK
	&hddOpen, // open => OK
	&hddClose, // close => OK
	&hddRead, // read => OK
	&hddWrite, // write => OK
	&hddLseek, // lseek => OK
	NOT_SUPPORTED, // ioctl => EPERM
	&hddRemove, // remove => OK
	NOT_SUPPORTED, // mkdir => EPERM
	NOT_SUPPORTED, // rmdir => EPERM
	&hddDopen, // dopen => OK
	&hddClose, // dclose => OK
	&hddDread, // dread => OK
	&hddGetStat, // getstat => OK
	NOT_SUPPORTED, // chstat => EPERM
	&hddReName, // rename => OK
	NOT_SUPPORTED, // chdir => EPERM
	NOT_SUPPORTED, // sync => EPERM
	hddMount, // mount => OK
	hddUmount, // umount => OK
	NOT_SUPPORTED_S64, // lseek64 => EPERM
	&hddDevctl, // devctl => OK
	NOT_SUPPORTED, // symlink => EPERM
	NOT_SUPPORTED, // readlink => EPERM
	&hddIoctl2, // ioctl2 => OK
};
```
- [ ] `iop/hdd/fsck/src/fsck.c`
```c
static iomanX_iop_device_ops_t FsckDeviceOps = {
    DUMMY_IMPLEMENTATION, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => 0
    &FsckOpen, // open => OK
    &FsckClose, // close => OK
    NOT_SUPPORTED, // read => 0
    NOT_SUPPORTED, // write => 0
    NOT_SUPPORTED, // lseek => 0
    NOT_SUPPORTED, // ioctl => 0
    NOT_SUPPORTED, // remove => 0
    NOT_SUPPORTED, // mkdir => 0
    NOT_SUPPORTED, // rmdir => 0
    NOT_SUPPORTED, // dopen => 0
    NOT_SUPPORTED, // dclose => 0
    NOT_SUPPORTED, // dread => 0
    NOT_SUPPORTED, // getstat => 0
    NOT_SUPPORTED, // chstat => 0
    NOT_SUPPORTED, // rename => 0
    NOT_SUPPORTED, // chdir => 0
    NOT_SUPPORTED, // sync => 0
    NOT_SUPPORTED, // mount => 0
    NOT_SUPPORTED, // umount => 0
    NOT_SUPPORTED_S64, // lseek64 => 0
    NOT_SUPPORTED, // devctl => 0
    NOT_SUPPORTED, // symlink => 0
    NOT_SUPPORTED, // readlink => 0
    &FsckIoctl2, // ioctl2 => OK
};
```
- [ ] `iop/hdd/fssk/src/fssk.c`
```c
static iomanX_iop_device_ops_t FsskDeviceOps = {
    DUMMY_IMPLEMENTATION, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => 0
    &FsskOpen, // open => OK
    &FsskClose, // close => OK
    NOT_SUPPORTED, // read => 0
    NOT_SUPPORTED, // write => 0
    NOT_SUPPORTED, // lseek => 0
    NOT_SUPPORTED, // ioctl => 0
    NOT_SUPPORTED, // remove => 0
    NOT_SUPPORTED, // mkdir => 0
    NOT_SUPPORTED, // rmdir => 0
    NOT_SUPPORTED, // dopen => 0
    NOT_SUPPORTED, // dclose => 0
    NOT_SUPPORTED, // dread => 0
    NOT_SUPPORTED, // getstat => 0
    NOT_SUPPORTED, // chstat => 0
    NOT_SUPPORTED, // rename => 0
    NOT_SUPPORTED, // chdir => 0
    NOT_SUPPORTED, // sync => 0
    NOT_SUPPORTED, // mount => 0
    NOT_SUPPORTED, // umount => 0
    NOT_SUPPORTED_S64, // lseek64 => 0
    NOT_SUPPORTED, // devctl => 0
    NOT_SUPPORTED, // symlink => 0
    NOT_SUPPORTED, // readlink => 0
    &FsskIoctl2, // ioctl2 => OK
};
```
- [ ] `iop/hdd/hdck/src/hdck.c`
```c
static iomanX_iop_device_ops_t HdckDeviceOps = {
    &HdckInit, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => OK
    NOT_SUPPORTED, // format => EPERM
    NOT_SUPPORTED, // open => EPERM
    NOT_SUPPORTED, // close => EPERM
    NOT_SUPPORTED, // read => EPERM
    NOT_SUPPORTED, // write => EPERM
    NOT_SUPPORTED, // lseek => EPERM
    NOT_SUPPORTED, // ioctl => EPERM
    NOT_SUPPORTED, // remove => EPERM
    NOT_SUPPORTED, // mkdir => EPERM
    NOT_SUPPORTED, // rmdir => EPERM
    NOT_SUPPORTED, // dopen => EPERM
    NOT_SUPPORTED, // dclose => EPERM
    NOT_SUPPORTED, // dread => EPERM
    NOT_SUPPORTED, // getstat => EPERM
    NOT_SUPPORTED, // chstat => EPERM
    NOT_SUPPORTED, // rename => EPERM
    NOT_SUPPORTED, // chdir => EPERM
    NOT_SUPPORTED, // sync => EPERM
    NOT_SUPPORTED, // mount => EPERM
    NOT_SUPPORTED, // umount => EPERM
    NOT_SUPPORTED_S64, // lseek64 => EPERM
    &HdckDevctl, // devctl => OK
    NOT_SUPPORTED, // symlink => EPERM
    NOT_SUPPORTED, // readlink => EPERM
    NOT_SUPPORTED, // ioctl2 => EPERM
};
```
- [ ] `iop/hdd/hdsk/src/hdsk.c`
```c
static iomanX_iop_device_ops_t HdskDeviceOps = {
    &HdskInit, // init => OK
    DUMMY_IMPLEMENTATION, // deinit => EPERM
    NOT_SUPPORTED, // format => EPERM
    NOT_SUPPORTED, // open => EPERM
    NOT_SUPPORTED, // close => EPERM
    NOT_SUPPORTED, // read => EPERM
    NOT_SUPPORTED, // write => EPERM
    NOT_SUPPORTED, // lseek => EPERM
    NOT_SUPPORTED, // ioctl => EPERM
    NOT_SUPPORTED, // remove => EPERM
    NOT_SUPPORTED, // mkdir => EPERM
    NOT_SUPPORTED, // rmdir => EPERM
    NOT_SUPPORTED, // dopen => EPERM
    NOT_SUPPORTED, // dclose => EPERM
    NOT_SUPPORTED, // dread => EPERM
    NOT_SUPPORTED, // getstat => EPERM
    NOT_SUPPORTED, // chstat => EPERM
    NOT_SUPPORTED, // rename => EPERM
    NOT_SUPPORTED, // chdir => EPERM
    NOT_SUPPORTED, // sync => EPERM
    NOT_SUPPORTED, // mount => EPERM
    NOT_SUPPORTED, // umount => EPERM
    NOT_SUPPORTED_S64, // lseek64 => EPERM
    &HdskDevctl, // devctl => OK
    NOT_SUPPORTED, // symlink => EPERM
    NOT_SUPPORTED, // readlink => EPERM
    NOT_SUPPORTED, // ioctl2 => EPERM
};
```
- [X] `iop/hdd/pfs/src/pfs.c`
```c
static iomanX_iop_device_ops_t pfsOps = {
	&pfsFioInit, // init => OK
	&pfsFioDeinit, // deinit => OK
	&pfsFioFormat, // format => OK
	&pfsFioOpen, // open => OK
	&pfsFioClose, // close => OK
	&pfsFioRead, // read => OK
	&pfsFioWrite, // write => OK
	&pfsFioLseek, // lseek => OK
	&pfsFioIoctl, // ioctl => OK
	&pfsFioRemove, // remove => OK
	&pfsFioMkdir, // mkdir => OK
	&pfsFioRmdir, // rmdir => OK
	&pfsFioDopen, // dopen => OK
	&pfsFioClose, // dclose => OK
	&pfsFioDread, // dread => OK
	&pfsFioGetstat, // getstat => OK
	&pfsFioChstat, // chstat => OK
	&pfsFioRename, // rename => OK
	&pfsFioChdir, // chdir => OK
	&pfsFioSync, // sync => OK
	&pfsFioMount, // mount => OK
	&pfsFioUmount, // umount => OK
	&pfsFioLseek64, // lseek64 => OK
	&pfsFioDevctl, // devctl => OK
	&pfsFioSymlink, // symlink => OK
	&pfsFioReadlink, // readlink => OK
	&pfsFioIoctl2, // ioctl2 => OK
};
```
- [ ] `iop/network/smbman/src/smb_fio.c`
```c
static iop_device_ops_t smbman_ops = {
    &smb_init, // init => OK
    &smb_deinit, // deinit => OK
    NOT_SUPPORTED, // format => EOI
    &smb_open, // open => OK
    &smb_close, // close => OK
    &smb_read, // read => OK
    &smb_write, // write => OK
    &smb_lseek, // lseek => OK
    NOT_SUPPORTED, // ioctl => EOI
    &smb_remove, // remove => OK
    &smb_mkdir, // mkdir => OK
    &smb_rmdir, // rmdir => OK
    &smb_dopen, // dopen => OK
    &smb_dclose, // dclose => OK
    &smb_dread, // dread => OK
    &smb_getstat, // getstat => OK
    NOT_SUPPORTED, // chstat => EOI
    &smb_rename, // rename => OK
    &smb_chdir, // chdir => OK
    NOT_SUPPORTED, // sync => EOI
    NOT_SUPPORTED, // mount => EOI
    NOT_SUPPORTED, // umount => EOI
    &smb_lseek64, // lseek64 => OK
    &smb_devctl, // devctl => OK
    NOT_SUPPORTED, // symlink => EOI
    NOT_SUPPORTED, // readlink => EOI
    NOT_SUPPORTED, // ioctl2 => EOI
};
```
- [ ] `iop/network/udptty/src/udptty.c`
```c
static iop_device_ops_t tty_ops = {
    tty_init, // init => OK
    tty_deinit, // deinit => OK
    NOT_SUPPORTED, // format => EOI
    (void *)tty_stdout_fd, // open => OK
    (void *)tty_stdout_fd, // close => OK
    NOT_SUPPORTED, // read => EOI
    (void *)tty_write, // write => OK
    NOT_SUPPORTED, // lseek => EOI
    NOT_SUPPORTED, // ioctl => EOI
    NOT_SUPPORTED, // remove => EOI
    NOT_SUPPORTED, // mkdir => EOI
    NOT_SUPPORTED, // rmdir => EOI
    NOT_SUPPORTED, // dopen => EOI
    NOT_SUPPORTED, // dclose => EOI
    NOT_SUPPORTED, // dread => EOI
    NOT_SUPPORTED, // getstat => EOI
    NOT_SUPPORTED, // chstat => EOI
};
```
- [ ] `iop/system/ioman/src/ioman.c`
```c
iop_io_device_ops_t tty_dev_operations = {
	DUMMY_IMPLEMENTATION, // init => OK
	DUMMY_IMPLEMENTATION, // deinit => OK
	NOT_SUPPORTED, // format => 0
	NOT_SUPPORTED, // open => 0
	NOT_SUPPORTED, // close => 0
	NOT_SUPPORTED, // read => 0
	NOT_SUPPORTED, // write => 0
	NOT_SUPPORTED, // lseek => 0
	NOT_SUPPORTED, // ioctl => 0
	NOT_SUPPORTED, // remove => 0
	NOT_SUPPORTED, // mkdir => 0
	NOT_SUPPORTED, // rmdir => 0
	NOT_SUPPORTED, // dopen => 0
	NOT_SUPPORTED, // dclose => 0
	NOT_SUPPORTED, // dread => 0
	NOT_SUPPORTED, // getstat => 0
	NOT_SUPPORTED, // chstat => 0
};
```
- [ ] `iop/system/iomanx/src/iomanX.c`
```c
static iomanX_iop_device_ops_t dev_tty_dev_operations = {
	DUMMY_IMPLEMENTATION, // init => OK
	DUMMY_IMPLEMENTATION, // deinit => OK
	NOT_SUPPORTED, // format => 0
	NOT_SUPPORTED, // open => 0
	NOT_SUPPORTED, // close => 0
	NOT_SUPPORTED, // read => 0
	NOT_SUPPORTED, // write => 0
	NOT_SUPPORTED, // lseek => 0
	NOT_SUPPORTED, // ioctl => 0
	NOT_SUPPORTED, // remove => 0
	NOT_SUPPORTED, // mkdir => 0
	NOT_SUPPORTED, // rmdir => 0
	NOT_SUPPORTED, // dopen => 0
	NOT_SUPPORTED, // dclose => 0
	NOT_SUPPORTED, // dread => 0
	NOT_SUPPORTED, // getstat => 0
	NOT_SUPPORTED, // chstat => 0
	NOT_SUPPORTED, // rename => 0
	NOT_SUPPORTED, // chdir => 0
	NOT_SUPPORTED, // sync => 0
	NOT_SUPPORTED, // mount => 0
	NOT_SUPPORTED, // umount => 0
	NOT_SUPPORTED_S64, // lseek64 => 0
	NOT_SUPPORTED, // devctl => 0
	NOT_SUPPORTED, // symlink => 0
	NOT_SUPPORTED, // readlink => 0
	NOT_SUPPORTED, // ioctl2 => 0
};
```
- [ ] `iop/usb/keyboard/src/ps2kbd.c`
```c
static iop_device_ops_t fio_ops =
  {
  &fio_init, // init => OK
  DUMMY_IMPLEMENTATION, // deinit => EOI
  &fio_format, // format => OK
  &fio_open, // open => OK
  &fio_close, // close => OK
  &fio_read, // read => OK
  NOT_SUPPORTED, // write => EOI
  NOT_SUPPORTED, // lseek => EOI
  &fio_ioctl, // ioctl => OK
  NOT_SUPPORTED, // remove => EOI
  NOT_SUPPORTED, // mkdir => EOI
  NOT_SUPPORTED, // rmdir => EOI
  NOT_SUPPORTED, // dopen => EOI
  NOT_SUPPORTED, // dclose => EOI
  NOT_SUPPORTED, // dread => EOI
  NOT_SUPPORTED, // getstat => EOI
  NOT_SUPPORTED, // chstat => EOI
  };
```