### PR TITLE
fix mcman detection of unformatted card insertion

### DIFF
--- a/iop/memorycard/mcman/src/mcsio2.c
+++ b/iop/memorycard/mcman/src/mcsio2.c
@@ -917,18 +917,11 @@ int mcman_probePS2Card(int port, int slot) //2
             SecrAuthDongle(2, slot, mcman_getcnum(port, slot));
         }
 #endif
-		if (r > 0)
-		{
+        if (r != 0) {
+            HAKAMA_SIGNALSEMA();
 			DPRINTF("mcman_probePS2Card sio2cmd succeeded\n");
-            HAKAMA_SIGNALSEMA();
-			return sceMcResSucceed;
-		}
-		else if (r < 0)
-		{
-			DPRINTF("mcman_probePS2Card sio2cmd failed (no format)\n");
-            HAKAMA_SIGNALSEMA();
-			return sceMcResNoFormat;
-		}
+            return sceMcResSucceed;
+        }
 	}
 
 #if !defined(BUILDING_XFROMMAN) && !defined(BUILDING_VMCMAN)


### PR DESCRIPTION
Before this change, every time mcdetectcard was called from libmc over an unformatted card, the mcsync return value was -2

It should have been -2 if a new unformatted card was inserted since las call, and 0 if the same card remains plugged

fixes #785 

Only tested on emulator so far...

For refence, here you have other instances of this code:

Soulcalibur2 DONGLEMAN.IRX:
```c

int mcman_probePS2Card(int param_1,int param_2)

{
  undefined4 uVar1;
  int r;
  int iVar2;
  
  WaitSema(sema_hakama);
  mcman_55_retval = 0xff;
  r = mcman_cardchanged(param_1,param_2);
  if ((r == 0) && (r = McGetFormat(param_1,param_2), r != 0)) {
    if (param_1 == 0) {
      uVar1 = mcman_getcnum(0,param_2);
      SecrAuthDongle(2,param_2,uVar1);
    }
    SignalSema(sema_hakama);
    r = 0;
  } else {
...........
  }
  return r;
  ```


SCPH-50001/N `rom0:XMCMAN`:
```c
int mcman_probePS2Card(int port,int slot)
{
  int iVar1;
  int iVar2;
  undefined4 uVar3;
  
  iVar1 = mcman_cardchanged();
  if ((iVar1 == 0) && (iVar1 = McGetFormat(port,slot), iVar1 != 0)) {
    return 0;
  }
  iVar2 = mcman_resetauth(port,slot);
  iVar1 = -0xb;
  ......
```