### PR TITLE
elf-loader: add no-IOP-reset loader variant and NoReset entry point

### DIFF
--- a/ee/elf-loader/include/elf-loader.h
+++ b/ee/elf-loader/include/elf-loader.h
@@ -50,6 +50,8 @@ extern int LoadELFFromFile(const char *filename, int argc, char *argv[]);
  */
 extern int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
 
+extern int LoadELFFromFileWithPartitionNoReset(const char *filename, const char *partition, int argc, char *argv[]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ee/elf-loader/src/elf.c
+++ b/ee/elf-loader/src/elf.c
@@ -54,13 +54,13 @@ static void wipe_bramMem(void) {
 #endif
 }
 
-int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]) {
+static int LoadELFFromFileResetCommon(const char *filename, const char *partition, int reset, int argc, char *argv[]) {
 	u8 *boot_elf;
 	elf_header_t *eh;
 	elf_pheader_t *eph;
 	void *pdata;
 	int i;
-	int new_argc = argc + 2;
+	int new_argc = argc + 3;
 	
 	// We need to check that the ELF file before continue
 	if (!file_exists(filename)) {
@@ -70,11 +70,12 @@ int LoadELFFromFileWithPartition(const char *filename, const char *partition, in
 	wipe_bramMem();
 
 	// Preparing filename and partition to be sent in the argv
-	char *new_argv[argc + 2];
+	char *new_argv[argc + 3];
 	new_argv[0] = partition != NULL ? (char *)partition : "";
 	new_argv[1] = (char *)filename;
+	new_argv[2] = reset ? "1" : "0";
 	for (i = 0; i < argc; i++) {
-		new_argv[i + 2] = argv[i];
+		new_argv[i + 3] = argv[i];
 	}
 	
 	/* NB: LOADER.ELF is embedded  */
@@ -103,6 +104,14 @@ int LoadELFFromFileWithPartition(const char *filename, const char *partition, in
 	FlushCache(2);
 	
 	return ExecPS2((void *)eh->entry, NULL, new_argc, new_argv);
+}
+
+int LoadELFFromFileWithPartition(const char *filename, const char *partition, int argc, char *argv[]) {
+	return LoadELFFromFileResetCommon(filename, partition, 1, argc, argv);
+}
+
+int LoadELFFromFileWithPartitionNoReset(const char *filename, const char *partition, int argc, char *argv[]) {
+	return LoadELFFromFileResetCommon(filename, partition, 0, argc, argv);
 }
 
 int LoadELFFromFile(const char *filename, int argc, char *argv[])

--- a/ee/elf-loader/src/loader/src/loader.c
+++ b/ee/elf-loader/src/loader/src/loader.c
@@ -90,22 +90,26 @@ int main(int argc, char *argv[])
 	SET_GS_BGCOLOUR(WHITE_BG);
 	// arg[0] partition if exists, otherwise is ""
 	// arg[1]=path to ELF
-	if (argc < 2) {  
+	// arg[2]=reset flag ("0" = keep IOP, otherwise reset)
+	if (argc < 3) {  
 		SET_GS_BGCOLOUR(RED_BG);
 		return -EINVAL;
 	}
 
-	char *new_argv[argc - 1];
+	int reset = (argv[2][0] != '0');
+
+	char *new_argv[argc - 2];
 	int argv0_len = strlen(argv[0]);
 	int argv1_len = strlen(argv[1]);
 	char fullPath[argv0_len + argv1_len + 1];
+
 	memcpy(&fullPath[0], argv[0], argv0_len);
 	memcpy(&fullPath[argv0_len], argv[1], argv1_len);
 	fullPath[argv0_len + argv1_len] = 0;
 	// final new_argv[0] is partition + path to elf
 	new_argv[0] = fullPath;
-	for (i = 2; i < argc; i++) {
-		new_argv[i - 1] = argv[i];
+	for (i = 3; i < argc; i++) {
+		new_argv[i - 2] = argv[i];
 	}
 
 	SET_GS_BGCOLOUR(CYAN_BG);
@@ -124,20 +128,22 @@ int main(int argc, char *argv[])
 	if (ret == 0 && elfdata.epc != 0) {
 		SET_GS_BGCOLOUR(YELLOW_BG);
 
-		// Let's reset IOP because ELF was already loaded in memory
-		while(!SifIopReset(NULL, 0)){};
-		while (!SifIopSync()) {};
+		if (reset) {
+			// Let's reset IOP because ELF was already loaded in memory
+			while(!SifIopReset(NULL, 0)){};
+			while (!SifIopSync()) {};
 
-		SET_GS_BGCOLOUR(ORANGE_BG);
+			SET_GS_BGCOLOUR(ORANGE_BG);
 
-        sceSifInitRpc(0);
-        // Load modules.
-        SifLoadFileInit();
-        SifLoadModule("rom0:SIO2MAN", 0, NULL);
-        SifLoadModule("rom0:MCMAN", 0, NULL);
-        SifLoadModule("rom0:MCSERV", 0, NULL);
-        SifLoadFileExit();
-        sceSifExitRpc();
+        	sceSifInitRpc(0);
+        	// Load modules.
+        	SifLoadFileInit();
+        	SifLoadModule("rom0:SIO2MAN", 0, NULL);
+        	SifLoadModule("rom0:MCMAN", 0, NULL);
+        	SifLoadModule("rom0:MCSERV", 0, NULL);
+        	SifLoadFileExit();
+        	sceSifExitRpc();
+		}
 
 		SET_GS_BGCOLOUR(BROWN_BG);
 
@@ -145,8 +151,8 @@ int main(int argc, char *argv[])
 		FlushCache(2);
 
 		SET_GS_BGCOLOUR(PURPBLE_BG);
-		
-		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc-1, new_argv);
+
+		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 2, new_argv);
 	} else {
 		SET_GS_BGCOLOUR(MAGENTA_BG);
 		sceSifExitRpc();


### PR DESCRIPTION
Adds LoadELFFromFileWithPartitionNoReset() via a runtime reset flag passed to the loader through argv, so an ELF launched from USB/BDM can still reach its boot device's storage modules (one blob; small change to the stub's argv layout).

Alternative to #877 