### PR TITLE
fix: use sio2_pad_transfer_init2 for xfer init with mtap

### DIFF
--- a/iop/system/padman/src/imports.lst
+++ b/iop/system/padman/src/imports.lst
@@ -64,7 +64,7 @@ xsio2man_IMPORTS_start
 rsio2man_IMPORTS_start
 #endif
 I_sio2_stat70_get
-I_sio2_pad_transfer_init
+I_sio2_pad_transfer_init2
 I_sio2_transfer2
 I_sio2_transfer_reset2
 I_sio2_mtap_change_slot

--- a/iop/system/padman/src/padData.c
+++ b/iop/system/padman/src/padData.c
@@ -335,7 +335,7 @@ void pdTransfer(void)
 	u32 slot;
 
 #ifdef BUILDING_XPADMAN
-	sio2_pad_transfer_init();
+	sio2_pad_transfer_init2();
 #endif
 
 	transferCount++;
@@ -450,7 +450,7 @@ u32 pdCheckConnection(u32 port, u32 slot)
 #endif
 
 #ifdef BUILDING_XPADMAN
-	sio2_pad_transfer_init();
+	sio2_pad_transfer_init2();
 #endif
 
 	change_slot_buffer[0] = slot;


### PR DESCRIPTION
This works around the backwards compat potential hang