### PR TITLE
romimg: Use uintptr_t

### DIFF
--- a/tools/romimg/src/romimg.h
+++ b/tools/romimg/src/romimg.h
@@ -21,11 +21,10 @@
 #define __ROMING_H__
 
 #include "dprintf.h"
-#if defined(_WIN32) || defined(WIN32)
-#define RMIMG_PTRCAST unsigned int
-#else
-#define RMIMG_PTRCAST unsigned char *
-#endif
+#include <stdint.h> // for uintptr_t
+
+#define RMIMG_PTRCAST uintptr_t
+
 struct RomDirEntry
 {
 	char name[10];


### PR DESCRIPTION
I know it's a bit of a taboo thing to use ChatGPT for coding, Sorry but I had to use it to fix issue #738 since MINGW32 has already been considered as Legacy Environment.

uintptr_t is part of the C standard (<stdint.h>), so it works on all major platforms, including Linux, macOS, and Windows, for both 32-bit and 64-bit architectures.

On 32-bit systems, uintptr_t is a 32-bit unsigned integer. On 64-bit systems, uintptr_t is a 64-bit unsigned integer.

It’s specifically designed for storing pointer values as integers safely, so any pointer-to-integer or integer-to-pointer cast using uintptr_t is portable and safe, unlike using unsigned int, which can break on 64-bit systems.