### PR TITLE
Fix DONGLEMAN semaphores

### DIFF
--- a/iop/memorycard/mcman/src/main.c
+++ b/iop/memorycard/mcman/src/main.c
@@ -103,9 +103,6 @@ static const u8 mcman_xortable[256] = {
 };
 // clang-format on
 
-#ifdef BUILDING_DONGLEMAN
-int sema_hakama_id = 0;
-#endif
 
 //--------------------------------------------------------------
 void long_multiply(u32 v1, u32 v2, u32 *HI, u32 *LO)
@@ -1166,8 +1163,6 @@ int McReadPage(int port, int slot, int page, void *buf) // Export #18
 	u8 eccbuf[32];
 	u8 *pdata, *peccb;
 
-    HAKAMA_WAITSEMA();
-
 	count = (mcdi->pagesize + 127) >> 7;
 	erase_byte = (mcdi->cardflags & CF_ERASE_ZEROES) ? 0x0 : 0xFF;
 
@@ -1208,8 +1203,6 @@ int McReadPage(int port, int slot, int page, void *buf) // Export #18
 			}
 		}
 	} while (++retries < 5);
-
-    HAKAMA_SIGNALSEMA();
 
 	if (retries < 5)
 		return sceMcResSucceed;

--- a/iop/memorycard/mcman/src/mcman-internal.h
+++ b/iop/memorycard/mcman/src/mcman-internal.h
@@ -367,9 +367,8 @@ extern u8 mcman_sio2outbufs_PS1PDA[0x90];
 
 #ifdef BUILDING_DONGLEMAN
 extern int sema_hakama_id;
-/// El_isra: Not sure why it hangs... I still need to determine their actual purpose. disabled for now...
-#define HAKAMA_SIGNALSEMA() //SignalSema(sema_hakama_id)
-#define HAKAMA_WAITSEMA() //WaitSema(sema_hakama_id)
+#define HAKAMA_SIGNALSEMA() SignalSema(sema_hakama_id)
+#define HAKAMA_WAITSEMA() WaitSema(sema_hakama_id)
 #else
 #define HAKAMA_SIGNALSEMA() //while(0) {} /* SignalSema wrapper for an additional semaphore used by arcade MCMAN */
 #define HAKAMA_WAITSEMA() //while(0) {} /* WaitSema wrapper for an additional semaphore used by arcade MCMAN */


### PR DESCRIPTION
DONGLEMAN will no longer hang bc of semaphores.
I haven't confirmed if this will work well with DAEMON, beyond what I can see on emulator...

It should be safe to access `mc0:` While `rom0:DAEMON` is running now

Only thing left to confirm is if the watchdog is satisfied now...