### PR TITLE
bdm MBR add support for VBR

### DIFF
--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -18,7 +18,7 @@ int partitions_sanity_check_mbr(struct block_device *bd, master_boot_record* pMb
     for (int i = 0; i < 4; i++)
     {
         
-        if (pMbrBlock->primary_partitions[i] != 0) {
+        if (pMbrBlock->primary_partitions[i].partition_type != 0) {
             
             if((pMbrBlock->primary_partitions[i].first_lba == 0) || (pMbrBlock->primary_partitions[i].first_lba >= bd->sectorCount))
                 return 0; //invalid

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -39,6 +39,7 @@ int part_connect_mbr(struct block_device *bd)
     int ret;
     int mountCount = 0;
     int partIndex;
+    int valid_partitions;
 
     M_DEBUG("%s\n", __func__);
     

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -89,7 +89,7 @@ int part_connect_mbr(struct block_device *bd)
 
     printf("MBR disk valid_partitions=%d \n", valid_partitions);
 
-    //Most likely a VDH
+    //Most likely a VBR
     if(valid_partitions == 0) {
 
         if ((partIndex = GetNextFreePartitionIndex()) == -1)

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -83,19 +83,19 @@ int part_connect_mbr(struct block_device *bd)
         return rval;
     }
     
-    // Loop and parse the primary partition entries in the MBR block.
-    printf("Found MBR disk\n");
-
+    
     valid_partitions = partitions_sanity_check_mbr(bd, pMbrBlock);
-
-    printf("MBR disk valid_partitions=%d \n", valid_partitions);
 
     //Most likely a VBR
     if(valid_partitions == 0) {
+        printf("MBR disk valid_partitions=%d \n", valid_partitions);
         FreeSysMemory(pMbrBlock);
         return -1;
     }
-    
+
+    printf("Found MBR disk\n");
+
+    // Loop and parse the primary partition entries in the MBR block.
     for (int i = 0; i < 4; i++)
     {
         // Check if the partition is active, checking the status bit is not reliable so check if the sector_count is greater than zero instead.
@@ -114,7 +114,6 @@ int part_connect_mbr(struct block_device *bd)
         {
             // No more free partition slots.
             printf("Can't mount partition, no more free partition slots!\n");
-            FreeSysMemory(pMbrBlock);
             continue;
         }
 

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -87,7 +87,7 @@ int part_connect_mbr(struct block_device *bd)
 
     valid_partitions = partitions_sanity_check_mbr(bd, pMbrBlock);
 
-    printf("MBR disk valid_partitions=% \n", valid_partitions);
+    printf("MBR disk valid_partitions=%d \n", valid_partitions);
 
     //Most likely a VDH
     if(valid_partitions == 0) {

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -97,7 +97,7 @@ int part_connect_mbr(struct block_device *bd)
         {
             // No more free partition slots.
             printf("Can't mount partition, no more free partition slots!\n");
-            continue;
+            return -1;
         }
 
         // Create the pseudo block device for the partition.
@@ -110,8 +110,6 @@ int part_connect_mbr(struct block_device *bd)
         g_part_bd[partIndex].sectorOffset = bd->sectorOffset;
         g_part_bd[partIndex].sectorCount  = bd->sectorCount;
         bdm_connect_bd(&g_part_bd[partIndex]);
-        //TODO, mountCount should only increase on success of bdm_connect_bd
-        mountCount++;
         
         FreeSysMemory(pMbrBlock);
         return 0;

--- a/iop/fs/bdm/src/part_driver_mbr.c
+++ b/iop/fs/bdm/src/part_driver_mbr.c
@@ -92,27 +92,8 @@ int part_connect_mbr(struct block_device *bd)
 
     //Most likely a VBR
     if(valid_partitions == 0) {
-
-        if ((partIndex = GetNextFreePartitionIndex()) == -1)
-        {
-            // No more free partition slots.
-            printf("Can't mount partition, no more free partition slots!\n");
-            return -1;
-        }
-
-        // Create the pseudo block device for the partition.
-        g_part[partIndex].bd              = bd;
-        g_part_bd[partIndex].name         = bd->name;
-        g_part_bd[partIndex].devNr        = bd->devNr;
-        g_part_bd[partIndex].parNr        = 1;
-        g_part_bd[partIndex].parId        = 0; //Can be any type of (ex)FATxx, is parsed later.
-        g_part_bd[partIndex].sectorSize   = bd->sectorSize;
-        g_part_bd[partIndex].sectorOffset = bd->sectorOffset;
-        g_part_bd[partIndex].sectorCount  = bd->sectorCount;
-        bdm_connect_bd(&g_part_bd[partIndex]);
-        
         FreeSysMemory(pMbrBlock);
-        return 0;
+        return -1;
     }
     
     for (int i = 0; i < 4; i++)
@@ -133,6 +114,7 @@ int part_connect_mbr(struct block_device *bd)
         {
             // No more free partition slots.
             printf("Can't mount partition, no more free partition slots!\n");
+            FreeSysMemory(pMbrBlock);
             continue;
         }
 


### PR DESCRIPTION
Latest bdm exFAT drivers fail on some FAT32 drivers. Looks like bdm has forgot to add support for VBR.

On invalid MBR records it is trying to mount invalid partitions. This restores that functionality. Many of the such devices are formatted this way to bypass FAT32 max limit of 32GB in Windows. 

Alternatively someone needs to add better support for VBR. Sometimes a VBR can be valid and not even have MBR signature in the end of first sector. For now this will do.

The original authors of bdm are welcomed to give their insight.

resolves DKWDRV/DKWDRV#82

Possible impacts OPL since a long time already?

resolves ps2homebrew/Open-PS2-Loader#1311
resolves ps2homebrew/Open-PS2-Loader#1295
resolves ps2homebrew/Open-PS2-Loader#1271
resolves ps2homebrew/Open-PS2-Loader#1493


