### PR TITLE
Invert condition for ACMEME status on init

### DIFF
--- a/iop/arcade/acmeme/src/meme.c
+++ b/iop/arcade/acmeme/src/meme.c
@@ -518,7 +518,7 @@ int acMemeModuleStart(int argc, char **argv)
 	int v14;
 	char *next;
 
-	if ( acMemeModuleStatus() == 0 )
+	if ( acMemeModuleStatus() != 0 )
 	{
 		return -16;
 	}


### PR DESCRIPTION
condition is ok, but original code sorrounds startup code on condition instead of returning err
