### PR TITLE
cleanup: remove unneeded memset in SifExitIopHeap

### DIFF
--- a/ee/kernel/src/iopheap.c
+++ b/ee/kernel/src/iopheap.c
@@ -62,7 +62,6 @@ int SifInitIopHeap()
 void SifExitIopHeap()
 {
     _ih_caps = 0;
-    memset(&_ih_caps, 0, sizeof _ih_caps);
 }
 #endif
 


### PR DESCRIPTION
It is redundant. It may be a typo on the version variable, but we don't need to check version in that case

Closes #434 