### PR TITLE
srxfixup: explain IOP max alignment errors

### DIFF
--- a/tools/srxfixup/src/srxgen.c
+++ b/tools/srxfixup/src/srxgen.c
@@ -310,6 +310,12 @@ int layout_srx_file(elf_file *elf)
 			}
 		}
 	}
+
+	if (error && tp->target == SRX_TARGET_IOP)
+	{
+		fprintf(stderr, "LOADCORE limits possible alignment to 16 bytes\n");
+	}
+
 	free(order);
 	free(neworder);
 	return error;


### PR DESCRIPTION
It seemed like a pretty confusing limitation, so it's probably good to explain why.