### PR TITLE
fix: restore libmpeg

### DIFF
--- a/ee/mpeg/Makefile
+++ b/ee/mpeg/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-EE_OBJS = libmpeg.o libmpeg_core_c.o erl-support.o
+EE_OBJS = libmpeg.o libmpeg_core.o erl-support.o
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/ee/Rules.lib.make

--- a/ee/mpeg/samples/mpeg.c
+++ b/ee/mpeg/samples/mpeg.c
@@ -287,7 +287,7 @@ static void* InitCB ( void* apParam, MPEGSequenceInfo* apInfo ) {
  q++;
  PACK_GIFTAG(q, GS_SET_UV( 0, 0 ), GS_REG_UV  );
  q++;
- PACK_GIFTAG(q, GS_SET_XYZ( 0, 0, 0 ), GS_REG_XYZ2 );
+ PACK_GIFTAG(q, GS_SET_XYZ( (2048 << 4), (2048 << 4), 0 ), GS_REG_XYZ2 );
  q++;
  PACK_GIFTAG(q, GS_SET_UV( apInfo -> m_Width << 4, apInfo -> m_Height << 4 ), GS_REG_UV );
  q++;


### PR DESCRIPTION
This PR fixes libmpeg and it's sample code.

Change registers to N32 ABI standards.
Fix $at usage, changing it for $t8 and/or using "use no/at".
Fix sample code primitive offset values.
Restore Assembly source compilation, since the C source doesn't work yet.