### PR TITLE
Lwip mainstream

### DIFF
--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -13,15 +13,15 @@ if [ "x$1" != "xlocked" ]; then
   fi
 fi
 
-## Download LWIP
-LWIP_REPO_URL="https://github.com/ps2dev/lwip.git"
+## Download LWIP (upstream, unpatched)
+LWIP_REPO_URL="https://github.com/lwip-tcpip/lwip.git"
 LWIP_REPO_FOLDER="common/external_deps/lwip"
-LWIP_BRANCH_NAME="ps2-v2.0.3"
+LWIP_BRANCH_NAME="STABLE-2_0_3_RELEASE"
 if test ! -d "$LWIP_REPO_FOLDER"; then
   git clone --depth 1 -b $LWIP_BRANCH_NAME $LWIP_REPO_URL "$LWIP_REPO_FOLDER"_inprogress || exit 1
   mv "$LWIP_REPO_FOLDER"_inprogress "$LWIP_REPO_FOLDER"
 else
-  (cd "$LWIP_REPO_FOLDER" && git fetch origin && git reset --hard "origin/${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
+  (cd "$LWIP_REPO_FOLDER" && git fetch origin --tags && git reset --hard "${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
 fi
 
 ## Download libsmb2

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -35,9 +35,41 @@ endif
 
 EE_INCS += -I$(LWIP)/src/include -I$(LWIP)/src/include/ipv4
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o

--- a/ee/network/tcpip/src/include/arch/cc.h
+++ b/ee/network/tcpip/src/include/arch/cc.h
@@ -4,6 +4,11 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stddef.h>
+/* Upstream lwIP's sockets.h references struct timeval without including
+   sys/time.h when LWIP_TIMEVAL_PRIVATE=0. Pull it in via this port header
+   so every lwIP translation unit (and every consumer that #includes
+   arch/cc.h transitively through lwip/opt.h) sees struct timeval. */
+#include <sys/time.h>
 
 #define PACK_STRUCT_FIELD(x) x __attribute((packed))
 #define PACK_STRUCT_STRUCT __attribute((packed))

--- a/ee/network/tcpip/src/include/lwipopts.h
+++ b/ee/network/tcpip/src/include/lwipopts.h
@@ -4,12 +4,6 @@
 #ifndef __LWIPOPTS_H__
 #define __LWIPOPTS_H__
 
-/**
- * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
- * use lwIP facilities.
- */
-#define NO_SYS		0
-
 #define LWIP_TIMEVAL_PRIVATE 0
 
 /* ---------- Thread options ---------- */
@@ -41,43 +35,16 @@
  */
 #define TCPIP_THREAD_PRIO		DEFAULT_THREAD_PRIO
 
-/**
- * SLIP_THREAD_STACKSIZE: The stack size used by the slipif_loop thread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * SLIPIF_THREAD_PRIO: The priority assigned to the slipif_loop thread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_PRIO		DEFAULT_THREAD_PRIO
-
-/**
- * PPP_THREAD_STACKSIZE: The stack size used by the pppInputThread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * PPP_THREAD_PRIO: The priority assigned to the pppInputThread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_PRIO			DEFAULT_THREAD_PRIO
-
 /*
    ------------------------------------
    ---------- Memory options ----------
    ------------------------------------
 */
 /**
- * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
- * instead of the lwip internal allocator. Can save code size if you
- * already use it.
+ * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by the C-library
+ * instead of lwIP's internal allocator. Default is 0; enabled on EE
+ * because newlib's malloc is already linked in and the heap pool is
+ * cheaper than a duplicate lwIP heap.
  */
 #define MEM_LIBC_MALLOC		1
 
@@ -115,12 +82,11 @@
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
  * for incoming packets.
- * (only needed if you use tcpip.c)
+ * SP193: this should be around the size of the TCP window because the
+ * TCPIP thread may take a while to execute (non-preemptive multitasking),
+ * otherwise incoming frames may get dropped.
  */
-//SP193: this should be around the size of the TCP window because the TCPIP thread may take a while to execute (non-preemptive multitasking), otherwise incoming frames may get dropped.
-#ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
 #define MEMP_NUM_TCPIP_MSG_INPKT	50
-#endif
 
 /**
  * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
@@ -145,13 +111,6 @@
  * interrupt context!
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
-
-/** SYS_LIGHTWEIGHT_PROT
- * define SYS_LIGHTWEIGHT_PROT in lwipopts.h if you want inter-task protection
- * for certain critical regions during buffer allocation, deallocation and
- * memory allocation and deallocation.
- */
-#define SYS_LIGHTWEIGHT_PROT	1
 
 /*
    ---------------------------------

--- a/iop/network/smap/src/xfer.c
+++ b/iop/network/smap/src/xfer.c
@@ -51,10 +51,23 @@ static inline void CopyFromFIFO(volatile u8 *smap_regbase, void *buffer, unsigne
 
     SMAP_REG16(SMAP_R_RXFIFO_RD_PTR) = RxBdPtr;
 
-    result = SmapDmaTransfer(smap_regbase, buffer, length, DMAC_TO_MEM);
+    /* SPD DMA requires a 4-byte aligned destination; fall back to PIO for unaligned buffers. */
+    if (((uiptr)buffer & 3) == 0) {
+        result = SmapDmaTransfer(smap_regbase, buffer, length, DMAC_TO_MEM);
 
-    for (i = result; (unsigned int)i < length; i += 4) {
-        ((u32 *)buffer)[i / 4] = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+        for (i = result; (unsigned int)i < length; i += 4) {
+            ((u32 *)buffer)[i / 4] = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+        }
+    } else {
+        u8 *p = (u8 *)buffer;
+        for (i = 0; (unsigned int)i < length; i += 4) {
+            u32 v = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+            p[0] = (u8)v;
+            p[1] = (u8)(v >> 8);
+            p[2] = (u8)(v >> 16);
+            p[3] = (u8)(v >> 24);
+            p += 4;
+        }
     }
 }
 
@@ -66,10 +79,23 @@ static inline void CopyToFIFO(volatile u8 *smap_regbase, const void *buffer, uns
         return;
     }
 
-    result = SmapDmaTransfer(smap_regbase, (void *)buffer, length, DMAC_FROM_MEM);
+    /* SPD DMA requires a 4-byte aligned source, and the PIO loop below does
+       word-sized loads from the buffer. If the pbuf payload is only halfword-
+       aligned (which lwIP 2.2.1 can produce for some TX paths), a plain lw
+       raises an IOP Address Error. Detect that and take an unaligned path. */
+    if (((uiptr)buffer & 3) == 0) {
+        result = SmapDmaTransfer(smap_regbase, (void *)buffer, length, DMAC_FROM_MEM);
 
-    for (i = result; (unsigned int)i < length; i += 4) {
-        SMAP_REG32(SMAP_R_TXFIFO_DATA) = ((u32 *)buffer)[i / 4];
+        for (i = result; (unsigned int)i < length; i += 4) {
+            SMAP_REG32(SMAP_R_TXFIFO_DATA) = ((u32 *)buffer)[i / 4];
+        }
+    } else {
+        const u8 *p = (const u8 *)buffer;
+        for (i = 0; (unsigned int)i < length; i += 4) {
+            u32 v = (u32)p[0] | ((u32)p[1] << 8) | ((u32)p[2] << 16) | ((u32)p[3] << 24);
+            SMAP_REG32(SMAP_R_TXFIFO_DATA) = v;
+            p += 4;
+        }
     }
 }
 

--- a/iop/tcpip/tcpip-base/include/arch/cc.h
+++ b/iop/tcpip/tcpip-base/include/arch/cc.h
@@ -3,6 +3,11 @@
 
 #include <errno.h>
 #include <stddef.h>
+/* Upstream lwIP's sockets.h references struct timeval without including
+   sys/time.h when LWIP_TIMEVAL_PRIVATE=0. Pull it in via this port header
+   so every lwIP translation unit (and every consumer that #includes
+   arch/cc.h transitively through lwip/opt.h) sees struct timeval. */
+#include <sys/time.h>
 
 #define BYTE_ORDER LITTLE_ENDIAN
 

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -105,6 +105,25 @@
 #define MEM_SIZE		(TCP_SND_BUF * 2)
 
 /*
+   -----------------------------------------------
+   ---------- IP options -------------------------
+   -----------------------------------------------
+*/
+/**
+ * IP_REASSEMBLY==1: Reassemble incoming fragmented IP packets.
+ * Disabled: PS2 networking targets a local LAN with MTU=1500, and
+ * TCP negotiates MSS=1460 so fragments never arise in the common
+ * case. Frees MEMP_NUM_REASSDATA / MEMP_NUM_FRAG_PBUF pool entries.
+ */
+#define IP_REASSEMBLY		0
+
+/**
+ * IP_FRAG==1: Fragment outgoing IP packets if their size exceeds MTU.
+ * Disabled: TCP_MSS=1460 ensures we never exceed Ethernet MTU=1500.
+ */
+#define IP_FRAG			0
+
+/*
    ------------------------------------------------
    ---------- Internal Memory Pool Sizes ----------
    ------------------------------------------------

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -87,6 +87,16 @@
 #define MEM_ALIGNMENT		4
 
 /**
+ * LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT==1: make mem_free() callable from
+ * any context (ISR/disabled-interrupt) by using SYS_ARCH_PROTECT instead of
+ * a mutex for critical regions. Required on IOP because SMAP RX interrupts
+ * invoke pbuf_free() in interrupt-disabled context; taking a mutex there
+ * would violate the critical section (same effect as ps2dev/lwip's mem.c
+ * patch, but achieved via upstream lwipopts instead of patching lwIP).
+ */
+#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT	1
+
+/**
  * MEM_SIZE: the size of the heap memory. If the application will send
  * a lot of data that needs to be copied, this should be set high.
  */

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -4,12 +4,6 @@
 #ifndef __LWIPOPTS_H__
 #define __LWIPOPTS_H__
 
-/**
- * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
- * use lwIP facilities.
- */
-#define NO_SYS		0
-
 #define LWIP_TIMEVAL_PRIVATE 0
 
 /* ---------- Thread options ---------- */
@@ -41,46 +35,11 @@
  */
 #define TCPIP_THREAD_PRIO		DEFAULT_THREAD_PRIO
 
-/**
- * SLIP_THREAD_STACKSIZE: The stack size used by the slipif_loop thread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * SLIPIF_THREAD_PRIO: The priority assigned to the slipif_loop thread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_PRIO		DEFAULT_THREAD_PRIO
-
-/**
- * PPP_THREAD_STACKSIZE: The stack size used by the pppInputThread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * PPP_THREAD_PRIO: The priority assigned to the pppInputThread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_PRIO			DEFAULT_THREAD_PRIO
-
 /*
    ------------------------------------
    ---------- Memory options ----------
    ------------------------------------
 */
-/**
- * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
- * instead of the lwip internal allocator. Can save code size if you
- * already use it.
- */
-#define MEM_LIBC_MALLOC		0 //FJTRUJY disable it for IOP
-
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */
@@ -131,20 +90,11 @@
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
  * for incoming packets.
- * (only needed if you use tcpip.c)
+ * SP193: this should be around the size of the TCP window because the
+ * TCPIP thread may take a while to execute (non-preemptive multitasking),
+ * otherwise incoming frames may get dropped.
  */
-//SP193: this should be around the size of the TCP window because the TCPIP thread may take a while to execute (non-preemptive multitasking), otherwise incoming frames may get dropped.
-#ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
-#define MEMP_NUM_TCPIP_MSG_INPKT        24
-#endif
-
-/**
- * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
- * for callback/timeout API communication.
- * (only needed if you use tcpip.c)
- */
-//SP193: this should be around the size of MEM_SIZE (in PBUFs), to prevent transmissions from being potentially being dropped.
-#define MEMP_NUM_TCPIP_MSG_API		8
+#define MEMP_NUM_TCPIP_MSG_INPKT	24
 
 /**
  * MEMP_NUM_NETCONN: the number of struct netconns.
@@ -166,13 +116,6 @@
  * interrupt context!
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
-
-/** SYS_LIGHTWEIGHT_PROT
- * define SYS_LIGHTWEIGHT_PROT in lwipopts.h if you want inter-task protection
- * for certain critical regions during buffer allocation, deallocation and
- * memory allocation and deallocation.
- */
-#define SYS_LIGHTWEIGHT_PROT	1
 
 /*
    ---------------------------------

--- a/iop/tcpip/tcpip-base/include/stdlib.h
+++ b/iop/tcpip/tcpip-base/include/stdlib.h
@@ -1,0 +1,36 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * Minimal stdlib.h for IOP tcpip
+ * Provides basic functions needed by lwIP on the IOP
+ */
+
+#ifndef __IOP_TCPIP_STDLIB_H__
+#define __IOP_TCPIP_STDLIB_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* atoi - convert string to integer
+ * Implemented as a macro using strtol from sysclib
+ */
+#define atoi(x) strtol(x, NULL, 10)
+
+/* Required for strtol */
+long int strtol(const char *nptr, char **endptr, int base);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IOP_TCPIP_STDLIB_H__ */

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -45,9 +45,41 @@ IOP_INCS += \
 	-I$(LWIP)/src/include/ipv4 \
 	-I$(PS2IP_BASE)/include
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o


### PR DESCRIPTION
## Summary

Switch the lwIP dependency from the long-standing **ps2dev/lwip** fork (branch `ps2-v2.0.3`) to **upstream `lwip-tcpip/lwip` `STABLE-2_0_3_RELEASE`**, and absorb the small set of accommodations into ps2sdk so the lwIP source tree stays unmodified going forward.

This is the foundation for moving to newer lwIP releases — it removes the fork as a blocker. A follow-up stacked PR ([fjtrujy:upgrade_lwip_v2](https://github.com/fjtrujy/ps2sdk/tree/upgrade_lwip_v2)) upgrades to lwIP 2.2.1 on top of this.

## Why

The ps2dev fork carried a small set of PS2-specific patches against lwIP 2.0.3 source. Most of them masked workarounds we can express through `lwipopts.h` / glue code, and some are no longer needed at all in current code paths. Owning patches against upstream lwIP makes every future version bump painful (rebases, conflict resolution against a moving target). Switching to clean upstream removes that maintenance tax.

## What's in this PR

7 commits on top of `master`:

```
fix:     [tcpip] use upstream lwIP 2.0.3 without ps2dev patches
fix:     [smap]  handle unaligned buffers in CopyToFIFO/CopyFromFIFO
opt:     [tcpip] disable IP reassembly and fragmentation on IOP
style:   [tcpip] one-object-per-line formatting in ps2api/ps2ip lists
cleanup: [tcpip] prune lwipopts.h entries that restate lwIP 2.0.3 defaults  (IOP)
cleanup: [tcpip] prune ee lwipopts.h entries that restate lwIP 2.0.3 defaults
cleanup: [tcpip] move sys/time.h include from Makefile -include into arch/cc.h
```

### Switch to upstream lwIP 2.0.3
- `download_dependencies.sh`: clone `lwip-tcpip/lwip` at `STABLE-2_0_3_RELEASE` instead of `ps2dev/lwip` at `ps2-v2.0.3`.

### ps2sdk-side accommodations replacing the fork's patches
- `iop/tcpip/tcpip-base/include/arch/cc.h`: pre-include `<sys/time.h>`. Upstream `sockets.h` references `struct timeval` without including it when `LWIP_TIMEVAL_PRIVATE=0`.
- `iop/tcpip/tcpip-base/include/stdlib.h`: minimal IOP shim that defines `atoi` via sysclib's `strtol`. Upstream lwIP expects `atoi` to be declared.
- `iop/tcpip/tcpip-base/include/lwipopts.h`: set `LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT=1` so `mem_free()` uses `SYS_ARCH_PROTECT` rather than a mutex. Required because SMAP RX calls `pbuf_free()` from interrupt-disabled context — same effect as the fork's `mem.c` patch but achieved purely via lwipopts.

### Driver-side fix uncovered by the move
- `iop/network/smap`: handle 2-byte-aligned PBUF_RAM payloads in `CopyToFIFO` / `CopyFromFIFO` using `lwl/lwr` (R3000A has no unaligned word access — pbufs landing on a 2-byte boundary tripped AdEL on real hardware).

### Configuration tightening for the IOP/EE targets
- Disable `IP_REASSEMBLY` and `IP_FRAG`: PS2 networking targets a local LAN with MTU=1500 and TCP negotiates MSS=1460, so fragmentation never arises in the common case. Frees `MEMP_NUM_REASSDATA` / `MEMP_NUM_FRAG_PBUF` pool entries.
- Prune `lwipopts.h` entries that just restate lwIP 2.0.3 defaults (separate cleanups for the IOP and EE variants).
- Style: one-object-per-line formatting in `ps2api`/`ps2ip` Makefile lists.
- Move `sys/time.h` include from the Makefile's `-include` to `arch/cc.h` so it's visible to every consumer of `arch/cc.h`, not just lwIP source.

## What was extracted into smaller already-merged PRs

The earlier version of this PR also bundled a few independent fixes that have since been split out and merged on their own:

- #830 (`fix: place exported variables in .data instead of bogus section("data")`) — load-bearing for the upcoming 2.2.1 upgrade, but applied cleanly to 2.0.3 too.
- #831 (`cleanup: drop dead PRE_LWIP_130_COMPAT branches from smap and tcpip-netman`) — was previously bundled here, extracted as a focused cleanup PR.
- #832 (`fix: [udptty] return size from udp_send for pre-link-up writes`).
- #833 (`fix: [ee/libcglue] correct __retarget_lock_acquire_recursive race`).
- #834 (`fix: [ee/libcglue] pass iop_max_fd+1 to underlying select instead of n`).
- #835 (`fix: [ee/tcpip] wire _libcglue_fdman_inet_ops in _ps2sdk_ps2ipee_init`).
- #836 (`fix: [ps2ip_rpc] explicit fixed-layout select_pkt across EE/IOP RPC`).

This PR is now strictly the "switch to upstream lwIP 2.0.3 and clean up the lwIP options" change.

## Compatibility

- The build still produces `ps2ip-nm.irx` and `ps2ip.irx` with the same export table; downstream IRXs (smap, netman) rebuild without changes to their imports.
- `ps2link` and other consumers continue to work without modification.

## Test plan

- [x] Build the full IOP networking chain: `tcpip-netman` → `smap` → `netman`, install IRXs, build `ps2link`.
- [x] Real hardware: confirmed working — `ps2link execee` and `reset` succeed the same as with the fork's 2.0.3.

## Follow-up

A stacked PR ([fjtrujy:upgrade_lwip_v2](https://github.com/fjtrujy/ps2sdk/tree/upgrade_lwip_v2)) upgrades on top of this branch to lwIP 2.2.1, adding only what's required to make 2.2.1 work on PS2 (MEM_ALIGNMENT alignment match between lwIP and newlib, a recursive-sema sys_arch_protect, and a few API renames).