### PR TITLE
Specify minimum policy version for CMake backwards compatibility

### DIFF
--- a/samples/ps2dev.cmake
+++ b/samples/ps2dev.cmake
@@ -7,7 +7,7 @@
 # Copyright (C) 2024-Present PS2DEV Team
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 INCLUDE(CMakeForceCompiler)
 if(DEFINED ENV{PS2SDK})

--- a/samples/ps2dev_iop.cmake
+++ b/samples/ps2dev_iop.cmake
@@ -7,7 +7,7 @@
 # Copyright (C) 2024-Present PS2DEV Team
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.12)
 
 INCLUDE(CMakeForceCompiler)
 if(DEFINED ENV{PS2SDK})


### PR DESCRIPTION
Fixes usage with newer cmake that dropped support for older versions compatibility