### PR TITLE
Handle volatile MMIO correctly in acata

### DIFF
--- a/iop/arcade/acata/src/ata.c
+++ b/iop/arcade/acata/src/ata.c
@@ -190,7 +190,13 @@ int ata_probe(acAtaReg atareg)
 	while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
 		;
 	*((volatile acUint16 *)0xB6020000) = 4660;
+	// cppcheck-suppress knownConditionTrueFalse
+	if ( *((volatile acUint16 *)0xB6020000) != 52 )
+		return 0;
 	*((volatile acUint16 *)0xB6030000) = 18;
+	// cppcheck-suppress knownConditionTrueFalse
+	if ( *((volatile acUint16 *)0xB6030000) != 18 )
+		return 0;
 	active = 0;
 	unit = 0;
 	*((volatile acUint16 *)0xB6160000) = 2;
@@ -199,6 +205,7 @@ int ata_probe(acAtaReg atareg)
 	while ( unit < 2 )
 	{
 		*((volatile acUint16 *)0xB6060000) = 16 * (unit != 0);
+		*((volatile acUint16 *)0xB6070000) = 0;
 		*((volatile acUint16 *)0xB6070000) = 0;
 		while ( count <= 1999999 )
 		{

--- a/iop/arcade/acata/src/atacmd.c
+++ b/iop/arcade/acata/src/atacmd.c
@@ -215,7 +215,7 @@ static int ata_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 					{
 						sr = *((volatile acUint16 *)0xB6160000);
 						ret_v20 = sr & 0xFF;
-						while ( (*((volatile acUint16 *)0xB6160000) & 0x80) != 0 )
+						while ( (ret_v20 & 0x80) != 0 )
 						{
 							ret_v20 = -116;
 							if ( SleepThread() != 0 )
@@ -226,7 +226,7 @@ static int ata_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 					else
 					{
 						ret_v20 = *((volatile acUint16 *)0xB6070000);
-						while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
+						while ( (ret_v20 & 0x80) != 0 )
 						{
 							sr = *((volatile acUint16 *)0xB6070000);
 							ret_v20 = sr & 0xFF;
@@ -257,7 +257,7 @@ static int ata_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 					{
 						sr_v25 = *((volatile acUint16 *)0xB6160000);
 						sr_v25 = sr_v25 & 0xFF;
-						while ( (*((volatile acUint16 *)0xB6160000) & 0x80) != 0 )
+						while ( (sr_v25 & 0x80) != 0 )
 						{
 							sr_v25 = -116;
 							if ( SleepThread() )
@@ -268,7 +268,7 @@ static int ata_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 					else
 					{
 						sr_v25 = *((volatile acUint16 *)0xB6070000);
-						while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
+						while ( (sr_v25 & 0x80) != 0 )
 						{
 							sr_v25 = *((volatile acUint16 *)0xB6070000);
 							sr_v25 = sr_v25 & 0xFF;

--- a/iop/arcade/acata/src/atapicmd.c
+++ b/iop/arcade/acata/src/atapicmd.c
@@ -86,6 +86,7 @@ static int atapi_packet_send(acAtaReg atareg, acAtapiPacketData *pkt, int flag)
 	*((volatile acUint16 *)0xB6010000) = flag & 1;
 	*((volatile acUint16 *)0xB6070000) = 160;
 	tmout = 999;
+	v6 = 1000;
 	// cppcheck-suppress knownConditionTrueFalse
 	while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
 	{
@@ -138,7 +139,7 @@ static int atapi_pio_read(acAtaReg atareg, acUint16 *buf, int count, int flag)
 		if ( !sr )
 		{
 			sr_v5 = *((volatile acUint16 *)0xB6070000);
-			while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
+			while ( (sr_v5 & 0x80) != 0 )
 			{
 				xlen = *((volatile acUint16 *)0xB6070000);
 				sr_v5 = xlen & 0xFF;
@@ -148,7 +149,7 @@ static int atapi_pio_read(acAtaReg atareg, acUint16 *buf, int count, int flag)
 		{
 			xlen = *((volatile acUint16 *)0xB6160000);
 			sr_v5 = xlen & 0xFF;
-			while ( (*((volatile acUint16 *)0xB6160000) & 0x80) != 0 )
+			while ( (sr_v5 & 0x80) != 0 )
 			{
 				sr_v5 = -116;
 				if ( SleepThread() != 0 )
@@ -314,7 +315,7 @@ static int atapi_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 						{
 							xlen = *((volatile acUint16 *)0xB6160000);
 							sr_v14 = xlen & 0xFF;
-							while ( (*((volatile acUint16 *)0xB6160000) & 0x80) != 0 )
+							while ( (sr_v14 & 0x80) != 0 )
 							{
 								sr_v14 = -116;
 								if ( SleepThread() != 0 )
@@ -325,7 +326,7 @@ static int atapi_ops_command(struct ac_ata_h *atah, int cmdpri, int pri)
 						else
 						{
 							sr_v14 = *((volatile acUint16 *)0xB6070000);
-							while ( (*((volatile acUint16 *)0xB6070000) & 0x80) != 0 )
+							while ( (sr_v14 & 0x80) != 0 )
 							{
 								xlen = *((volatile acUint16 *)0xB6070000);
 								sr_v14 = xlen & 0xFF;


### PR DESCRIPTION
Multiple RW or read after write were omitted to MMIO regions. Re-add those.