### PR TITLE
[ps2hdd] Do not restore journal on unformatted HDDs to avoid corrupting non-APA HDDs

### DIFF
--- a/iop/hdd/apa/src/hdd.c
+++ b/iop/hdd/apa/src/hdd.c
@@ -339,7 +339,7 @@ int APA_ENTRYPOINT(int argc, char *argv[])
 	{
 		if(hddDevices[i].status<2)
 		{
-			if(apaJournalRestore(i) != 0)
+			if((hddDevices[i].status != 1) && apaJournalRestore(i) != 0)
 			{
 				APA_PRINTF(APA_DRV_NAME": error: log check failed.\n");
 				return hddInitError();


### PR DESCRIPTION
This PR adds a check before `apaJournalRestore` to avoid corrupting non-APA HDDs during ps2hdd initialization.
Fixes #726.