### PR TITLE
ATAD: fix device probing for slave device

### DIFF
--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -1221,23 +1221,23 @@ static int ata_init_devices(ata_devinfo_t *devinfo)
     int i, res;
     u32 total_sectors_nonlba48, total_sectors_lba48;
 
-    if ((res = sceAtaSoftReset()) != 0)
-        return res;
+    /* Probe devices */
+    for (i = 0; i < 2; i++) {
+        if ((res = sceAtaSoftReset()) != 0)
+            return res;
 
-    ata_device_probe(&devinfo[0]);
+        ata_device_select(i);
+        if (ata_hwport->r_control & 0xff)
+            ata_device_probe(&devinfo[i]);
+        else
+            devinfo[i].exists = 0;
+    }
+
     if (!devinfo[0].exists) {
         M_PRINTF("Error: Unable to detect HDD 0.\n");
         devinfo[1].exists = 0;
         return ATA_RES_ERR_NODEV; // Returns 0 in v1.04.
     }
-
-    /* If there is a device 1, grab it's info too.  */
-    if ((res = ata_device_select(1)) != 0)
-        return res;
-    if (ata_hwport->r_control & 0xff)
-        ata_device_probe(&devinfo[1]);
-    else
-        devinfo[1].exists = 0;
 
 #ifdef ATA_USE_DEV9
     ata_pio_mode(0); // PIO mode is set here, in late ATAD versions.


### PR DESCRIPTION
This PR fixes device probing for ATA slave device in `ata_init_devices`.

ata_device_probe writes to ATA registers after checking `nsector`, `sector`, `hcyl` and `lcyl` values:
https://github.com/ps2dev/ps2sdk/blob/f388f51af7a82252bac8d9c2501769795de00489/iop/dev9/atad/src/ps2atad.c#L1204-L1207

As it turns out, simply switching from device 0 to device 1 does not clear the ATA controller register values. This causes probing for device 1 to reuse register values from the previous `ata_device_probe` call.

Resetting the ATA controller before calling `ata_device_select` fixes this.

Before the change, device 1 was ignored.
After the change, probing correctly handles all cases, including setups with a missing master device.

```
  hdd: disk0: 0x07744000 sectors, max 0x00200000
  hdd: disk1: 0x01dd7fb0 sectors, max 0x00080000
  hdd: drive status 0, format version 00000002
  hdd: drive status 0, format version 00000002
  hdd: version 0205 driver start. This is OSD version!
  pfs Playstation Filesystem Driver v2.2
ps2fs: (c) 2003 Sjeep, V  ector and Florin Sasu
  pfs Max mount: 4, Max open: 10, Number of buffers: 40
  pfs version 0202 driver start.
  Checking APA header for HDD0: 0
  Checking APA header for HDD1: 0
  hdd0 partitions:
        __mbr
        __net
        __system
        __sysconf
        __common
        __.POPS
  hdd1 partitions:
        __mbr
        __net
        __system
        __sysconf
        __common
        PP.SLUS-20002..RIDGE_RACER_V
        PP.SLUS-20002..RIDGE_RACER_V
        PP.SLUS-20002..RIDGE_RACER_V
  Mounting hdd0:__common to pfs0: 0
  Mounting hdd1:__common to pfs0: 0
```