### PR TITLE
add implementation of arcade `DAEMON.IRX`

### DIFF
--- a/iop/security/daemon/Makefile
+++ b/iop/security/daemon/Makefile
@@ -1,0 +1,21 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+
+IOP_INCS += \
+	-I$(PS2SDKSRC)/iop/system/thbase/include \
+	-I$(PS2SDKSRC)/iop/memorycard/mcman/include \
+	-I$(PS2SDKSRC)/iop/system/stdio/include \
+	-I$(PS2SDKSRC)/iop/system/intrman/include
+
+IOP_OBJS = daemon.o imports.o
+
+include $(PS2SDKSRC)/Defs.make
+include $(PS2SDKSRC)/iop/Rules.bin.make
+include $(PS2SDKSRC)/iop/Rules.make
+include $(PS2SDKSRC)/iop/Rules.release

--- a/iop/security/daemon/README.MD
+++ b/iop/security/daemon/README.MD
@@ -1,0 +1,11 @@
+# Daemon (aka: sec_checker)
+
+This module, found on the bootrom of the Arcade PS2s (COH-H models and derivative units) is in charge of checking the security dongle status.
+
+Arcade SYSCON has a 3 to 5 minutes countdown (time may depend on the model) to reset the console.
+
+Arcade Mechacon resets this countdown when the secrAuthDongle routine is successfully completed.
+
+This module setups an IOP thread that calls mcdetectcard2 (DONGLEMAN EXPORT:21) once every minute. effectively keeping the watchdog at bay, but also making access to `mc0:/` rather unstable.
+
+This module is placed here just for hystorical purposes and preservation. there is (as of today) no reason to use a homebrew implementation in favor of `rom0:DAEMON`

--- a/iop/security/daemon/src/daemon.c
+++ b/iop/security/daemon/src/daemon.c
@@ -1,0 +1,34 @@
+#include "irx_imports.h"
+
+IRX_ID("Sec_Checker", 0x1, 0x1)
+
+void sec_checker(void) {
+    int x;
+    printf("check card routine start\n");
+    do {
+        McDetectCard2(0,0);
+        x = 0x3c;
+        while (0 < x) {
+            DelayThread(1000000);
+            x--;
+        }
+    } while ( 1 );
+
+}
+
+//Original debug symbol: `start`
+int _start() {
+    iop_thread_t sec_thread;
+    int thid, bVar1;
+    CpuEnableIntr();
+    sec_thread.attr = TH_C;
+    sec_thread.thread = sec_checker;
+    sec_thread.priority = LOWEST_PRIORITY;
+    sec_thread.stacksize = 0x800;
+    sec_thread.option = 0;
+    thid = CreateThread(&sec_thread);
+    bVar1 = thid < 1;
+    if (!bVar1)
+    StartThread(thid,0);
+    return bVar1;
+}

--- a/iop/security/daemon/src/imports.lst
+++ b/iop/security/daemon/src/imports.lst
@@ -1,0 +1,18 @@
+xmcman_IMPORTS_start
+//Debug Symbol: mciConfInsert
+I_McDetectCard2
+xmcman_IMPORTS_end
+
+intrman_IMPORTS_start
+I_CpuEnableIntr
+intrman_IMPORTS_end
+
+stdio_IMPORTS_start
+I_printf
+stdio_IMPORTS_end
+
+thbase_IMPORTS_start
+I_CreateThread
+I_StartThread
+I_DelayThread
+thbase_IMPORTS_end

--- a/iop/security/daemon/src/irx_imports.h
+++ b/iop/security/daemon/src/irx_imports.h
@@ -1,0 +1,6 @@
+#include <irx.h>
+
+#include <mcman.h>
+#include <intrman.h>
+#include <stdio.h>
+#include <thbase.h>


### PR DESCRIPTION
# Daemon (aka: sec_checker)

This module, found on the bootrom of the Arcade PS2s (COH-H models and derivative units) is in charge of checking the security dongle status.

Arcade SYSCON has a 3 to 5 minutes countdown (time may depend on the model) to reset the console.

Arcade Mechacon resets this countdown when the secrAuthDongle routine is successfully completed.

This module setups an IOP thread that calls mcdetectcard2 (DONGLEMAN EXPORT:21) once every minute. effectively keeping the watchdog at bay, but also making access to `mc0:/` rather unstable.

This module is placed here just for hystorical purposes and preservation. there is (as of today) no reason to use a homebrew implementation in favor of `rom0:DAEMON`

> [!NOTE]
> Due to the previosly mentioned things. the commit does not include hooking the daemon source code to the PS2SDK buildsystem. if it's prefferred to have it building with the SDK. please let me know and I'll add it