### PR TITLE
cleanup: drop dead `PRE_LWIP_130_COMPAT` branches from `smap` and `tcpip-netman`

### DIFF
--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -92,36 +92,6 @@ SMapLowLevelOutput(NetIF *pNetIF, PBuf *pOutput)
     return result;
 }
 
-// SMapOutput():
-
-// This function is called by the TCP/IP stack when an IP packet should be sent. It'll be invoked in the context of the
-// tcpip-thread, hence no synchronization is required.
-//  For LWIP versions before v1.3.0.
-#ifdef PRE_LWIP_130_COMPAT
-static err_t
-SMapOutput(NetIF *pNetIF, PBuf *pOutput, IPAddr *pIPAddr)
-{
-    err_t result;
-    PBuf *pBuf;
-
-#if USE_GP_REGISTER
-    void *OldGP;
-
-    OldGP = SetModuleGP();
-#endif
-
-    pBuf = etharp_output(pNetIF, pIPAddr, pOutput);
-
-    result = pBuf != NULL ? SMapLowLevelOutput(pNetIF, pBuf) : ERR_OK;
-
-#if USE_GP_REGISTER
-    SetGP(OldGP);
-#endif
-
-    return result;
-}
-#endif
-
 // SMapIFInit():
 
 // Should be called at the beginning of the program to set up the network interface.
@@ -138,20 +108,12 @@ SMapIFInit(NetIF *pNetIF)
     TxHead = NULL;
     TxTail = NULL;
 
-    pNetIF->name[0] = IFNAME0;
-    pNetIF->name[1] = IFNAME1;
-#ifdef PRE_LWIP_130_COMPAT
-    pNetIF->output = &SMapOutput; // For LWIP versions before v1.3.0.
-#else
-    pNetIF->output = &etharp_output; // For LWIP 1.3.0 and later.
-#endif
+    pNetIF->name[0]    = IFNAME0;
+    pNetIF->name[1]    = IFNAME1;
+    pNetIF->output     = &etharp_output;
     pNetIF->linkoutput = &SMapLowLevelOutput;
     pNetIF->hwaddr_len = NETIF_MAX_HWADDR_LEN;
-#ifdef PRE_LWIP_130_COMPAT
-    pNetIF->flags |= (NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST); // For LWIP versions before v1.3.0.
-#else
-    pNetIF->flags |= (NETIF_FLAG_ETHARP | NETIF_FLAG_BROADCAST); // For LWIP v1.3.0 and later.
-#endif
+    pNetIF->flags |= (NETIF_FLAG_ETHARP | NETIF_FLAG_BROADCAST);
     pNetIF->mtu = 1500;
 
     // Get MAC address.

--- a/iop/tcpip/tcpip-netman/src/ps2ip.c
+++ b/iop/tcpip/tcpip-netman/src/ps2ip.c
@@ -348,21 +348,6 @@ SMapLowLevelOutput(struct netif *pNetIF, struct pbuf* pOutput)
 	return result;
 }
 
-//SMapOutput():
-
-//This function is called by the TCP/IP stack when an IP packet should be sent. It'll be invoked in the context of the
-//tcpip-thread, hence no synchronization is required.
-// For LWIP versions before v1.3.0.
-#ifdef PRE_LWIP_130_COMPAT
-static err_t
-SMapOutput(struct netif *pNetIF, struct pbuf *pOutput, IPAddr* pIPAddr)
-{
-	struct pbuf *pBuf=etharp_output(pNetIF,pIPAddr,pOutput);
-
-	return	pBuf!=NULL ? SMapLowLevelOutput(pNetIF, pBuf):ERR_OK;
-}
-#endif
-
 //Should be called at the beginning of the program to set up the network interface.
 static err_t SMapIFInit(struct netif* pNetIF)
 {
@@ -371,18 +356,10 @@ static err_t SMapIFInit(struct netif* pNetIF)
 
 	pNetIF->name[0]='s';
 	pNetIF->name[1]='m';
-#ifdef PRE_LWIP_130_COMPAT
-	pNetIF->output=&SMapOutput;	// For LWIP versions before v1.3.0.
-#else
-	pNetIF->output=&etharp_output;	// For LWIP 1.3.0 and later.
-#endif
+	pNetIF->output=&etharp_output;
 	pNetIF->linkoutput=&SMapLowLevelOutput;
 	pNetIF->hwaddr_len=NETIF_MAX_HWADDR_LEN;
-#ifdef PRE_LWIP_130_COMPAT
-	pNetIF->flags|=(NETIF_FLAG_LINK_UP|NETIF_FLAG_BROADCAST);	// For LWIP versions before v1.3.0.
-#else
-	pNetIF->flags|=(NETIF_FLAG_ETHARP|NETIF_FLAG_BROADCAST);	// For LWIP v1.3.0 and later.
-#endif
+	pNetIF->flags|=(NETIF_FLAG_ETHARP|NETIF_FLAG_ETHERNET|NETIF_FLAG_BROADCAST);
 	pNetIF->mtu=1500;
 
 	//Get MAC address.


### PR DESCRIPTION
## Summary

Drop unreachable lwIP-1.2-vs-1.3 compatibility code from the IOP networking modules. Upstream lwIP has been ≥ 1.3.0 for over a decade, and ps2sdk's vendored lwIP is 2.0.3 on this branch — the `PRE_LWIP_130_COMPAT` macro is never defined and the legacy paths are dead.

Two commits, structurally identical, one for each affected file.

## Commits

### 1. `cleanup: [smap] remove dead PRE_LWIP_130_COMPAT branches from main.c`

Removes the unreachable `SMapOutput()` wrapper and its `#ifdef` forks in `SMapIFInit`. smap-ps2ip now unconditionally uses `etharp_output` and `NETIF_FLAG_ETHARP`.

No functional change. The `netman` / `netdev` `smap.irx` binaries are byte-identical (`shasum` unchanged).

### 2. `cleanup: [tcpip-netman] drop dead PRE_LWIP_130_COMPAT, advertise NETIF_FLAG_ETHERNET`

Symmetric with the smap cleanup. Drops the same `SMapOutput()` wrapper + ifdef forks in `tcpip-netman`'s `SMapIFInit`, and replaces the conditional flag block with a single line — adding `NETIF_FLAG_ETHERNET` to correctly mark the netif as Ethernet. lwIP 2.0.3 defines this flag in `netif.h:95`, and certain code paths (e.g. when `LWIP_ARP` is disabled) branch on it.

## Test plan

- [ ] CI build of ps2sdk.
- [x] `smap.irx` (BUILDING_SMAP_PS2IP variant) builds clean — byte-identical output.
- [x] ps2link end-to-end (execee over TCP) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)