### PR TITLE
Explicitly specify the lowest C/C++ standard flags required

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -38,18 +38,24 @@ EE_WARNFLAGS ?= -Wall -Werror
 # Debug information flags
 EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
 
+# C standard compiler flags
+EE_CSTDFLAGS ?= -std=gnu89
+
+# C++ standard compiler flags
+EE_CXXSTDFLAGS ?= -std=gnu++98
+
 # These flags will generate LTO and non-LTO code in the same object file,
 # allowing the choice of using LTO or not in the final linked binary.
 EE_FATLTOFLAGS ?= -flto -ffat-lto-objects
 
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_INCS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CSTDFLAGS) $(EE_INCS) $(EE_CFLAGS)
 
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG
 endif
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 -$(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_INCS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 -$(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXSTDFLAGS) $(EE_INCS) $(EE_CXXFLAGS)
 
 # Linker flags
 # EE_LDFLAGS := $(EE_LDFLAGS)

--- a/ee/kernel/Makefile
+++ b/ee/kernel/Makefile
@@ -6,6 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+EE_CSTDFLAGS ?= -std=gnu99
 
 EXEC_SYSCALLS = KExit.o _LoadExecPS2.o _ExecPS2.o
 EXECOSD_SYSCALL = _ExecOSD.o

--- a/ee/libcglue/Makefile
+++ b/ee/libcglue/Makefile
@@ -8,6 +8,8 @@
 
 EE_LIB = libcglue.a
 
+EE_CSTDFLAGS ?= -std=gnu99
+
 RTC_OBJS = \
 	_libcglue_rtc_data.o \
 	_libcglue_rtc_get_offset_from_busclk.o \

--- a/ee/libcglue/include/sys/socket.h
+++ b/ee/libcglue/include/sys/socket.h
@@ -103,7 +103,7 @@ struct msghdr {
 	int		msg_flags;	/* flags on received message */
 };
 
-// TODO: Not available in LWIP
+/* TODO: Not available in LWIP */
 #define	MSG_TRUNC	0x0000		/* data discarded before delivery */
 
 #if 0

--- a/ee/libcglue/samples/mem_test/Makefile.sample
+++ b/ee/libcglue/samples/mem_test/Makefile.sample
@@ -12,6 +12,7 @@ VERBOSE = 0
 EE_BIN   = mem_test.elf
 EE_OBJS  = main.o
 
+EE_CSTDFLAGS ?= -std=gnu99
 EE_CFLAGS = -Os -g
 # EE_CFLAGS += -fdata-sections -ffunction-sections
 # EE_LDFLAGS += -s

--- a/ee/libprofglue/samples/basic/Makefile.sample
+++ b/ee/libprofglue/samples/basic/Makefile.sample
@@ -9,6 +9,7 @@
 EE_BIN   = gprofbasic.elf
 EE_OBJS  = main.o
 
+EE_CSTDFLAGS ?= -std=gnu99
 EE_CFLAGS = -Os -pg -g
 EE_LDFLAGS += -pg -g
 

--- a/ee/libprofglue/samples/custom/Makefile.sample
+++ b/ee/libprofglue/samples/custom/Makefile.sample
@@ -9,6 +9,7 @@
 EE_BIN   = gprofcustom.elf
 EE_OBJS  = main.o
 
+EE_CSTDFLAGS ?= -std=gnu99
 EE_CFLAGS = -Os -pg -g
 EE_LDFLAGS += -pg -g
 

--- a/ee/rpc/ps2snd/Makefile
+++ b/ee/rpc/ps2snd/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-EE_CFLAGS += -std=c99
+EE_CSTDFLAGS ?= -std=c99
 
 EE_OBJS = ps2snd.o erl-support.o
 

--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -36,10 +36,13 @@ IOP_WARNFLAGS ?= -Wall -Werror
 # Debug information flags
 IOP_DBGINFOFLAGS ?= -gdwarf-2 -gz
 
+# C standard compiler flags
+IOP_CSTDFLAGS ?= -std=gnu89
+
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,
 #   for finer-grained control over what goes into each IRX.
-IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
+IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_CSTDFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
 ifeq ($(DEBUG),1)
 IOP_CFLAGS += -DDEBUG
 endif

--- a/iop/deckard/xparam/Makefile
+++ b/iop/deckard/xparam/Makefile
@@ -7,7 +7,10 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 IOP_BIN = xparam.irx
+
 DATABASE ?= 0#0: Homebrew, 1: ROM 2.20, 2: ROM 2.50
+
+IOP_CSTDFLAGS ?= -std=gnu99
 
 IOP_OBJS = xparam.o imports.o
 

--- a/iop/dev9/atad/Makefile
+++ b/iop/dev9/atad/Makefile
@@ -32,6 +32,8 @@ ATA_USE_AIFDEV9 ?= 0
 
 IOP_BIN ?= ps2atad.irx
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_IMPORT_INCS += \
 	dev9/dev9 \
 	system/loadcore \

--- a/iop/dev9/pvrdrv/Makefile
+++ b/iop/dev9/pvrdrv/Makefile
@@ -8,6 +8,8 @@
 
 IOP_BIN ?= dvrdrv.irx
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_IMPORT_INCS += \
 	dev9/dev9 \
 	system/intrman \

--- a/iop/dvrp/dvrfile/Makefile
+++ b/iop/dvrp/dvrfile/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_CFLAGS += -DIOMANX_OLD_NAME_COMPATIBILITY=0 -DIOMANX_OLD_NAME_ADDDELDRV=0
 
 IOP_IMPORT_INCS += \

--- a/iop/fs/bdm/Makefile
+++ b/iop/fs/bdm/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 # IOP_CFLAGS += -DDEBUG
 
 IOP_IMPORT_INCS += \

--- a/iop/fs/bdmfs_fatfs/Makefile
+++ b/iop/fs/bdmfs_fatfs/Makefile
@@ -8,6 +8,8 @@
 
 FATFS := $(PS2SDKSRC)/common/external_deps/fatfs
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 DEBUG ?= 0
 DEBUG_EXTREME ?= 0
 

--- a/iop/sio/mx4sio_bd/Makefile
+++ b/iop/sio/mx4sio_bd/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_IMPORT_INCS += \
 	fs/bdm \
 	system/dmacman \

--- a/iop/sound/ahx/Makefile
+++ b/iop/sound/ahx/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_IMPORT_INCS += \
 	sound/libsd \
 	system/intrman \

--- a/iop/sound/ps2snd/Makefile
+++ b/iop/sound/ps2snd/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+IOP_CSTDFLAGS ?= -std=c99
+
 IOP_IMPORT_INCS += \
 	sound/libsd \
 	system/intrman \

--- a/iop/system/sysclib/Makefile
+++ b/iop/system/sysclib/Makefile
@@ -15,6 +15,8 @@ USE_SIZE_OPTIMIZED ?= 0
 # Use full version of printf? This will massively increase the file size
 USE_FULL_PRINTF ?= 0
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_CFLAGS += -D_COMPILING_NEWLIB -DPRINTF_ALIAS_STANDARD_FUNCTION_NAMES=1
 
 IOP_IMPORT_INCS += \

--- a/iop/system/threadman/Makefile
+++ b/iop/system/threadman/Makefile
@@ -8,6 +8,8 @@
 
 IOP_BIN ?= threadman.irx
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_IMPORT_INCS += \
 	system/heaplib \
 	system/intrman \

--- a/iop/system/timrman/Makefile
+++ b/iop/system/timrman/Makefile
@@ -9,6 +9,8 @@
 # Enable compatibility with PS1 mode?
 TIMRMAN_PS1 ?= 0
 
+IOP_CSTDFLAGS ?= -std=gnu99
+
 IOP_BIN_ALTNAMES ?= timemani.irx
 
 IOP_IMPORT_INCS += \

--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -34,11 +34,17 @@ EE_WARNFLAGS ?= -Wall
 # Debug information flags
 EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
 
+# C standard compiler flags
+EE_CSTDFLAGS ?= -std=gnu89
+
+# C++ standard compiler flags
+EE_CXXSTDFLAGS ?= -std=gnu++98
+
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CSTDFLAGS) $(EE_CFLAGS)
 
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXSTDFLAGS) $(EE_CXXFLAGS)
 
 # Linker flags
 EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)

--- a/samples/Makefile.eeglobal_sample
+++ b/samples/Makefile.eeglobal_sample
@@ -34,11 +34,17 @@ EE_WARNFLAGS ?= -Wall
 # Debug information flags
 EE_DBGINFOFLAGS ?= -gdwarf-2 -gz
 
+# C standard compiler flags
+EE_CSTDFLAGS ?= -std=gnu89
+
+# C++ standard compiler flags
+EE_CXXSTDFLAGS ?= -std=gnu++98
+
 # C compiler flags
-EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CFLAGS)
+EE_CFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CSTDFLAGS) $(EE_CFLAGS)
 
 # C++ compiler flags
-EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXFLAGS)
+EE_CXXFLAGS := -D_EE -G0 $(EE_OPTFLAGS) $(EE_WARNFLAGS) $(EE_DBGINFOFLAGS) $(EE_CXXSTDFLAGS) $(EE_CXXFLAGS)
 
 # Linker flags
 EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)

--- a/samples/Makefile.iopglobal_sample
+++ b/samples/Makefile.iopglobal_sample
@@ -33,10 +33,13 @@ IOP_WARNFLAGS ?= -Wall
 # Debug information flags
 IOP_DBGINFOFLAGS ?= -gdwarf-2 -gz
 
+# C standard compiler flags
+IOP_CSTDFLAGS ?= -std=gnu89
+
 # C compiler flags
 # -fno-builtin is required to prevent the GCC built-in functions from being included,
 #   for finer-grained control over what goes into each IRX.
-IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
+IOP_CFLAGS := -D_IOP -fno-builtin -G0 $(IOP_OPTFLAGS) $(IOP_WARNFLAGS) $(IOP_DBGINFOFLAGS) $(IOP_CSTDFLAGS) $(IOP_INCS) $(IOP_CFLAGS)
 # linker flags
 IOP_LDFLAGS := -nostdlib -dc -r $(IOP_LDFLAGS)
 

--- a/samples/ps2dev.cmake
+++ b/samples/ps2dev.cmake
@@ -22,6 +22,14 @@ else()
     message(FATAL_ERROR "The environment variable PS2DEV needs to be defined.")
 endif()
 
+if(NOT DEFINED CMAKE_C_STANDARD)
+set(CMAKE_C_STANDARD 90)
+endif()
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+set(CMAKE_CXX_STANDARD 98)
+endif()
+
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
 SET(CMAKE_SYSTEM_PROCESSOR mips)

--- a/samples/ps2dev_iop.cmake
+++ b/samples/ps2dev_iop.cmake
@@ -22,6 +22,14 @@ else()
     message(FATAL_ERROR "The environment variable PS2DEV needs to be defined.")
 endif()
 
+if(NOT DEFINED CMAKE_C_STANDARD)
+set(CMAKE_C_STANDARD 90)
+endif()
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+set(CMAKE_CXX_STANDARD 98)
+endif()
+
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_VERSION 1)
 SET(CMAKE_SYSTEM_PROCESSOR mips)


### PR DESCRIPTION
Fixes GCC 15 compilation