### PR TITLE
fix: [ee/tcpip] wire `_libcglue_fdman_inet_ops` in `_ps2sdk_ps2ipee_init`

### DIFF
--- a/ee/network/tcpip/src/ps2ip_ps2sdk.c
+++ b/ee/network/tcpip/src/ps2ip_ps2sdk.c
@@ -457,14 +457,24 @@ void __ps2ipeeOpsInitializeImpl(void)
 
 /* Backup pointer functions to restore after exit ps2ipee */
 static _libcglue_fdman_socket_ops_t *_backup_libcglue_fdman_socket_ops;
+static _libcglue_fdman_inet_ops_t   *_backup_libcglue_fdman_inet_ops;
 
 void _ps2sdk_ps2ipee_init(void)
 {
     _backup_libcglue_fdman_socket_ops = _libcglue_fdman_socket_ops;
     _libcglue_fdman_socket_ops = &__ps2ipee_fdman_socket_ops;
+    /* Without this, libcglue's inet_addr/inet_ntoa/inet_aton fall into the
+     * ops==NULL branch and silently return 0/NULL — so inet_addr("1.2.3.4")
+     * gives 0.0.0.0, and any outbound packet using a string-resolved IP
+     * (UDP sendto, TCP connect by IP literal) ends up addressed to 0.0.0.0,
+     * which lwIP routes to the broadcast MAC. The IOP-side path doesn't hit
+     * this because its init wires libcglue ops via a different code path. */
+    _backup_libcglue_fdman_inet_ops = _libcglue_fdman_inet_ops;
+    _libcglue_fdman_inet_ops = &__ps2ipee_fdman_inet_ops;
 }
 
 void _ps2sdk_ps2ipee_deinit(void)
 {
     _libcglue_fdman_socket_ops = _backup_libcglue_fdman_socket_ops;
+    _libcglue_fdman_inet_ops = _backup_libcglue_fdman_inet_ops;
 }


### PR DESCRIPTION
## Summary

`_ps2sdk_ps2ipee_init` (the EE-side init that hooks the lwIP/ps2sdk stack into libcglue) wired `_libcglue_fdman_socket_ops` but **forgot to wire `_libcglue_fdman_inet_ops`**. The inet ops table (`__ps2ipee_fdman_inet_ops`, populated with `ipaddr_addr` / `ip4addr_ntoa` / `ip4addr_aton`) was filled in, but the global pointer it backs stayed `NULL`.

libcglue's `inet_addr` / `inet_ntoa` / `inet_aton` wrappers each check the pointer before dispatching and silently return `0` / `NULL` when it's `NULL`, so on the EE-side path:

```c
inet_addr("192.168.31.233") => 0
```

Any code that resolved a literal IP string for outbound traffic (UDP `sendto`, TCP `connect` by IP) ended up addressed to `0.0.0.0`. lwIP classifies that as broadcast and emits the frame with destination MAC `ff:ff:ff:ff:ff:ff` — the host's IP stack drops it because the unicast destination IP doesn't match its own.

## The fix

Wire `_libcglue_fdman_inet_ops` symmetrically with the existing socket-ops registration. Single 10-line addition in `_ps2sdk_ps2ipee_init`.

## Test plan

- [x] EE-side UDP echo client (`ps2_drivers/samples/udp_echo_server_ee`) — 100/100 round trips sustained on real hardware. Pre-fix: every iter times out; `tcpdump` on the host shows the packet emitted as a broadcast for IP destination `0.0.0.0`.
- [x] EE-side TCP burst client (`tcp_burst_client_ee`) — `ok=20 fail=0` against a host TCP echo server. Pre-fix: same broadcast-to-0.0.0.0 symptom.
- [x] No regression in select_test_ee / tcp_echo_test_ee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)