### PR TITLE
Delete semaphore on E_SIF_PKT_SEND error

### DIFF
--- a/ee/kernel/src/sifrpc.c
+++ b/ee/kernel/src/sifrpc.c
@@ -148,6 +148,7 @@ int SifBindRpc(SifRpcClientData_t *cd, int sid, int mode)
 
     if (!SifSendCmd(SIF_CMD_RPC_BIND, bind, RPC_PACKET_SIZE, NULL, NULL, 0)) {
         rpc_packet_free(bind);
+        DeleteSema(cd->hdr.sema_id);
         return -E_SIF_PKT_SEND;
     }
 
@@ -214,6 +215,7 @@ int SifCallRpc(SifRpcClientData_t *cd, int rpc_number, int mode,
 
     if (!SifSendCmd(SIF_CMD_RPC_CALL, call, RPC_PACKET_SIZE, sendbuf, cd->buff, ssize)) {
         rpc_packet_free(call);
+        DeleteSema(cd->hdr.sema_id);
         return -E_SIF_PKT_SEND;
     }
 
@@ -263,6 +265,7 @@ int SifRpcGetOtherData(SifRpcReceiveData_t *rd, void *src, void *dest,
 
     if (!SifSendCmd(SIF_CMD_RPC_RDATA, other, RPC_PACKET_SIZE, NULL, NULL, 0)) {
         rpc_packet_free(other);
+        DeleteSema(rd->hdr.sema_id);
         return -E_SIF_PKT_SEND;
     }
 


### PR DESCRIPTION
## Description
This PR solves an issue when `SifSendCmd` fails and the Semaphore wasn't being deleted.
Additionally, I'm now deleting the semaphore in case of success in the `_request_end` callback function, which simplifies the logic a bit.

Cheers