### PR TITLE
Fix SPU2 DMA address calculation

### DIFF
--- a/iop/sound/libsd/src/libsd.c
+++ b/iop/sound/libsd/src/libsd.c
@@ -1548,9 +1548,9 @@ static u32 DmaStartStop(int mainarg, void *vararg2, u32 vararg3)
 	switch ( mainarg & 0xF )
 	{
 		case 2:
-			tsa_tmp = ((u16)(uiptr)vararg2 >> 1) & ~7;
-			spu2_mmio_hwport->m_u.m_m.m_core_regs[core].m_cregs.m_tsa.m_pair[1] = tsa_tmp;
-			spu2_mmio_hwport->m_u.m_m.m_core_regs[core].m_cregs.m_tsa.m_pair[0] = (tsa_tmp >> 16) & 0xFFFF;
+			tsa_tmp = ((uiptr)vararg2 >> 1) & ~7;
+			spu2_mmio_hwport->m_u.m_m.m_core_regs[core].m_cregs.m_tsa.m_pair[0] = (tsa_tmp >> 16) & 0x000F;
+			spu2_mmio_hwport->m_u.m_m.m_core_regs[core].m_cregs.m_tsa.m_pair[1] = tsa_tmp & 0xFFFF;
 			return 0;
 		case 4:
 			if ( (spu2_mmio_hwport->m_u.m_m.m_core_regs[core].m_cregs.m_attr & SD_DMA_IN_PROCESS) )


### PR DESCRIPTION
I was seeing some strange behaviour when ADPCM voice samples were being uploaded past a certain address.

It seems that the Transfer Start Address was being truncated to 16 bits when it should be 20. This adds the extra 4 bits to the TSAH register, meaning that the full 2MB is now addressable (in 16 bit units). As far as I can tell, this fixes the problem.