### PR TITLE
Use BDM bd.devNr for port numbers

### DIFF
--- a/iop/iLink/IEEE1394_bd/src/include/scsi.h
+++ b/iop/iLink/IEEE1394_bd/src/include/scsi.h
@@ -5,6 +5,7 @@ struct scsi_interface
 {
     void *priv;
     char *name;
+    unsigned int devNr;
     unsigned int max_sectors;
 
     int (*get_max_lun)(struct scsi_interface *scsi);

--- a/iop/iLink/IEEE1394_bd/src/include/scsi.h
+++ b/iop/iLink/IEEE1394_bd/src/include/scsi.h
@@ -5,6 +5,7 @@ struct scsi_interface
 {
     void *priv;
     char *name;
+    // cppcheck-suppress unusedStructMember
     unsigned int devNr;
     unsigned int max_sectors;
 

--- a/iop/iLink/IEEE1394_bd/src/sbp2_driver.c
+++ b/iop/iLink/IEEE1394_bd/src/sbp2_driver.c
@@ -97,6 +97,7 @@ void init_ieee1394DiskDriver(void)
 
         SBP2Devices[i].scsi.priv        = &SBP2Devices[i];
         SBP2Devices[i].scsi.name        = "sd";
+        SBP2Devices[i].scsi.devNr       = i;
         SBP2Devices[i].scsi.max_sectors = XFER_BLOCK_SIZE / 512;
         SBP2Devices[i].scsi.get_max_lun = sbp2_get_max_lun;
         SBP2Devices[i].scsi.queue_cmd   = sbp2_queue_cmd;

--- a/iop/iLink/IEEE1394_bd/src/scsi.c
+++ b/iop/iLink/IEEE1394_bd/src/scsi.c
@@ -275,6 +275,7 @@ void scsi_connect(struct scsi_interface *scsi)
 
             bd->priv = scsi;
             bd->name = scsi->name;
+            bd->devNr = scsi->devNr;
             scsi_warmup(bd);
             bdm_connect_bd(bd);
             break;
@@ -305,7 +306,6 @@ int scsi_init(void)
     M_DEBUG("%s\n", __func__);
 
     for (i = 0; i < NUM_DEVICES; ++i) {
-        g_scsi_bd[i].devNr = i;
         g_scsi_bd[i].parNr = 0;
         g_scsi_bd[i].parId = 0x00;
 

--- a/iop/usb/usbmass_bd/src/imports.lst
+++ b/iop/usb/usbmass_bd/src/imports.lst
@@ -36,4 +36,5 @@ I_sceUsbdClosePipe
 I_sceUsbdSetPrivateData
 I_sceUsbdTransferPipe
 I_sceUsbdRegisterLdd
+I_sceUsbdGetDeviceLocation
 usbd_IMPORTS_end

--- a/iop/usb/usbmass_bd/src/include/scsi.h
+++ b/iop/usb/usbmass_bd/src/include/scsi.h
@@ -5,6 +5,7 @@ struct scsi_interface
 {
     void *priv;
     char *name;
+    unsigned int devNr;
     unsigned int max_sectors;
 
     int (*get_max_lun)(struct scsi_interface *scsi);

--- a/iop/usb/usbmass_bd/src/include/scsi.h
+++ b/iop/usb/usbmass_bd/src/include/scsi.h
@@ -5,6 +5,7 @@ struct scsi_interface
 {
     void *priv;
     char *name;
+    // cppcheck-suppress unusedStructMember
     unsigned int devNr;
     unsigned int max_sectors;
 

--- a/iop/usb/usbmass_bd/src/scsi.c
+++ b/iop/usb/usbmass_bd/src/scsi.c
@@ -300,6 +300,7 @@ void scsi_connect(struct scsi_interface *scsi)
 
             bd->priv = scsi;
             bd->name = scsi->name;
+            bd->devNr = scsi->devNr;
             scsi_warmup(bd);
             bdm_connect_bd(bd);
             break;
@@ -330,7 +331,6 @@ int scsi_init(void)
     M_DEBUG("%s\n", __func__);
 
     for (i = 0; i < NUM_DEVICES; ++i) {
-        g_scsi_bd[i].devNr = i;
         g_scsi_bd[i].parNr = 0;
         g_scsi_bd[i].parId = 0x00;
 

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -764,7 +764,9 @@ static void usb_mass_update(void *arg)
         for (i = 0; i < new_devs_count; i += 1) {
             mass_dev *dev = new_devs[i];
             {
+                u8 path[16] = {0};
                 int ret;
+
                 if ((ret = usb_set_configuration(dev, dev->configId)) != USB_RC_OK) {
                     M_PRINTF("ERROR: sending set_configuration %d\n", ret);
                     usb_mass_release(dev);
@@ -783,6 +785,14 @@ static void usb_mass_update(void *arg)
                         continue;
                     }
                 }
+
+                sceUsbdGetDeviceLocation(dev->devId, path);
+                if (path[0] == 1)
+                    dev->scsi.devNr = 0; // first USB port
+                else if  (path[0] == 2)
+                    dev->scsi.devNr = 1; // second USB port
+                else
+                    dev->scsi.devNr = 2; // hub?
 
                 dev->status |= USBMASS_DEV_STAT_CONF;
                 scsi_connect(&dev->scsi);

--- a/iop/usb/usbmass_bd/src/usb_mass.c
+++ b/iop/usb/usbmass_bd/src/usb_mass.c
@@ -787,9 +787,9 @@ static void usb_mass_update(void *arg)
                 }
 
                 sceUsbdGetDeviceLocation(dev->devId, path);
-                if (path[0] == 1)
+                if (path[0] == 2)
                     dev->scsi.devNr = 0; // first USB port
-                else if  (path[0] == 2)
+                else if  (path[0] == 1)
                     dev->scsi.devNr = 1; // second USB port
                 else
                     dev->scsi.devNr = 2; // hub?


### PR DESCRIPTION
This PR fixes the use of the block_device `devNr` field. Whenever possible the `devNr` should hold a value that is persistent across reboots.

- **ATA**: master=0, slave=1 (was already implemented)
- **USB**: 0=first port, 1=second port, 2=hub, fixed in this PR
- **MX4SIO**: 1=second port, fixed in this PR
- **IEEE1394**: not implemented (incrementing number)
- **UDPBD**: not implemented (incrementing number)

The already existing ioctl can be used to query this device number:
https://github.com/ps2dev/ps2sdk/blob/88fdeb04289a0bf5c3dbf1e9ebfcd825cd82105f/common/include/usbhdfsd-common.h#L38-L39

@DKWDRV I have put this code together for you, to end the dicussion in https://github.com/ps2dev/ps2sdk/pull/757. I only compile tested it. Please check [this commit](https://github.com/ps2dev/ps2sdk/commit/6a28311284bad6bf49ea01e91c24af76d06dbb7f) and test if this works for you.