### PR TITLE
graph: fix callback function ptr

### DIFF
--- a/ee/graph/include/graph.h
+++ b/ee/graph/include/graph.h
@@ -132,7 +132,7 @@ extern void graph_set_bgcolor(unsigned char r, unsigned char g, unsigned char b)
 extern void graph_set_output(int rc1, int rc2, int alpha_select, int alpha_output, int blend_method, unsigned char alpha);
 
 /** Add a vsync interrupt handler */
-extern int graph_add_vsync_handler(int (*vsync_callback)());
+extern int graph_add_vsync_handler(int (*vsync_callback)(int));
 
 /** Remove a vsync interrupt handler */
 extern void graph_remove_vsync_handler(int callback_id);

--- a/ee/graph/src/graph.c
+++ b/ee/graph/src/graph.c
@@ -26,7 +26,7 @@ int graph_initialize(int fbp, int width, int height, int psm, int x, int y)
 
 }
 
-int graph_add_vsync_handler(int (*vsync_callback)())
+int graph_add_vsync_handler(int (*vsync_callback)(int))
 {
 
 	int callback_id;


### PR DESCRIPTION
Specify argument type of function ptr, empty args will be equavalent to `(void)` in future C standards. Fixes a GCC15 error.