### PR TITLE
Fix timer accuracy

### DIFF
--- a/ee/kernel/src/timer.c
+++ b/ee/kernel/src/timer.c
@@ -263,9 +263,10 @@ __attribute__((weak)) s32 StopTimerSystemTime(void)
 #endif
 
 #ifdef F_SetNextComp
+#define CLOCKS_GAP 0x200 // For assuring the timer interrupt is triggered
 void SetNextComp(u64 time_now)
 {
-    u64 a0, a1;
+    u64 current_schedule, next_schedule;
     counter_struct_t *timer_current;
 
     if (g_Timer.current_handling_timer_id >= 0)
@@ -279,14 +280,16 @@ void SetNextComp(u64 time_now)
         SetT2_MODE((*T2_MODE) & (~(1 << 11)));
         return;
     }
-    a0 = timer_current->timer_schedule + timer_current->timer_base_time - timer_current->timer_base_count;
+    current_schedule = timer_current->timer_schedule + timer_current->timer_base_time - timer_current->timer_base_count;
     timer_current = timer_current->timer_next;
+    
+    // Grouping the timers that are so close to each other, to reduce the number of interrupts
     while (timer_current != NULL)
     {
-        a1 = timer_current->timer_schedule + timer_current->timer_base_time - timer_current->timer_base_count;
-        if (a1 < (a0 + 0x733))
+        next_schedule = timer_current->timer_schedule + timer_current->timer_base_time - timer_current->timer_base_count;
+        if (next_schedule < (current_schedule + CLOCKS_GAP))
         {
-            a0 = a1;
+            current_schedule = next_schedule;
         }
         else
         {
@@ -294,15 +297,15 @@ void SetNextComp(u64 time_now)
         }
         timer_current = timer_current->timer_next;
     }
-    if (a0 < (time_now + 0x733))
+    if (current_schedule < (time_now + CLOCKS_GAP))
     {
-        SetT2_COMP((*T2_COUNT) + (0x733 >> (((*T2_MODE) & 3) << 2)));
+        SetT2_COMP((*T2_COUNT) + (CLOCKS_GAP >> (((*T2_MODE) & 3) << 2)));
         SetT2_MODE((*T2_MODE) & (~(1 << 11)));
     }
     else
     {
         SetT2_MODE((*T2_MODE) & (~(1 << 11)));
-        SetT2_COMP(a0 >> (((*T2_MODE) & 3) << 2));
+        SetT2_COMP(current_schedule >> (((*T2_MODE) & 3) << 2));
     }
 }
 #endif

--- a/ee/libcglue/samples/nanosleep/main.c
+++ b/ee/libcglue/samples/nanosleep/main.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     struct timespec tv = {0};
     tv.tv_sec = 1;
     tv.tv_nsec = 0;
-    error_tolerance = 200; // 200 miliseconds of error tolerance
+    error_tolerance = 5; // 5 miliseconds of error tolerance
 
 #if defined(SCREEN_DEBUG)
     init_scr();

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -805,7 +805,12 @@ int _gettimeofday(struct timeval *tv, struct timezone *tz)
 #ifdef F__times
 // Called from newlib timesr.c
 clock_t _times(struct tms *buffer) {
-	clock_t clk = GetTimerSystemTime() / (kBUSCLK / (1000 * 1000));
+	clock_t clk;
+	u32 busclock_sec;
+	u32 busclock_usec;
+
+	TimerBusClock2USec(GetTimerSystemTime(), &busclock_sec, &busclock_usec);
+	clk = busclock_sec * CLOCKS_PER_SEC + busclock_usec;
 
 	if (buffer != NULL) {
 		buffer->tms_utime  = clk;


### PR DESCRIPTION
## Description
This PR fixes an existing issue #530.

The existing timer implementation was working almost right, the real issue was in the `_times`'s implementation in `libcglue` that was losing too much precision.
Additional changes have been made too:
- Use `TimerBusClock2USec` for returning proper `usecs` in the `_times` function
- Improve `errno` logic in the `nanosleep` function.
- Improve the accuracy of the timer by reducing the GAP after the immediate equal interruption.
- Improve variable names and comments in the timer.
- Put back the error tolerance in the nanosleep example to `5ms` as it was originally.


Additionally, I have also tested implementation with the  program described here: https://github.com/ps2dev/ps2sdk/issues/527#issue-2132778883

```
Bigger diff: 24, requested: 9145, got: 9169
```

So everything looks to be right 👏 

Closes #530 