### PR TITLE
Fix build for gcc-15/16

### DIFF
--- a/tools/srxfixup/src/anaarg.c
+++ b/tools/srxfixup/src/anaarg.c
@@ -17,7 +17,7 @@
 int analize_arguments(const Opttable *dopttable, int argc, char **argv)
 {
 	Opt_strings *optstr;
-	const char *opt;
+	char *opt;
 	Opttable *otp;
 	Opttable *igadd;
 	Opttable *opttable;
@@ -128,7 +128,7 @@ int analize_arguments(const Opttable *dopttable, int argc, char **argv)
 							opttable->option = opt;
 							opttable->vartype = 'n';
 							opttable->havearg = ARG_HAVEARG_UNK3;
-							cp = strchr(opttable->option, ':');
+							cp = strchr(opt, ':');
 							if ( cp )
 							{
 								*cp = 0;


### PR DESCRIPTION
GCC-15/16 was still failing after #852, with a similar error to the one originally raised (#851):

```
make all
...
cc -O2 -Wall -Werror  -Isrc/ -Isrc/include -Iinclude/   -Isrc/ -Isrc/include -Iinclude/ -c src/anaarg.c -o obj/anaarg.o
src/anaarg.c: In function ‘analize_arguments’:
src/anaarg.c:131:60: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  131 |                                                         cp = strchr(opttable->option, ':');
      |                                                            ^
cc1: all warnings being treated as errors
```


This PR fixes that and GCC-15/16 now compiles cleanly.