### PR TITLE
Reduce cdfs ram

### DIFF
--- a/iop/cdvd/cdfs/src/cdfs_iop.c
+++ b/iop/cdvd/cdfs/src/cdfs_iop.c
@@ -446,35 +446,6 @@ static enum PathMatch comparePath(const char *path) {
         return NOT_MATCH;
 }
 
-// Check if a TOC Entry matches our extension list
-static int compareTocEntry(char *filename, const char *extensions) {
-    static char ext_list[129];
-
-    char *token;
-
-
-    strncpy(ext_list, extensions, 128);
-    ext_list[128] = 0;
-
-    token = strtok(ext_list, " ,");
-    while (token != NULL) {
-        char *ext_point;
-
-        // if 'token' matches extension of 'filename'
-        // then return a match
-        ext_point = strrchr(filename, '.');
-
-        if (strcasecmp(ext_point, token) == 0)
-            return TRUE;
-
-        /* Get next token: */
-        token = strtok(NULL, " ,");
-    }
-
-    // If not match found then return FALSE
-    return FALSE;
-}
-
 // Find, and cache, the requested directory, for use by GetDir or  (and thus open)
 // provide an optional offset variable, for use when caching dirs of greater than 500 files
 
@@ -897,7 +868,7 @@ int cdfs_readSect(u32 lsn, u32 sectors, u8 *buf) {
     return FALSE;  // error
 }
 
-int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode getMode, struct TocEntry tocEntry[], unsigned int req_entries) {
+int cdfs_getDir(const char *pathname, struct TocEntry tocEntry[], unsigned int req_entries) {
     int matched_entries;
     int dir_entry;
 
@@ -916,165 +887,146 @@ int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode 
 
     DPRINTF("requested directory is %u sectors\n", cacheInfoDir.sector_num);
 
-    if ((getMode == CDFS_GET_DIRS_ONLY) || (getMode == CDFS_GET_FILES_AND_DIRS)) {
-        // Cache the start of the requested directory
-        if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_START)) {
-            DPRINTF("cdfs_getDir - Call of cdfs_cacheDir failed\n\n");
-            return -1;
-        }
+    // Cache the start of the requested directory
+    if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_START)) {
+        DPRINTF("cdfs_getDir - Call of cdfs_cacheDir failed\n\n");
+        return -1;
+    }
 
-        tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
-        // skip the first self-referencing entry
+    tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
+    // skip the first self-referencing entry
+    tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
+
+    // skip the parent entry if this is the root
+    if (cacheInfoDir.path_depth == 0)
         tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
 
-        // skip the parent entry if this is the root
-        if (cacheInfoDir.path_depth == 0)
-            tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
+    dir_entry = 0;
 
-        dir_entry = 0;
+    while (1) {
+        DPRINTF("cdfs_getDir - inside while-loop\n\n");
 
-        while (1) {
-            DPRINTF("cdfs_getDir - inside while-loop\n\n");
+        // parse the current cache block
+        for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
+            if (tocEntryPointer->length == 0) {
+                // if we have a toc entry length of zero,
+                // then we've either reached the end of the sector, or the end of the dir
+                // so point to next sector (if there is one - will be checked by next condition)
 
-            // parse the current cache block
-            for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
-                if (tocEntryPointer->length == 0) {
-                    // if we have a toc entry length of zero,
-                    // then we've either reached the end of the sector, or the end of the dir
-                    // so point to next sector (if there is one - will be checked by next condition)
+                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+            }
 
-                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
-                }
-
-                if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
-                    // we've reached the end of the current cache block (which may be end of entire dir
-                    // so just break the loop
-                    break;
-                }
-
-                // Check if the current entry is a dir or a file
-                if (tocEntryPointer->fileProperties & 0x02) {
-                    DPRINTF("We found a dir, and we want all dirs\n\n");
-                    copyToTocEntry(&localTocEntry, tocEntryPointer);
-
-                    if (dir_entry == 0) {
-                        if (cacheInfoDir.path_depth != 0) {
-                            DPRINTF("It's the first directory entry, so name it '..'\n\n");
-                            strcpy(localTocEntry.filename, "..");
-                        }
-                    }
-
-                    // Copy from localTocEntry
-                    tocEntry[matched_entries] = localTocEntry;
-                    matched_entries++;
-                } else { // it must be a file
-                    DPRINTF("We found a file, but we dont want files (at least not yet)\n\n");
-                }
-
-                dir_entry++;
-
-                if ((unsigned int)matched_entries >= req_entries)  // if we've filled the requested buffer
-                    return (matched_entries);        // then just return
-
-            }  // end of the current cache block
-
-            // if there is more dir to load, then load next chunk, else finish
-            if ((cacheInfoDir.cache_offset + cacheInfoDir.cache_size) < cacheInfoDir.sector_num) {
-                if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_NEXT)) {
-                    // failed to cache next block (should return TRUE even if
-                    // there is no more directory, as long as a CD read didnt fail
-                    return -1;
-                }
-            } else
+            if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
+                // we've reached the end of the current cache block (which may be end of entire dir
+                // so just break the loop
                 break;
+            }
 
-            tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
-        }
+            // Check if the current entry is a dir or a file
+            if (tocEntryPointer->fileProperties & 0x02) {
+                DPRINTF("We found a dir, and we want all dirs\n\n");
+                copyToTocEntry(&localTocEntry, tocEntryPointer);
+
+                if (dir_entry == 0) {
+                    if (cacheInfoDir.path_depth != 0) {
+                        DPRINTF("It's the first directory entry, so name it '..'\n\n");
+                        strcpy(localTocEntry.filename, "..");
+                    }
+                }
+
+                // Copy from localTocEntry
+                tocEntry[matched_entries] = localTocEntry;
+                matched_entries++;
+            } else { // it must be a file
+                DPRINTF("We found a file, but we dont want files (at least not yet)\n\n");
+            }
+
+            dir_entry++;
+
+            if ((unsigned int)matched_entries >= req_entries)  // if we've filled the requested buffer
+                return (matched_entries);        // then just return
+
+        }  // end of the current cache block
+
+        // if there is more dir to load, then load next chunk, else finish
+        if ((cacheInfoDir.cache_offset + cacheInfoDir.cache_size) < cacheInfoDir.sector_num) {
+            if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_NEXT)) {
+                // failed to cache next block (should return TRUE even if
+                // there is no more directory, as long as a CD read didnt fail
+                return -1;
+            }
+        } else
+            break;
+
+        tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
     }
 
     // Next do files
-    if ((getMode == CDFS_GET_FILES_ONLY) || (getMode == CDFS_GET_FILES_AND_DIRS)) {
-        // Cache the start of the requested directory
-        if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_START)) {
-            DPRINTF("cdfs_getDir - Call of cdfs_cacheDir failed\n\n");
-            return -1;
-        }
+    // Cache the start of the requested directory
+    if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_START)) {
+        DPRINTF("cdfs_getDir - Call of cdfs_cacheDir failed\n\n");
+        return -1;
+    }
 
-        tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
+    tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
 
-        // skip the first self-referencing entry
+    // skip the first self-referencing entry
+    tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
+
+    // skip the parent entry if this is the root
+    if (cacheInfoDir.path_depth == 0)
         tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
 
-        // skip the parent entry if this is the root
-        if (cacheInfoDir.path_depth == 0)
-            tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length);
+    dir_entry = 0;
 
-        dir_entry = 0;
+    while (1) {
+        DPRINTF("cdfs_getDir - inside while-loop\n\n");
 
-        while (1) {
-            DPRINTF("cdfs_getDir - inside while-loop\n\n");
+        // parse the current cache block
+        for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
+            if (tocEntryPointer->length == 0) {
+                // if we have a toc entry length of zero,
+                // then we've either reached the end of the sector, or the end of the dir
+                // so point to next sector (if there is one - will be checked by next condition)
 
-            // parse the current cache block
-            for (; tocEntryPointer < (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048)); tocEntryPointer = (struct DirTocEntry *)((u8 *)tocEntryPointer + tocEntryPointer->length)) {
-                if (tocEntryPointer->length == 0) {
-                    // if we have a toc entry length of zero,
-                    // then we've either reached the end of the sector, or the end of the dir
-                    // so point to next sector (if there is one - will be checked by next condition)
+                tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
+            }
 
-                    tocEntryPointer = (struct DirTocEntry *)(cacheInfoDir.cache + (((((u8 *)tocEntryPointer - cacheInfoDir.cache) / 2048) + 1) * 2048));
-                }
-
-                if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
-                    // we've reached the end of the current cache block (which may be end of entire dir
-                    // so just break the loop
-                    break;
-                }
-
-                // Check if the current entry is a dir or a file
-                if (tocEntryPointer->fileProperties & 0x02) {
-                    DPRINTF("We don't want files now\n\n");
-                } else { // it must be a file
-                    copyToTocEntry(&localTocEntry, tocEntryPointer);
-
-                    if (strlen(extensions) > 0) {
-                        // check if the file matches the extension list
-                        if (compareTocEntry(localTocEntry.filename, extensions)) {
-                            DPRINTF("We found a file that matches the requested extension list\n\n");
-                            // Copy from localTocEntry
-                            tocEntry[matched_entries] = localTocEntry; 
-                            matched_entries++;
-                        } else {
-                            DPRINTF("We found a file, but it didnt match the requested extension list\n\n");
-                        }
-                    } else { // no extension list to match against
-                        DPRINTF("We found a file, and there is not extension list to match against\n\n");
-
-                        // Copy from localTocEntry
-                        tocEntry[matched_entries] = localTocEntry; 
-                        matched_entries++;
-                    }
-                }
-
-                dir_entry++;
-
-                if ((unsigned int)matched_entries >= req_entries)  // if we've filled the requested buffer
-                    return (matched_entries);        // then just return
-
-            }  // end of the current cache block
-
-
-            // if there is more dir to load, then load next chunk, else finish
-            if ((cacheInfoDir.cache_offset + cacheInfoDir.cache_size) < cacheInfoDir.sector_num) {
-                if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_NEXT)) {
-                    // failed to cache next block (should return TRUE even if
-                    // there is no more directory, as long as a CD read didnt fail
-                    return -1;
-                }
-            } else
+            if (tocEntryPointer >= (struct DirTocEntry *)(cacheInfoDir.cache + (cacheInfoDir.cache_size * 2048))) {
+                // we've reached the end of the current cache block (which may be end of entire dir
+                // so just break the loop
                 break;
+            }
 
-            tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
-        }
+            // Check if the current entry is a dir or a file
+            if (tocEntryPointer->fileProperties & 0x02) {
+                DPRINTF("We don't want files now\n\n");
+            } else { // it must be a file
+                copyToTocEntry(&localTocEntry, tocEntryPointer);
+                // Copy from localTocEntry
+                tocEntry[matched_entries] = localTocEntry; 
+                matched_entries++;
+                }
+
+            dir_entry++;
+
+            if ((unsigned int)matched_entries >= req_entries)  // if we've filled the requested buffer
+                return (matched_entries);        // then just return
+
+        }  // end of the current cache block
+
+
+        // if there is more dir to load, then load next chunk, else finish
+        if ((cacheInfoDir.cache_offset + cacheInfoDir.cache_size) < cacheInfoDir.sector_num) {
+            if (!cdfs_cacheDir(cacheInfoDir.pathname, CACHE_NEXT)) {
+                // failed to cache next block (should return TRUE even if
+                // there is no more directory, as long as a CD read didnt fail
+                return -1;
+            }
+        } else
+            break;
+
+        tocEntryPointer = (struct DirTocEntry *)cacheInfoDir.cache;
     }
     // reached the end of the dir, before filling up the requested entries
 

--- a/iop/cdvd/cdfs/src/cdfs_iop.c
+++ b/iop/cdvd/cdfs/src/cdfs_iop.c
@@ -1035,7 +1035,7 @@ int cdfs_getDir(const char *pathname, struct TocEntry tocEntry[], unsigned int r
 
 // This function uses sceCdTrayReq to check if the disc in the disc drive has changed.
 // Once sceCdTrayReq is called it will reset the flag inside CDVDMAN.
-// Avoid using sceCdTrayReq with SCECdTrayCheck as arguemnt in other code if possible.
+// Avoid using sceCdTrayReq with SCECdTrayCheck as argument in other code if possible.
 
 int cdfs_checkDiskChanged(enum Cdvd_Changed_Index index) {
     u32 res = 0;

--- a/iop/cdvd/cdfs/src/cdfs_iop.h
+++ b/iop/cdvd/cdfs/src/cdfs_iop.h
@@ -18,12 +18,6 @@ struct TocEntry {
     char filename[128 + 1];
 } __attribute__((packed));
 
-enum CDFS_getMode {
-    CDFS_GET_FILES_ONLY = 1,
-    CDFS_GET_DIRS_ONLY = 2,
-    CDFS_GET_FILES_AND_DIRS = 3
-};
-
 enum Cdvd_Changed_Index {
     CHANGED_TOC = 0,
     CHANGED_FIO = 1,
@@ -35,7 +29,7 @@ extern int cdfs_start(void);
 extern int cdfs_finish(void);
 extern int cdfs_findfile(const char *fname, struct TocEntry *tocEntry);
 extern int cdfs_readSect(u32 lsn, u32 sectors, u8 *buf);
-extern int cdfs_getDir(const char *pathname, const char *extensions, enum CDFS_getMode getMode, struct TocEntry tocEntry[], unsigned int req_entries);
+extern int cdfs_getDir(const char *pathname, struct TocEntry tocEntry[], unsigned int req_entries);
 extern int cdfs_checkDiskChanged(enum Cdvd_Changed_Index index);
 
 #endif  // _CDFS_H

--- a/iop/cdvd/cdfs/src/cdfs_iop.h
+++ b/iop/cdvd/cdfs/src/cdfs_iop.h
@@ -16,6 +16,7 @@ struct TocEntry {
     u8 fileProperties;
     unsigned char dateStamp[8];
     char filename[128 + 1];
+    u8 padding[2]; // Padding to make the structure 4 byte aligned
 } __attribute__((packed));
 
 enum Cdvd_Changed_Index {

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -9,16 +9,19 @@
 
 // 16 sectors worth of toc entry
 #define MAX_FILES_PER_FOLDER 256
-#define MAX_FILES_OPENED 16
-#define MAX_FOLDERS_OPENED 16
+#define MAX_FILES_OPENED 4
+#define MAX_FOLDERS_OPENED 4
 #define MAX_BYTES_READ 16384
 
 #define DRIVER_UNIT_NAME "cdfs"
-#define DRIVER_UNIT_VERSION 2
-#define VERSION_STRINGIFY(x) #x
+#define DRIVER_MAJOR_VERSION 2
+#define DRIVER_MINOR_VERSION 2
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define DRIVER_DESC DRIVER_UNIT_NAME " Filedriver v" TOSTRING(DRIVER_MAJOR_VERSION) "." TOSTRING(DRIVER_MINOR_VERSION)
 
-IRX_ID(MODNAME, 1, 1);
+IRX_ID(MODNAME, DRIVER_MAJOR_VERSION, DRIVER_MINOR_VERSION);
 
 struct fdtable
 {
@@ -443,8 +446,8 @@ static iop_device_ops_t fio_ops = {
 static iop_device_t fio_driver = {
     DRIVER_UNIT_NAME,
     IOP_DT_FS,
-    DRIVER_UNIT_VERSION,
-    DRIVER_UNIT_NAME " Filedriver v" VERSION_STRINGIFY(DRIVER_UNIT_VERSION),
+    DRIVER_MAJOR_VERSION,
+    DRIVER_DESC,
     &fio_ops,
 };
 

--- a/iop/cdvd/cdfs/src/main.c
+++ b/iop/cdvd/cdfs/src/main.c
@@ -296,7 +296,7 @@ static int fio_openDir(iop_file_t *f, const char *path) {
     if (j >= MAX_FOLDERS_OPENED)
         return -ESRCH;
 
-    fod_table[j].files = cdfs_getDir(path, NULL, CDFS_GET_FILES_AND_DIRS, fod_table[j].entries, MAX_FILES_PER_FOLDER);
+    fod_table[j].files = cdfs_getDir(path, fod_table[j].entries, MAX_FILES_PER_FOLDER);
     if (fod_table[j].files < 0) {
         printf("The path doesn't exist\n\n");
         return -ENOENT;
@@ -381,10 +381,10 @@ static int fio_dread(iop_file_t *fd, io_dirent_t *dirent)
     dirent->stat.mode = (entry.fileProperties == CDFS_FILEPROPERTY_DIR) ? FIO_SO_IFDIR : FIO_SO_IFREG;
     dirent->stat.attr = entry.fileProperties;
     dirent->stat.size = entry.fileSize;
-    memcpy(dirent->stat.ctime, entry.dateStamp, 8);
-    memcpy(dirent->stat.atime, entry.dateStamp, 8);
-    memcpy(dirent->stat.mtime, entry.dateStamp, 8);
-    strncpy(dirent->name, entry.filename, 128);
+    memcpy(dirent->stat.ctime, entry.dateStamp, sizeof(entry.dateStamp));
+    memcpy(dirent->stat.atime, entry.dateStamp, sizeof(entry.dateStamp));
+    memcpy(dirent->stat.mtime, entry.dateStamp, sizeof(entry.dateStamp));
+    strncpy(dirent->name, entry.filename, sizeof(dirent->name));
     
     fod_table[i].filesIndex++;
     return fod_table[i].filesIndex;
@@ -411,9 +411,9 @@ static int fio_getstat(iop_file_t *fd, const char *name, io_stat_t *stat)
     stat->mode = (entry.fileProperties == CDFS_FILEPROPERTY_DIR) ? FIO_SO_IFDIR : FIO_SO_IFREG;
     stat->attr = entry.fileProperties;
     stat->size = entry.fileSize;
-    memcpy(stat->ctime, entry.dateStamp, 8);
-    memcpy(stat->atime, entry.dateStamp, 8);
-    memcpy(stat->mtime, entry.dateStamp, 8);
+    memcpy(stat->ctime, entry.dateStamp, sizeof(entry.dateStamp));
+    memcpy(stat->atime, entry.dateStamp, sizeof(entry.dateStamp));
+    memcpy(stat->mtime, entry.dateStamp, sizeof(entry.dateStamp));
 
     return ret;
 }


### PR DESCRIPTION
Reducing the number of max folders and max files that can be opened at the same time in the CDFS driver.
This drastically reduces the amount of RAM wasted on this driver.

I plan to do a further refactor in the following PRs, but this is a a quick win for now.

Before:
```
================== RAM ====================
Symbol                   Size        %
===========================================
?                        613.1 KiB   100.00
  fod_table              584.2 KiB    95.28
  local_buffer.1          18.0 KiB     2.94
  dvdvBuffer               2.0 KiB     0.33
  cdVolDesc                2.0 KiB     0.33
  localVolDesc.1           2.0 KiB     0.33
  cacheInfoDir             1.0 KiB     0.17
  pathcopy.3               1.0 KiB     0.16
  pathname.5               1.0 KiB     0.16
  dirname.2                1.0 KiB     0.16
  fd_table               256.0 B       0.04
  tocEntry.0             146.0 B       0.02
  ext_list.0             129.0 B       0.02
  filename.4             129.0 B       0.02
  fio_ops                 68.0 B       0.01
  fod_used                64.0 B       0.01
  fd_used                 64.0 B       0.01
  fio_driver              20.0 B       0.00
  cdvdChangedMagicLast     8.0 B       0.00
  _irx_id                  8.0 B       0.00
  lastsector               4.0 B       0.00
  last_bk                  4.0 B       0.00
  cdReadMode               4.0 B       0.00
  cdvdChangedMagic         4.0 B       0.00
===========================================
Symbols total            613.1 KiB
===========================================
```

After:
```
================== RAM ====================
Symbol                   Size        %
===========================================
?                        174.6 KiB   100.00
  fod_table              146.0 KiB    83.66
  local_buffer.1          18.0 KiB    10.31
  dvdvBuffer               2.0 KiB     1.15
  cdVolDesc                2.0 KiB     1.15
  localVolDesc.0           2.0 KiB     1.15
  cacheInfoDir             1.0 KiB     0.59
  pathcopy.2               1.0 KiB     0.57
  pathname.4               1.0 KiB     0.57
  dirname.1                1.0 KiB     0.57
  tocEntry.0             146.0 B       0.08
  filename.3             129.0 B       0.07
  fio_ops                 68.0 B       0.04
  fd_table                64.0 B       0.04
  fio_driver              20.0 B       0.01
  fod_used                16.0 B       0.01
  fd_used                 16.0 B       0.01
  cdvdChangedMagicLast     8.0 B       0.00
  _irx_id                  8.0 B       0.00
  lastsector               4.0 B       0.00
  last_bk                  4.0 B       0.00
  cdReadMode               4.0 B       0.00
  cdvdChangedMagic         4.0 B       0.00
===========================================
Symbols total            174.6 KiB
===========================================
```

Cheers