### PR TITLE
For mcman, use succeed instead of no format return value on erase block for non-sio2 backing

### DIFF
--- a/iop/memorycard/mcman/src/mcsio2.c
+++ b/iop/memorycard/mcman/src/mcsio2.c
@@ -541,9 +541,12 @@ int mcman_eraseblock(int port, int slot, int block, void **pagebuf, void *eccbuf
         //HAKAMA_SIGNALSEMA();
 		return sceMcResFailReplace;
     }
-#endif
     //HAKAMA_SIGNALSEMA();
 	return sceMcResNoFormat;
+#else
+    //HAKAMA_SIGNALSEMA();
+	return sceMcResSucceed;
+#endif
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Fixes xfrom write