### PR TITLE
Upgrade to mainstream `lwip` 2.2.1

### DIFF
--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -14,14 +14,14 @@ if [ "x$1" != "xlocked" ]; then
 fi
 
 ## Download LWIP
-LWIP_REPO_URL="https://github.com/ps2dev/lwip.git"
+LWIP_REPO_URL="https://github.com/lwip-tcpip/lwip.git"
 LWIP_REPO_FOLDER="common/external_deps/lwip"
-LWIP_BRANCH_NAME="ps2-v2.0.3"
+LWIP_BRANCH_NAME="STABLE-2_2_1_RELEASE"
 if test ! -d "$LWIP_REPO_FOLDER"; then
   git clone --depth 1 -b $LWIP_BRANCH_NAME $LWIP_REPO_URL "$LWIP_REPO_FOLDER"_inprogress || exit 1
   mv "$LWIP_REPO_FOLDER"_inprogress "$LWIP_REPO_FOLDER"
 else
-  (cd "$LWIP_REPO_FOLDER" && git fetch origin && git reset --hard "origin/${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
+  (cd "$LWIP_REPO_FOLDER" && git fetch origin --tags && git reset --hard "${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
 fi
 
 ## Download libsmb2

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -35,9 +35,42 @@ endif
 
 EE_INCS += -I$(LWIP)/src/include -I$(LWIP)/src/include/ipv4
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	acd.o \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o
@@ -80,6 +113,9 @@ $(EE_OBJS_DIR)api_msg.o: $(LWIP)/src/api/api_msg.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
 $(EE_OBJS_DIR)api_netbuf.o: $(LWIP)/src/api/netbuf.c
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+$(EE_OBJS_DIR)acd.o: $(LWIP)/src/core/ipv4/acd.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
 $(EE_OBJS_DIR)icmp.o: $(LWIP)/src/core/ipv4/icmp.c

--- a/ee/network/tcpip/src/include/arch/cc.h
+++ b/ee/network/tcpip/src/include/arch/cc.h
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <sys/select.h>
 
 #define PACK_STRUCT_FIELD(x) x __attribute((packed))
 #define PACK_STRUCT_STRUCT __attribute((packed))

--- a/ee/network/tcpip/src/include/lwipopts.h
+++ b/ee/network/tcpip/src/include/lwipopts.h
@@ -244,6 +244,8 @@
  */
 #define LWIP_CHECKSUM_ON_COPY	1
 
+/* Define LWIP_ERRNO_STDINCLUDE if you want to include <errno.h> here */
+#define LWIP_ERRNO_STDINCLUDE	1
 /*
    ------------------------------------
    ---------- Socket options ----------

--- a/ee/network/tcpip/src/ps2ip_internal.h
+++ b/ee/network/tcpip/src/ps2ip_internal.h
@@ -11,6 +11,7 @@
 #ifndef IOP_PS2IP_INTERNAL_H
 #define	IOP_PS2IP_INTERNAL_H
 
+#include <sys/select.h>
 #include "lwip/sockets.h"
 
 typedef struct

--- a/ee/network/tcpip/src/sys_arch.c
+++ b/ee/network/tcpip/src/sys_arch.c
@@ -338,6 +338,12 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *sys_msg)
 	return result;
 }
 
+err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg)
+{
+	// On PS2 EE, ISR and task level are the same, so just call trypost
+	return sys_mbox_trypost(mbox, msg);
+}
+
 void sys_mbox_post(sys_mbox_t *mbox, void *sys_msg)
 {
 	SendMbx(mbox, alloc_msg(), sys_msg);

--- a/iop/network/smap/src/imports.lst
+++ b/iop/network/smap/src/imports.lst
@@ -63,7 +63,7 @@ I_inet_addr
 I_tcpip_input
 I_netif_set_link_up
 I_netif_set_link_down
-I_tcpip_callback_with_block
+I_tcpip_callback
 ps2ip_IMPORTS_end
 #endif
 

--- a/iop/tcpip/tcpip-base/include/arch/cc.h
+++ b/iop/tcpip/tcpip-base/include/arch/cc.h
@@ -1,8 +1,8 @@
 #ifndef __CC_H__
 #define __CC_H__
 
-#include <errno.h>
 #include <stddef.h>
+#include <sys/time.h>
 
 #define BYTE_ORDER LITTLE_ENDIAN
 
@@ -46,8 +46,6 @@ typedef u32_t			mem_ptr_t;
 #define LWIP_PLATFORM_DIAG(args)
 #define LWIP_PLATFORM_ASSERT(args)
 #endif
-
-#define atoi(x) strtol(x, NULL, 10)
 
 #define LWIP_NO_STDINT_H	1	//stdint.h does not exist.
 #define LWIP_NO_INTTYPES_H	1	//inttypes.h does not exist.

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -87,6 +87,13 @@
 #define MEM_ALIGNMENT		4
 
 /**
+ * LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT==1: allows mem_free() to be called
+ * from ISR/different task context (uses SYS_ARCH_PROTECT instead of mutex).
+ * Required on IOP because interrupt context may free pbufs.
+ */
+#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT	1
+
+/**
  * MEM_SIZE: the size of the heap memory. If the application will send
  * a lot of data that needs to be copied, this should be set high.
  */
@@ -95,10 +102,59 @@
 #define MEM_SIZE		(TCP_SND_BUF * 2)
 
 /*
+   -----------------------------------------------
+   ---------- IP options -------------------------
+   -----------------------------------------------
+*/
+/**
+ * IP_REASSEMBLY==1: Reassemble incoming fragmented IP packets.
+ * Disabled: PS2 always operates on a local LAN; IP fragments never occur
+ * with MSS=1460 and MTU=1500. Saves MEMP_NUM_REASSDATA pool entries.
+ */
+#define IP_REASSEMBLY		0
+
+/**
+ * IP_FRAG==1: Fragment outgoing IP packets if their size exceeds MTU.
+ * Disabled: TCP_MSS=1460 ensures we never exceed Ethernet MTU=1500.
+ */
+#define IP_FRAG			0
+
+/*
    ------------------------------------------------
    ---------- Internal Memory Pool Sizes ----------
    ------------------------------------------------
 */
+/**
+ * MEMP_NUM_TCP_PCB: the number of simultaneously active TCP connections.
+ * ps2link handles at most a few simultaneous TCP connections.
+ */
+#define MEMP_NUM_TCP_PCB	4
+
+/**
+ * MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP connections.
+ * ps2link listens on a small number of ports.
+ */
+#define MEMP_NUM_TCP_PCB_LISTEN	4
+
+/**
+ * MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks.
+ * DNS (1) + DHCP (1) internally allocate raw UDP PCBs via udp_new(),
+ * plus application sockets (udptty 1, ps2link 1) need their own.
+ */
+#define MEMP_NUM_UDP_PCB	4
+
+/**
+ * MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP segments.
+ * Must be at least TCP_SND_QUEUELEN (enforced by lwIP sanity check in init.c).
+ */
+#define MEMP_NUM_TCP_SEG	TCP_SND_QUEUELEN
+
+/**
+ * MEMP_NUM_ARP_QUEUE: the number of ARP queued packets.
+ * ps2link communicates with a single host; 5 entries is more than enough.
+ */
+#define MEMP_NUM_ARP_QUEUE	5
+
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
  * for incoming packets.
@@ -125,8 +181,15 @@
 
 /**
  * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
+ * Each pool entry is ~1532 bytes (PBUF_POOL_BUFSIZE ≈ 1516 + struct pbuf).
+ * Reduced from 32 (~49 KB) to 12 (~18 KB). Safe because
+ * LWIP_TCPIP_CORE_LOCKING_INPUT=1 means RX is processed synchronously,
+ * so the pool backlog stays very small.
+ * Must satisfy: TCP_WND <= PBUF_POOL_SIZE * (PBUF_POOL_BUFSIZE - 54).
+ * With PBUF_POOL_SIZE=12 and PBUF_POOL_BUFSIZE=1516: max = 12 * 1462 = 17544.
+ * 16384 (16 KB) fits comfortably.
  */
-#define PBUF_POOL_SIZE		32	//SP193: should be at least ((TCP_WND/PBUF_POOL_BUFSIZE)+1). But that is too small to handle simultaneous connections.
+#define PBUF_POOL_SIZE		12
 
 /**
  * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
@@ -156,8 +219,11 @@
 /* TCP sender buffer space (bytes). */
 #define TCP_SND_BUF             (TCP_MSS*4)
 
-/* TCP receive window. */
-#define TCP_WND                 32768
+/* TCP receive window.
+ * Must satisfy: TCP_WND <= PBUF_POOL_SIZE * (PBUF_POOL_BUFSIZE - 54).
+ * With PBUF_POOL_SIZE=12 and PBUF_POOL_BUFSIZE=1516: max = 12 * 1462 = 17544.
+ * 16384 (16 KB) fits comfortably and still gives ample throughput on LAN. */
+#define TCP_WND                 16384
 
 /* ---------- DHCP options ---------- */
 #ifdef PS2IP_DHCP
@@ -166,6 +232,10 @@
  */
 #define LWIP_DHCP		1
 #endif
+
+/* ---------- ACD options ---------- */
+#define LWIP_ACD		0
+#define LWIP_DHCP_DOES_ACD_CHECK	0
 
 /**
  * DHCP_DOES_ARP_CHECK==1: Do an ARP check on the offered address.
@@ -236,6 +306,8 @@
  */
 #define LWIP_CHECKSUM_ON_COPY	1
 
+/* Use PS2SDK's errno.h instead of lwIP's own errno definitions */
+#define LWIP_ERRNO_STDINCLUDE	1
 /*
    ------------------------------------
    ---------- Socket options ----------
@@ -251,6 +323,11 @@
  * names (read, write & close). (only used if you use sockets.c)
  */
 #define LWIP_POSIX_SOCKETS_IO_NAMES	0
+/**
+ * LWIP_SOCKET_POLL==1: Enable poll() for sockets (new in lwIP 2.2.x, default=1).
+ * Disabled: lwip_poll() is not exported by ps2ip; disabling saves code size.
+ */
+#define LWIP_SOCKET_POLL	0
 
 /*
    ----------------------------------

--- a/iop/tcpip/tcpip-base/include/stdlib.h
+++ b/iop/tcpip/tcpip-base/include/stdlib.h
@@ -1,0 +1,36 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * Minimal stdlib.h for IOP tcpip
+ * Provides basic functions needed by lwIP on the IOP
+ */
+
+#ifndef __IOP_TCPIP_STDLIB_H__
+#define __IOP_TCPIP_STDLIB_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* atoi - convert string to integer
+ * Implemented as a macro using strtol from sysclib
+ */
+#define atoi(x) strtol(x, NULL, 10)
+
+/* Required for strtol */
+long int strtol(const char *nptr, char **endptr, int base);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IOP_TCPIP_STDLIB_H__ */

--- a/iop/tcpip/tcpip-base/sys_arch.c
+++ b/iop/tcpip/tcpip-base/sys_arch.c
@@ -182,6 +182,12 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *msg){
 	return result;
 }
 
+err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg)
+{
+	// On PS2 IOP, ISR and task level are the same, so just call trypost
+	return sys_mbox_trypost(mbox, msg);
+}
+
 void sys_mbox_post(sys_mbox_t *mbox, void *msg)
 {
 	arch_message *MsgPkt;

--- a/iop/tcpip/tcpip-netman/src/exports.tab
+++ b/iop/tcpip/tcpip-netman/src/exports.tab
@@ -65,7 +65,7 @@ DECLARE_EXPORT_TABLE(ps2ip, 2, 6)
 #endif
 	DECLARE_EXPORT(netif_set_link_up)
 	DECLARE_EXPORT(netif_set_link_down)	//55
-	DECLARE_EXPORT(tcpip_callback_with_block)
+	DECLARE_EXPORT(tcpip_callback)
 	DECLARE_EXPORT(pbuf_coalesce)
 END_EXPORT_TABLE
 

--- a/iop/tcpip/tcpip-netman/src/imports.lst
+++ b/iop/tcpip/tcpip-netman/src/imports.lst
@@ -50,6 +50,7 @@ I_ReceiveMbx
 thmsgbx_IMPORTS_end
 
 sysclib_IMPORTS_start
+I_look_ctype_table
 I_memset
 I_strcpy
 I_strncpy
@@ -59,8 +60,10 @@ I_strncmp
 I_strtok
 I_strtoul
 I_memcmp
+I_memmove
 I_strtol
 I_strcmp
+I_tolower
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/iop/tcpip/tcpip-netman/src/ps2ip.c
+++ b/iop/tcpip/tcpip-netman/src/ps2ip.c
@@ -35,6 +35,9 @@
 
 #include "ps2ip_internal.h"
 
+/* Define errno for IOP module */
+int errno __attribute__((section("data")));
+
 typedef struct pbuf	PBuf;
 typedef struct netif	NetIF;
 typedef struct ip4_addr	IPAddr;

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -45,9 +45,41 @@ IOP_INCS += \
 	-I$(LWIP)/src/include/ipv4 \
 	-I$(PS2IP_BASE)/include
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o

--- a/iop/tcpip/tcpip/include/ps2ip.h
+++ b/iop/tcpip/tcpip/include/ps2ip.h
@@ -61,13 +61,7 @@ extern err_t     tcpip_input(struct pbuf *p, struct netif *inp);
 /** Function prototype for functions passed to tcpip_callback() */
 typedef void (*tcpip_callback_fn)(void *ctx);
 
-extern err_t  tcpip_callback_with_block(tcpip_callback_fn function, void *ctx, u8 block);
-
-/**
- * @ingroup lwip_os
- * @see tcpip_callback_with_block
- */
-#define tcpip_callback(f, ctx)  tcpip_callback_with_block(f, ctx, 1)
+extern err_t  tcpip_callback(tcpip_callback_fn function, void *ctx);
 
 /* From include/lwip/netif.h:  */
 extern struct netif *netif_add(struct netif *netif,
@@ -188,7 +182,7 @@ extern const ip_addr_t* dns_getserver(u8 numdns);
 #define I_lwip_fcntl DECLARE_IMPORT(47, lwip_fcntl)
 #define I_etharp_output DECLARE_IMPORT(23, etharp_output)
 #define I_tcpip_input DECLARE_IMPORT(25, tcpip_input)
-#define I_tcpip_callback_with_block DECLARE_IMPORT(56, tcpip_callback_with_block)
+#define I_tcpip_callback DECLARE_IMPORT(56, tcpip_callback)
 #define I_netif_add DECLARE_IMPORT(26, netif_add)
 #define I_netif_find DECLARE_IMPORT(27, netif_find)
 #define I_netif_set_default DECLARE_IMPORT(28, netif_set_default)

--- a/iop/tcpip/tcpip/src/exports.tab
+++ b/iop/tcpip/tcpip/src/exports.tab
@@ -65,7 +65,7 @@ DECLARE_EXPORT_TABLE(ps2ip, 2, 6)
 #endif
 	DECLARE_EXPORT(netif_set_link_up)
 	DECLARE_EXPORT(netif_set_link_down)	//55
-	DECLARE_EXPORT(tcpip_callback_with_block)
+	DECLARE_EXPORT(tcpip_callback)
 	DECLARE_EXPORT(pbuf_coalesce)
 END_EXPORT_TABLE
 

--- a/iop/tcpip/tcpip/src/imports.lst
+++ b/iop/tcpip/tcpip/src/imports.lst
@@ -43,6 +43,7 @@ I_ReceiveMbx
 thmsgbx_IMPORTS_end
 
 sysclib_IMPORTS_start
+I_look_ctype_table
 I_memset
 I_strcpy
 I_strncpy
@@ -52,8 +53,10 @@ I_strncmp
 I_strtok
 I_strtoul
 I_memcmp
+I_memmove
 I_strtol
 I_strcmp
+I_tolower
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/iop/tcpip/tcpip/src/ps2ip.c
+++ b/iop/tcpip/tcpip/src/ps2ip.c
@@ -15,6 +15,7 @@
 
 #include <types.h>
 #include <stdio.h>
+#include <errno.h>
 #include <intrman.h>
 #include <loadcore.h>
 #include <thbase.h>
@@ -33,6 +34,9 @@
 #include "netif/etharp.h"
 
 #include "ps2ip_internal.h"
+
+/* Define errno for IOP module */
+int errno __attribute__((section("data")));
 
 typedef struct pbuf	PBuf;
 typedef struct netif	NetIF;


### PR DESCRIPTION
## Description
With this PR, now we are using 100% mainstream `lwip` repository without any specific change for IOP or EE.