### PR TITLE
fix ioctl failing with ENOSYS.

### DIFF
--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -75,6 +75,7 @@ GLUE_OBJS = \
 	lstat.o \
 	_fstat.o \
 	access.o \
+	_ioctl.o \
 	_fcntl.o \
 	getdents.o \
 	_lseek.o \

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -458,6 +458,7 @@ int __attribute__((weak)) _read(int fd, void *buf, size_t nbytes);
 off_t __attribute__((weak)) _lseek(int fd, off_t offset, int whence);
 int __attribute__((weak)) _write(int fd, const void *buf, size_t nbytes);
 int __attribute__((weak)) _ioctl(int fd, int request, void *data);
+int __attribute__((weak)) _ps2sdk_ioctl(int fd, int request, void *data);
 int __attribute__((weak)) getdents(int fd, void *dd_buf, int count);
 
 void __fioOpsInitializeImpl(void)
@@ -486,7 +487,7 @@ void __fioOpsInitializeImpl(void)
     // cppcheck-suppress knownConditionTrueFalse
     if (&_write) __fio_fdman_ops_file.write = __fioWriteHelper;
     // cppcheck-suppress knownConditionTrueFalse
-    if (&_ioctl) __fio_fdman_ops_file.ioctl = __fioIoctlHelper;
+    if ((&_ioctl) || (&_ps2sdk_ioctl)) __fio_fdman_ops_file.ioctl = __fioIoctlHelper;
 
     memset(&__fio_fdman_ops_dir, 0, sizeof(__fio_fdman_ops_dir));
     __fio_fdman_ops_dir.getfd = __fioGetFdHelper;

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -467,6 +467,7 @@ off_t __attribute__((weak)) _lseek(int fd, off_t offset, int whence);
 off64_t __attribute__((weak)) lseek64(int fd, off64_t offset, int whence);
 int __attribute__((weak)) _write(int fd, const void *buf, size_t nbytes);
 int __attribute__((weak)) _ioctl(int fd, int request, void *data);
+int __attribute__((weak)) _ps2sdk_ioctl(int fd, int request, void *data);
 int __attribute__((weak)) getdents(int fd, void *dd_buf, int count);
 
 extern void __fileXioOpsInitializeImpl(void)
@@ -503,7 +504,7 @@ extern void __fileXioOpsInitializeImpl(void)
     // cppcheck-suppress knownConditionTrueFalse
     if (&_write) __fileXio_fdman_ops_file.write = __fileXioWriteHelper;
     // cppcheck-suppress knownConditionTrueFalse
-    if (&_ioctl) __fileXio_fdman_ops_file.ioctl = __fileXioIoctlHelper;
+    if ((&_ioctl) || (&_ps2sdk_ioctl)) __fileXio_fdman_ops_file.ioctl = __fileXioIoctlHelper;
     __fileXio_fdman_ops_file.ioctl2 = __fileXioIoctl2Helper;
 
     memset(&__fileXio_fdman_ops_dir, 0, sizeof(__fileXio_fdman_ops_dir));


### PR DESCRIPTION
Currently, ioctl calls are failing, as `__fioOpsInitializeImpl` and `__fileXioOpsInitializeImpl` are checking for the wrong symbol when setting operation handlers.

Offending lines:

https://github.com/ps2dev/ps2sdk/blob/69f54b9f923db871ea1582a62c9db8866a017fe5/ee/libcglue/src/ps2sdkapi.c#L489

https://github.com/ps2dev/ps2sdk/blob/69f54b9f923db871ea1582a62c9db8866a017fe5/ee/rpc/filexio/src/fileXio_ps2sdk.c#L506

`_ioctl` is not defined anywhere, thus `x_ops_file.ioctl` will remain as `NULL`. This in turn will result in an ENOSYS in `_ps2sdk_ioctl`. The correct symbol to check here would be `_ps2sdk_ioctl`. I corrected the error, and defined `_ioctl` in `glue.c` for consistency.

Tested and validated via PCSX2 emulator.
