### PR TITLE
Link timer, timezone, and RTC functions only if they are used

### DIFF
--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -125,6 +125,8 @@ EXIT_OBJS += _exit_internals.o SetArg.o Exit.o ExecPS2.o LoadExecPS2.o ExecOSD.o
 
 TIMER_OBJS = \
 	timer_data.o \
+	_ps2sdk_init_timer.o \
+	_ps2sdk_deinit_timer.o \
 	SetT2.o \
 	SetT2_COUNT.o \
 	SetT2_MODE.o \

--- a/ee/kernel/include/kernel.h
+++ b/ee/kernel/include/kernel.h
@@ -575,10 +575,8 @@ extern void *GetEntryAddress(int syscall);
     void ExecOSD(int num_args, char *args[]) { _ExecOSD(num_args, args); }
 
 #define DISABLE_TimerSystemTime() \
-    s32 InitTimer(s32 in_mode) {(void)in_mode; return 0;} \
-    s32 EndTimer(void) {return 0;} \
-    s32 StartTimerSystemTime(void) {return 0;} \
-    s32 StopTimerSystemTime(void) {return 0;}
+    void _ps2sdk_init_timer() {} \
+    void _ps2sdk_deinit_timer() {}
 
 #define DISABLE_TimerAlarm() \
     void ForTimer_InitAlarm(void) {}

--- a/ee/kernel/include/timer.h
+++ b/ee/kernel/include/timer.h
@@ -66,6 +66,11 @@ typedef u64 (*timer_alarm_handler_t)(s32 id, u64 scheduled_time, u64 actual_time
 extern "C" {
 #endif
 
+extern void _ps2sdk_init_timer_impl(void);
+extern void _ps2sdk_init_timer(void);
+extern void _ps2sdk_deinit_timer_impl(void);
+extern void _ps2sdk_deinit_timer(void);
+
 extern s32 InitTimer(s32 in_mode);
 extern s32 EndTimer(void);
 extern s32 GetTimerPreScaleFactor(void);

--- a/ee/kernel/src/initsys.c
+++ b/ee/kernel/src/initsys.c
@@ -21,8 +21,7 @@
 void _InitSys(void)
 {
     InitAlarm();
-    InitTimer(2);
-    StartTimerSystemTime();
+    _ps2sdk_init_timer();
     InitThread();
     InitExecPS2();
     InitTLBFunctions();
@@ -32,8 +31,7 @@ void _InitSys(void)
 #ifdef F_TerminateLibrary
 void TerminateLibrary(void)
 {
-    StopTimerSystemTime();
-    EndTimer();
+    _ps2sdk_deinit_timer();
     InitTLB();
 }
 #endif

--- a/ee/kernel/src/timer.c
+++ b/ee/kernel/src/timer.c
@@ -79,6 +79,30 @@ extern timer_ee_global_struct g_Timer;
 extern counter_struct_t g_CounterBuf[COUNTER_COUNT] __attribute__((aligned(64)));
 #endif
 
+#ifdef F__ps2sdk_init_timer
+void __attribute__((weak)) _ps2sdk_init_timer_impl(void);
+__attribute__((weak)) void _ps2sdk_init_timer(void)
+{
+    // cppcheck-suppress knownConditionTrueFalse
+    if (&_ps2sdk_init_timer_impl)
+    {
+        _ps2sdk_init_timer_impl();
+    }
+}
+#endif
+
+#ifdef F__ps2sdk_deinit_timer
+void __attribute__((weak)) _ps2sdk_deinit_timer_impl(void);
+__attribute__((weak)) void _ps2sdk_deinit_timer(void)
+{
+    // cppcheck-suppress knownConditionTrueFalse
+    if (&_ps2sdk_deinit_timer_impl)
+    {
+        _ps2sdk_deinit_timer_impl();
+    }
+}
+#endif
+
 #ifdef F_SetT2
 void SetT2(volatile void *ptr, u32 val)
 {
@@ -477,6 +501,18 @@ u64 iGetTimerSystemTime(void)
     timer_system_time_now = (timer_handled_count << 16) | low;
     timer_system_time_now = timer_system_time_now << ((mode & 3) << 2);
     return timer_system_time_now;
+}
+
+void _ps2sdk_init_timer_impl(void)
+{
+    InitTimer(2);
+    StartTimerSystemTime();
+}
+
+void _ps2sdk_deinit_timer_impl(void)
+{
+    StopTimerSystemTime();
+    EndTimer();
 }
 #endif
 

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -8,9 +8,16 @@
 
 EE_LIB = libcglue.a
 
-CORE_OBJS = rtc.o
+RTC_OBJS = \
+	_libcglue_rtc_data.o \
+	_libcglue_rtc_get_offset_from_busclk.o \
+	_libcglue_rtc_update.o
 
-TIMEZONE_OBJS = _libcglue_timezone_update.o ps2sdk_setTimezone.o ps2sdk_setDaylightSaving.o
+TIMEZONE_OBJS = \
+	_libcglue_timezone_update_impl.o \
+	_libcglue_timezone_update.o \
+	ps2sdk_setTimezone.o \
+	ps2sdk_setDaylightSaving.o
 
 FDMAN_OBJS = \
 	__fdman_sema.o \
@@ -229,6 +236,7 @@ SOCKET_OBJS = \
 
 EE_OBJS = \
 	$(CORE_OBJS) \
+	$(RTC_OBJS) \
 	$(TIMEZONE_OBJS) \
 	$(SJIS_OBJS) \
 	$(TIME_OBJS) \
@@ -248,6 +256,10 @@ include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make
 include $(PS2SDKSRC)/ee/Rules.make
 include $(PS2SDKSRC)/ee/Rules.release
+
+$(RTC_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)rtc.c
+	$(DIR_GUARD)
+	$(EE_C_COMPILE) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 $(TIMEZONE_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)timezone.c
 	$(DIR_GUARD)

--- a/ee/libcglue/include/ps2sdkapi.h
+++ b/ee/libcglue/include/ps2sdkapi.h
@@ -175,6 +175,8 @@ static inline ps2_clock_t ps2_clock(void) {
 }
 
 extern s64 _ps2sdk_rtc_offset_from_busclk;
+s64 _libcglue_rtc_get_offset_from_busclk(void);
+extern void _libcglue_rtc_update_impl();
 extern void _libcglue_rtc_update();
 
 // The newlib port does not support 64bit
@@ -183,6 +185,7 @@ typedef int64_t off64_t;
 extern off64_t lseek64(int fd, off64_t offset, int whence);
 
 // Functions to be used related to timezone
+extern void _libcglue_timezone_update_impl();
 extern void _libcglue_timezone_update();
 
 extern void ps2sdk_setTimezone(int timezone);

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -788,7 +788,7 @@ int _gettimeofday(struct timeval *tv, struct timezone *tz)
 		u32 busclock_usec;
 
 		TimerBusClock2USec(GetTimerSystemTime(), &busclock_sec, &busclock_usec);
-		tv->tv_sec = (time_t)(_ps2sdk_rtc_offset_from_busclk + ((s64)busclock_sec));
+		tv->tv_sec = (time_t)(_libcglue_rtc_get_offset_from_busclk() + ((s64)busclock_sec));
 		tv->tv_usec = busclock_usec;
 	}
 

--- a/ee/libcglue/src/rtc.c
+++ b/ee/libcglue/src/rtc.c
@@ -24,10 +24,17 @@
 // The definition for this function is located in ee/rpc/cdvd/src/scmd.c
 extern time_t ps2time(time_t *t);
 
+#ifdef F__libcglue_rtc_data
 s64 _ps2sdk_rtc_offset_from_busclk = 0;
+#endif
 
-__attribute__((weak))
-void _libcglue_rtc_update()
+#ifdef F__libcglue_rtc_get_offset_from_busclk
+s64 _libcglue_rtc_get_offset_from_busclk(void)
+{
+	return _ps2sdk_rtc_offset_from_busclk;
+}
+
+void _libcglue_rtc_update_impl()
 {
 	time_t rtc_sec;
 	u32 busclock_sec;
@@ -38,3 +45,17 @@ void _libcglue_rtc_update()
 
 	_ps2sdk_rtc_offset_from_busclk = ((s64)rtc_sec) - ((s64)busclock_sec);
 }
+#endif
+
+#ifdef F__libcglue_rtc_update
+void __attribute__((weak)) _libcglue_rtc_update_impl();
+__attribute__((weak))
+void _libcglue_rtc_update()
+{
+	// cppcheck-suppress knownConditionTrueFalse
+	if (&_libcglue_rtc_update_impl)
+	{
+		_libcglue_rtc_update_impl();
+	}
+}
+#endif


### PR DESCRIPTION
Allows smaller executables when not using those functions.

Nanosleep and timezone samples continue to function.