### PR TITLE
fix: [ps2ip_rpc] explicit fixed-layout `select_pkt` across EE/IOP RPC

### DIFF
--- a/common/include/ps2ip_rpc.h
+++ b/common/include/ps2ip_rpc.h
@@ -132,6 +132,23 @@ typedef struct
     u8 buffer[128];
 } setsockopt_pkt;
 
+/* On-the-wire fd_set for the select RPC. The struct fd_set seen on EE
+ * (newlib, ~128 bytes) and IOP (lwIP, MEMP_NUM_NETCONN/8 bytes) compile
+ * units differs in size, which used to scramble select_pkt's layout
+ * across the SIF RPC boundary — IOP would only touch the first few
+ * bytes of EE's wider readset and never see writeset/exceptset at the
+ * right offsets. Using a fixed-size struct here keeps select_pkt
+ * byte-identical on both sides regardless of which struct fd_set is
+ * in scope at the include site. */
+typedef struct
+{
+    unsigned char fd_bits[(MEMP_NUM_NETCONN + 7) / 8];
+} ps2ip_rpc_fd_set;
+
+/* struct timeval differs across the boundary too — newlib's tv_sec/tv_usec
+ * are 64-bit on EE while the IOP defines them as 32-bit longs. Carry
+ * explicit 32-bit fields here so the layout is byte-identical on both
+ * sides; each end reconstructs its native struct timeval. */
 typedef struct
 {
     union
@@ -139,14 +156,15 @@ typedef struct
         s32 maxfdp1;
         s32 result;
     };
-    struct timeval *timeout_p;
-    struct timeval timeout;
-    struct fd_set *readset_p;
-    struct fd_set *writeset_p;
-    struct fd_set *exceptset_p;
-    struct fd_set readset;
-    struct fd_set writeset;
-    struct fd_set exceptset;
+    void *timeout_p;     /* opaque NULL/non-NULL flag */
+    s32 timeout_sec;
+    s32 timeout_usec;
+    void *readset_p;     /* opaque: only NULL/non-NULL is meaningful across RPC */
+    void *writeset_p;
+    void *exceptset_p;
+    ps2ip_rpc_fd_set readset;
+    ps2ip_rpc_fd_set writeset;
+    ps2ip_rpc_fd_set exceptset;
 } select_pkt;
 
 typedef struct

--- a/ee/rpc/tcpips/src/ps2ipc.c
+++ b/ee/rpc/tcpips/src/ps2ipc.c
@@ -481,6 +481,38 @@ int ps2ipc_ps2ip_getconfig(char *netif_name, t_ip_info *ip_info)
 	return 1;
 }
 
+/* Marshal between the caller's struct fd_set (newlib, ~128 bytes on EE)
+ * and the on-the-wire ps2ip_rpc_fd_set (MEMP_NUM_NETCONN/8 bytes, fixed
+ * size on both sides). Bit-by-bit copy avoids any reliance on
+ * sizeof(struct fd_set) matching across the RPC boundary. */
+static void ps2ipc_pack_fdset(ps2ip_rpc_fd_set *dst, struct fd_set *src, int maxfdp1)
+{
+	int i;
+	memset(dst, 0, sizeof(*dst));
+	if (src == NULL) return;
+	if (maxfdp1 > (int)(sizeof(dst->fd_bits) * 8))
+		maxfdp1 = (int)(sizeof(dst->fd_bits) * 8);
+	for (i = 0; i < maxfdp1; i++) {
+		if (FD_ISSET(i, src)) {
+			dst->fd_bits[i >> 3] |= (unsigned char)(1U << (i & 7));
+		}
+	}
+}
+
+static void ps2ipc_unpack_fdset(struct fd_set *dst, const ps2ip_rpc_fd_set *src, int maxfdp1)
+{
+	int i;
+	if (dst == NULL) return;
+	FD_ZERO(dst);
+	if (maxfdp1 > (int)(sizeof(src->fd_bits) * 8))
+		maxfdp1 = (int)(sizeof(src->fd_bits) * 8);
+	for (i = 0; i < maxfdp1; i++) {
+		if (src->fd_bits[i >> 3] & (1U << (i & 7))) {
+			FD_SET(i, dst);
+		}
+	}
+}
+
 int ps2ipc_select(int maxfdp1, struct fd_set *readset, struct fd_set *writeset, struct fd_set *exceptset, struct timeval *timeout)
 {
 	int result;
@@ -491,21 +523,19 @@ int ps2ipc_select(int maxfdp1, struct fd_set *readset, struct fd_set *writeset, 
 	WaitSema(lock_sema);
 
 	pkt->maxfdp1 = maxfdp1;
-	pkt->readset_p = readset;
-	pkt->writeset_p = writeset;
-	pkt->exceptset_p = exceptset;
+	pkt->readset_p = (void *)readset;
+	pkt->writeset_p = (void *)writeset;
+	pkt->exceptset_p = (void *)exceptset;
 	pkt->timeout_p = timeout;
 	if( timeout )
-		pkt->timeout = *timeout;
+	{
+		pkt->timeout_sec  = (s32)timeout->tv_sec;
+		pkt->timeout_usec = (s32)timeout->tv_usec;
+	}
 
-	if( readset )
-		pkt->readset = *readset;
-
-	if( writeset )
-		pkt->writeset = *writeset;
-
-	if( exceptset )
-		pkt->exceptset = *exceptset;
+	ps2ipc_pack_fdset(&pkt->readset,   readset,   maxfdp1);
+	ps2ipc_pack_fdset(&pkt->writeset,  writeset,  maxfdp1);
+	ps2ipc_pack_fdset(&pkt->exceptset, exceptset, maxfdp1);
 
 	if (sceSifCallRpc(&_ps2ip, PS2IPS_ID_SELECT, 0, (void*)pkt, sizeof(select_pkt), (void*)pkt, sizeof(select_pkt), NULL, NULL) < 0)
 	{
@@ -514,16 +544,14 @@ int ps2ipc_select(int maxfdp1, struct fd_set *readset, struct fd_set *writeset, 
 	}
 
 	if( timeout )
-		*timeout = pkt->timeout;
+	{
+		timeout->tv_sec  = pkt->timeout_sec;
+		timeout->tv_usec = pkt->timeout_usec;
+	}
 
-	if( readset )
-		*readset = pkt->readset;
-
-	if( writeset )
-		*writeset = pkt->writeset;
-
-	if( exceptset )
-		*exceptset = pkt->exceptset;
+	ps2ipc_unpack_fdset(readset,   &pkt->readset,   maxfdp1);
+	ps2ipc_unpack_fdset(writeset,  &pkt->writeset,  maxfdp1);
+	ps2ipc_unpack_fdset(exceptset, &pkt->exceptset, maxfdp1);
 
 	result = pkt->result;
 

--- a/iop/tcpip/tcpips/src/ps2ips.c
+++ b/iop/tcpip/tcpips/src/ps2ips.c
@@ -402,15 +402,34 @@ static void do_setconfig(void *rpcBuffer, int size)
 static void do_select( void * rpcBuffer, int size )
 {
 	select_pkt *pkt = (select_pkt*)_rpc_buffer;
+	struct timeval tv;
+	int result;
 
 	(void)rpcBuffer;
 	(void)size;
 
-	pkt->result = select(	pkt->maxfdp1,
-				pkt->readset_p != NULL ? &pkt->readset : NULL,
-				pkt->writeset_p != NULL ? &pkt->writeset : NULL,
-				pkt->exceptset_p != NULL ? &pkt->exceptset : NULL,
-				pkt->timeout_p != NULL ? &pkt->timeout : NULL );
+	/* Reconstruct an IOP-native struct timeval from the wire fields. */
+	if (pkt->timeout_p != NULL)
+	{
+		tv.tv_sec  = pkt->timeout_sec;
+		tv.tv_usec = pkt->timeout_usec;
+	}
+
+	/* ps2ip_rpc_fd_set is { unsigned char fd_bits[(MEMP_NUM_NETCONN+7)/8] },
+	 * which is byte-identical to lwIP's struct fd_set. The cast is safe and
+	 * keeps lwip_select free to mutate the bits in place. */
+	result = select(	pkt->maxfdp1,
+				pkt->readset_p   != NULL ? (struct fd_set *)&pkt->readset   : NULL,
+				pkt->writeset_p  != NULL ? (struct fd_set *)&pkt->writeset  : NULL,
+				pkt->exceptset_p != NULL ? (struct fd_set *)&pkt->exceptset : NULL,
+				pkt->timeout_p   != NULL ? &tv : NULL );
+
+	if (pkt->timeout_p != NULL)
+	{
+		pkt->timeout_sec  = (s32)tv.tv_sec;
+		pkt->timeout_usec = (s32)tv.tv_usec;
+	}
+	pkt->result = result;
 }
 
 static void do_ioctlsocket( void *rpcBuffer, int size )


### PR DESCRIPTION
## Summary

`select_pkt` (the SIF-RPC payload that `ee/rpc/tcpips` sends to `iop/tcpip/tcpips` for `select()`) used `struct fd_set` and `struct timeval` directly in the wire layout. Both types have **compiler-defined sizes that diverge between the EE and IOP compile environments**, so the EE and IOP saw different field offsets in the same struct — a silent ABI mismatch.

## The mismatch

| Field           | EE (newlib)                                    | IOP (lwIP)                                  |
|-----------------|------------------------------------------------|---------------------------------------------|
| `struct fd_set` | ~8 bytes (`FD_SETSIZE=64`, `__fd_mask=ulong=8`)| 2 bytes (packed `fd_bits[(MEMP_NUM_NETCONN+7)/8]`) |
| `struct timeval`| 16 bytes (`tv_sec`/`tv_usec` 64-bit longs)     | 8 bytes (32-bit longs)                      |

The two mismatches together meant every field of `select_pkt` after `timeout` lived at a different offset on each side. The EE wrote `pkt->writeset_p / exceptset_p / writeset / exceptset` at offsets the IOP never read; the IOP read garbage from the high half of the EE's `tv_usec` for what it thought were the `writeset_p` / `exceptset_p` pointers, ended up calling `lwip_select` with `NULL` fd-sets, and silently returned without modifying any bits.

This was harmless for **ps2link** (UDP only, never calls `select`), but broke **mongoose-based servers on the IOP-side path** (`ps2_http`): the listening socket was flagged as having an exception condition on the very first poll cycle (spurious eset bits), mongoose called `mg_error("socket error")`, and the listener was killed before the first client connection.

## The fix

Lock the wire layout to a fixed shape that's identical on both compile units:

- Define `ps2ip_rpc_fd_set` as a fixed-size byte array `unsigned char fd_bits[(MEMP_NUM_NETCONN + 7) / 8]`. Size is driven by `MEMP_NUM_NETCONN` and matches lwIP's internal `fd_set` semantics.
- Replace `struct timeval timeout` in `select_pkt` with explicit `s32 timeout_sec; s32 timeout_usec;` fields. Each side reconstructs/decomposes its own native `timeval` at the boundary.

Net result: every field of `select_pkt` is at the same byte offset on EE and IOP, regardless of toolchain header definitions.

## Files

- `common/include/ps2ip_rpc.h`     — fixed-layout struct
- `ee/rpc/tcpips/src/ps2ipc.c`     — EE side: convert local fd_set/timeval to wire shape
- `iop/tcpip/tcpips/src/ps2ips.c`  — IOP side: convert wire shape to local fd_set/timeval

## Test plan

- [x] `select_test_iop` (in [`ps2_drivers`](https://github.com/fjtrujy/ps2_drivers)) — listening-socket select probe shows `rc=0 r=0 w=0 e=0` ticks (no spurious eset bits). Pre-fix: `e=1` on the very first probe.
- [x] mongoose `ps2_http` on the IOP-side path — sustains repeated HTTP bursts on real hardware without the listener being killed by `mg_error("socket error")`.
- [x] No regression in ps2link / ps2client (UDP) which don't exercise this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)