### PR TITLE
fix: [udptty] return size from `udp_send` for pre-link-up writes

### DIFF
--- a/iop/network/udptty/src/udptty.c
+++ b/iop/network/udptty/src/udptty.c
@@ -205,7 +205,7 @@ int _start(int argc, char *argv[])
 
     close(0);
     open(DEVNAME "00:", 0x1000 | O_RDWR);
-    
+
     close(1);
     open(DEVNAME "00:", O_WRONLY);
 
@@ -230,7 +230,9 @@ int _shutdown()
 }
 
 /* Copy the data into place, calculate the various checksums, and send the
-   final packet.  */
+   final packet.  Always reports `size` bytes consumed, even when the UDP
+   send fails (e.g. before SMAP has reported link-up): otherwise the IOP's
+   stdio layer retries on a short write and ends up in an infinite loop. */
 static int udp_send(void *buf, size_t size)
 {
     struct sockaddr_in peer;
@@ -241,7 +243,7 @@ static int udp_send(void *buf, size_t size)
 
     lwip_sendto(udp_socket, buf, size, 0, (struct sockaddr *)&peer, sizeof(peer));
 
-    return 0;
+    return (int)size;
 }
 
 /* TTY driver.  */


### PR DESCRIPTION
## Summary

`udptty`'s `udp_send()` ignored the return value of `lwip_sendto()` and unconditionally returned 0. The IOP stdio layer interprets a return of 0 as "0 bytes written" and retries indefinitely — so any write that happens *before* the SMAP driver reports `NETIF_FLAG_LINK_UP` (~3 s into boot) hangs the loader forever.

This is most visible with **lwIP 2.2.1**, where `lwip_sendto()` correctly fails with `EHOSTUNREACH` if called before the link is up (`ip4_route()` needs link state to pick a netif). On lwIP 2.0.3 the call doesn't fail, so the bug was latent.

## The fix

Return `size` instead of `0`. The caller now treats the data as consumed — silently dropped on the wire when there's no route yet, written normally once link comes up.

This is independent of any lwIP-2.2.1-specific behaviour: `0` was always the wrong return value for a successful no-op write.

## Test plan

- [x] Boot a ps2link build that emits early prints over UDP — no longer hangs at the 3-second link-wait.
- [x] After link up, `kprintf` output appears on the UDP collector as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)