### PR TITLE
bdm add support for getting USB device port number.

### DIFF
--- a/common/include/usbhdfsd-common.h
+++ b/common/include/usbhdfsd-common.h
@@ -22,20 +22,6 @@ typedef struct bd_fragment {
     u32 count;  /// number of sector in this fragment
 } __attribute__((packed)) bd_fragment_t;
 
-typedef struct _mass_dev
-{
-    int controlEp;          // config endpoint id
-    int bulkEpI;            // in endpoint id
-    int bulkEpO;            // out endpoint id
-    int devId;              // device id
-    unsigned char configId; // configuration id
-    unsigned char status;
-    unsigned char interfaceNumber; // interface number
-    unsigned char interfaceAlt;    // interface alternate setting
-    int usbPortNumber; //physical port number the USB device is connected to
-    int ioSema;
-    struct scsi_interface scsi;
-} mass_dev;
 
 // IOCTL function codes
 /** Rename opened file. Data input to ioctl() -> new, full filename of file. */

--- a/common/include/usbhdfsd-common.h
+++ b/common/include/usbhdfsd-common.h
@@ -22,6 +22,21 @@ typedef struct bd_fragment {
     u32 count;  /// number of sector in this fragment
 } __attribute__((packed)) bd_fragment_t;
 
+typedef struct _mass_dev
+{
+    int controlEp;          // config endpoint id
+    int bulkEpI;            // in endpoint id
+    int bulkEpO;            // out endpoint id
+    int devId;              // device id
+    unsigned char configId; // configuration id
+    unsigned char status;
+    unsigned char interfaceNumber; // interface number
+    unsigned char interfaceAlt;    // interface alternate setting
+    int usbPortNumber; //physical port number the USB device is connected to
+    int ioSema;
+    struct scsi_interface scsi;
+} mass_dev;
+
 // IOCTL function codes
 /** Rename opened file. Data input to ioctl() -> new, full filename of file. */
 #define USBMASS_IOCTL_RENAME         0x0000

--- a/common/include/usbhdfsd-common.h
+++ b/common/include/usbhdfsd-common.h
@@ -37,6 +37,8 @@ typedef struct bd_fragment {
 #define USBMASS_IOCTL_GET_FRAGLIST   0x0005
 /** Get the device number for the block device backing the mass partition */
 #define USBMASS_IOCTL_GET_DEVICE_NUMBER     0x0006
+/** Get the physical USB port number where device is connected. 00 = Root Hub, 01=Rightmost port, 02=Leftmost Port */
+#define USBMASS_IOCTL_GET_USB_DEVICE_PORT_NUMBER     0x0007
 
 // DEVCTL function codes
 /** Issues the SCSI STOP UNIT command to the specified device. Use this to shut down devices properly. */

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -712,7 +712,7 @@ int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, void *r
 
             ret = -ENXIO;
             
-            if(bdu && (strncmp(bd->name, "mass", 4) == 0)) {
+            if(bdu && (strncmp(bdu->name, "mass", 4) == 0)) {
                 struct scsi_interface *scsi = (struct scsi_interface *)bdu->priv;
                 if (scsi) {
                     mass_dev *dev = (mass_dev *)scsi->priv;

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -709,28 +709,25 @@ int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, void *r
             break;
         case USBMASS_IOCTL_GET_USB_DEVICE_PORT_NUMBER:
             struct block_device* bd = fatfs_fs_driver_get_mounted_bd_from_index(file->obj.fs->pdrv);
-            if (bd == NULL)
-                ret = -ENXIO;
 
-            if(strncmp(bd->name, "mass", 4) != 0)
-                ret = -ENXIO;
-
-            struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
-            if (scsi == NULL)
-                ret = -ENXIO;
+            ret = -ENXIO;
             
-            mass_dev *dev = (mass_dev *)scsi->priv;
-
-            if (dev == NULL)
-                ret = -ENXIO;
-
-            /*
-            <0 = Invalid
-            00 = Root Hub,
-            01 = Rightmost port, 
-            02 = Leftmost Port
-            */
-            ret = dev->usbPortNumber;
+            if(bd && (strncmp(bd->name, "mass", 4) == 0)) {
+                struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
+                if (scsi) {
+                    mass_dev *dev = (mass_dev *)scsi->priv;
+                    if(dev) {
+                        /*
+                        <0 = Invalid
+                        00 = Root Hub,
+                        01 = Rightmost port, 
+                        02 = Leftmost Port
+                        */
+                        ret = dev->usbPortNumber;
+                    }
+                }
+            }
+            
             break;
         }
         default:

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -708,12 +708,12 @@ int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, void *r
             }
             break;
         case USBMASS_IOCTL_GET_USB_DEVICE_PORT_NUMBER:
-            struct block_device* bd = fatfs_fs_driver_get_mounted_bd_from_index(file->obj.fs->pdrv);
+            struct block_device* bdu = fatfs_fs_driver_get_mounted_bd_from_index(file->obj.fs->pdrv);
 
             ret = -ENXIO;
             
-            if(bd && (strncmp(bd->name, "mass", 4) == 0)) {
-                struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
+            if(bdu && (strncmp(bd->name, "mass", 4) == 0)) {
+                struct scsi_interface *scsi = (struct scsi_interface *)bdu->priv;
                 if (scsi) {
                     mass_dev *dev = (mass_dev *)scsi->priv;
                     if(dev) {

--- a/iop/fs/bdmfs_fatfs/src/fs_driver.c
+++ b/iop/fs/bdmfs_fatfs/src/fs_driver.c
@@ -707,6 +707,31 @@ int fs_ioctl2(iop_file_t *fd, int cmd, void *data, unsigned int datalen, void *r
                 ret = 0;
             }
             break;
+        case USBMASS_IOCTL_GET_USB_DEVICE_PORT_NUMBER:
+            struct block_device* bd = fatfs_fs_driver_get_mounted_bd_from_index(file->obj.fs->pdrv);
+            if (bd == NULL)
+                ret = -ENXIO;
+
+            if(strncmp(bd->name, "mass", 4) != 0)
+                ret = -ENXIO;
+
+            struct scsi_interface *scsi = (struct scsi_interface *)bd->priv;
+            if (scsi == NULL)
+                ret = -ENXIO;
+            
+            mass_dev *dev = (mass_dev *)scsi->priv;
+
+            if (dev == NULL)
+                ret = -ENXIO;
+
+            /*
+            <0 = Invalid
+            00 = Root Hub,
+            01 = Rightmost port, 
+            02 = Leftmost Port
+            */
+            ret = dev->usbPortNumber;
+            break;
         }
         default:
             break;

--- a/iop/fs/bdmfs_fatfs/src/imports.lst
+++ b/iop/fs/bdmfs_fatfs/src/imports.lst
@@ -28,6 +28,7 @@ I_memcmp
 I_memcpy
 I_strlen
 I_strcmp
+I_strncmp
 I_strcpy
 I_strncpy
 I_strtol

--- a/iop/fs/bdmfs_fatfs/src/include/fs_driver.h
+++ b/iop/fs/bdmfs_fatfs/src/include/fs_driver.h
@@ -4,6 +4,16 @@
 #include <bdm.h>
 #include "ff.h"
 
+struct scsi_interface
+{
+    void *priv;
+    char *name;
+    unsigned int max_sectors;
+
+    int (*get_max_lun)(struct scsi_interface *scsi);
+    int (*queue_cmd)(struct scsi_interface *scsi, const unsigned char *cmd, unsigned int cmd_len, unsigned char *data, unsigned int data_len, unsigned int data_wr);
+};
+
 typedef struct _mass_dev
 {
     int controlEp;          // config endpoint id

--- a/iop/fs/bdmfs_fatfs/src/include/fs_driver.h
+++ b/iop/fs/bdmfs_fatfs/src/include/fs_driver.h
@@ -4,6 +4,21 @@
 #include <bdm.h>
 #include "ff.h"
 
+typedef struct _mass_dev
+{
+    int controlEp;          // config endpoint id
+    int bulkEpI;            // in endpoint id
+    int bulkEpO;            // out endpoint id
+    int devId;              // device id
+    unsigned char configId; // configuration id
+    unsigned char status;
+    unsigned char interfaceNumber; // interface number
+    unsigned char interfaceAlt;    // interface alternate setting
+    int usbPortNumber; //physical port number the USB device is connected to
+    int ioSema;
+    struct scsi_interface scsi;
+} mass_dev;
+
 typedef struct fatfs_fs_driver_mount_info_
 {
     FATFS fatfs;

--- a/iop/usb/usbmass_bd/src/imports.lst
+++ b/iop/usb/usbmass_bd/src/imports.lst
@@ -36,4 +36,5 @@ I_sceUsbdClosePipe
 I_sceUsbdSetPrivateData
 I_sceUsbdTransferPipe
 I_sceUsbdRegisterLdd
+I_sceUsbdGetDeviceLocation
 usbd_IMPORTS_end

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -37,20 +37,6 @@
 #define CBW_TAG 0x43425355
 #define CSW_TAG 0x53425355
 
-typedef struct _mass_dev
-{
-    int controlEp;          // config endpoint id
-    int bulkEpI;            // in endpoint id
-    int bulkEpO;            // out endpoint id
-    int devId;              // device id
-    unsigned char configId; // configuration id
-    unsigned char status;
-    unsigned char interfaceNumber; // interface number
-    unsigned char interfaceAlt;    // interface alternate setting
-    int usbPortNumber; //physical port number the USB device is connected to
-    int ioSema;
-    struct scsi_interface scsi;
-} mass_dev;
 
 typedef struct _cbw_packet
 {

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -47,6 +47,7 @@ typedef struct _mass_dev
     unsigned char status;
     unsigned char interfaceNumber; // interface number
     unsigned char interfaceAlt;    // interface alternate setting
+    int usbPortNumber; //physical port number the USB device is connected to
     int ioSema;
     struct scsi_interface scsi;
 } mass_dev;

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -650,7 +650,7 @@ static int usb_mass_connect(int devId)
     dev->bulkEpI = -1;
     dev->bulkEpO = -1;
 
-    usb_get_port_number(devId, mass_dev);
+    usb_get_port_number(devId, dev);
     
     /* open the config endpoint */
     dev->controlEp = sceUsbdOpenPipe(devId, NULL);

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -614,6 +614,13 @@ static int usb_mass_probe(int devId)
     return 1;
 }
 
+static void usb_get_port_number(int devId, mass_dev *dev) {
+    dev->usbPortNumber = -1;
+    u8 path[16];
+    if(sceUsbdGetDeviceLocation(devId, path) == 0)
+        dev->usbPortNumber = path[0];
+}
+
 static int usb_mass_connect(int devId)
 {
     int i;
@@ -643,6 +650,8 @@ static int usb_mass_connect(int devId)
     dev->bulkEpI = -1;
     dev->bulkEpO = -1;
 
+    usb_get_port_number(devId, mass_dev);
+    
     /* open the config endpoint */
     dev->controlEp = sceUsbdOpenPipe(devId, NULL);
 

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -37,6 +37,20 @@
 #define CBW_TAG 0x43425355
 #define CSW_TAG 0x53425355
 
+typedef struct _mass_dev
+{
+    int controlEp;          // config endpoint id
+    int bulkEpI;            // in endpoint id
+    int bulkEpO;            // out endpoint id
+    int devId;              // device id
+    unsigned char configId; // configuration id
+    unsigned char status;
+    unsigned char interfaceNumber; // interface number
+    unsigned char interfaceAlt;    // interface alternate setting
+    int usbPortNumber; //physical port number the USB device is connected to
+    int ioSema;
+    struct scsi_interface scsi;
+} mass_dev;
 
 typedef struct _cbw_packet
 {


### PR DESCRIPTION
Need this for multiple USB support in DKWDRV after game launch. Used to identify the correct USB device no matter the initialization order. 

resolves DKWDRV/DKWDRV#82
resolves ps2homebrew/Open-PS2-Loader#1316 (partly)

@rickgaiser 
