### PR TITLE
Changes to avoid strncpy in EE and host code

### DIFF
--- a/ee/erl/src/erl.c
+++ b/ee/erl/src/erl.c
@@ -1050,7 +1050,7 @@ struct erl_record_t * _init_load_erl_from_file(const char * fname, char * erl_id
     argv[0] = erl_id;
     argv[1] = 0;
 
-    snprintf(tfname, sizeof(tfname), "%s%s", _init_erl_prefix, fname);
+    snprintf(tfname, sizeof(tfname), "%*s%s", sizeof(_init_erl_prefix), _init_erl_prefix, fname);
 
     return load_erl_from_file(tfname, 1, argv);
 }
@@ -1093,7 +1093,7 @@ struct erl_record_t * _init_load_erl_from_file_to_addr(const char * fname, u32 a
     argv[0] = erl_id;
     argv[1] = 0;
 
-    snprintf(tfname, sizeof(tfname), "%s%s", _init_erl_prefix, fname);
+    snprintf(tfname, sizeof(tfname), "%*s%s", sizeof(_init_erl_prefix), _init_erl_prefix, fname);
 
     return load_erl_from_file_to_addr(tfname, addr, 1, argv);
 }

--- a/ee/font/src/fontx.c
+++ b/ee/font/src/fontx.c
@@ -159,9 +159,9 @@ int fontx_load_single_krom(fontx_t *fontx)
 	fontx_header = (fontx_hdr*)fontx->font;
 
 	// define header as single-byte font
-	strncpy(fontx_header->id, "FONTX2", 6);
+	strcpy(fontx_header->id, "FONTX2");
 	fontx_header->id[6] = '\0';
-	strncpy(fontx_header->name, "KROM", 8);
+	strcpy(fontx_header->name, "KROM");
 	fontx_header->name[8] = '\0';
 
 	fontx_header->width = 8;
@@ -237,9 +237,9 @@ int fontx_load_double_krom(fontx_t *fontx)
 	fontx_header = (fontx_hdr*)fontx->font;
 
 	// define the header as double-byte font
-	strncpy(fontx_header->id, "FONTX2", 6);
+	strcpy(fontx_header->id, "FONTX2");
 	fontx_header->id[6] = '\0';
-	strncpy(fontx_header->name, "KROM", 8);
+	strcpy(fontx_header->name, "KROM");
 	fontx_header->name[8] = '\0';
 
 	fontx_header->width = 16;

--- a/ee/ioprpgen/src/ioprpgen.c
+++ b/ee/ioprpgen/src/ioprpgen.c
@@ -72,11 +72,7 @@ ioprpgen_write_romdir_entry(const struct ioprpgen_ctx *ctx, const char *name, u3
 {
 	struct ioprp_romdir_entry ent;
 	memset(&ent, 0, sizeof(ent));
-	if ( name )
-	{
-		strncpy(ent.m_name, name, sizeof(ent.m_name) - 1);
-		ent.m_name[sizeof(ent.m_name) - 1] = 0;
-	}
+	strlcpy(ent.m_name, name ? name : "", sizeof(ent.m_name));
 	ent.m_extinfo_size = extinfo_size;
 	ent.m_data_size = data_size;
 	return ctx->m_write_cb(ctx->m_write_cb_userdata, ctx, &ent, sizeof(ent)) == sizeof(ent);

--- a/ee/kernel/src/fileio.c
+++ b/ee/kernel/src/fileio.c
@@ -176,8 +176,7 @@ int fioOpen(const char *name, int mode)
     WaitSema(_fio_completion_sema);
 
     arg.mode = mode;
-    strncpy(arg.name, name, FIO_PATH_MAX - 1);
-    arg.name[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.name, name, sizeof(arg.name));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_OPEN, _fio_block_mode, &arg, sizeof arg,
                           _fio_recv_data, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -399,8 +398,7 @@ int fioRemove(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strncpy(arg.path, name, FIO_PATH_MAX - 1);
-    arg.path[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, name, sizeof(arg.path));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_REMOVE, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -432,8 +430,7 @@ int fioMkdir(const char *path)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strncpy(arg.path, path, FIO_PATH_MAX - 1);
-    arg.path[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, path, sizeof(arg.path));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_MKDIR, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -465,8 +462,7 @@ int fioRmdir(const char *dirname)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strncpy(arg.path, dirname, FIO_PATH_MAX - 1);
-    arg.path[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, dirname, sizeof(arg.path));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_RMDIR, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -542,8 +538,7 @@ int fioDopen(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strncpy(arg.name, name, FIO_PATH_MAX - 1);
-    arg.name[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.name, name, sizeof(arg.name));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_DOPEN, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -636,8 +631,7 @@ int fioGetstat(const char *name, io_stat_t *buf)
     WaitSema(_fio_completion_sema);
 
     arg.p.buf = buf;
-    strncpy(arg.name, name, FIO_PATH_MAX - 1);
-    arg.name[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.name, name, sizeof(arg.name));
 
     if (!IS_UNCACHED_SEG(buf))
         sceSifWriteBackDCache(buf, sizeof(io_stat_t));
@@ -670,8 +664,7 @@ int fioChstat(const char *name, io_stat_t *buf, u32 cbit)
 
     arg.p.cbit = cbit;
     memcpy(&arg.stat, buf, sizeof(io_stat_t));
-    strncpy(arg.name, name, FIO_PATH_MAX - 1);
-    arg.name[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.name, name, sizeof(arg.name));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_CHSTAT, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -703,8 +696,7 @@ int fioFormat(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strncpy(arg.path, name, FIO_PATH_MAX - 1);
-    arg.path[FIO_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, name, sizeof(arg.path));
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_FORMAT, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {

--- a/ee/kernel/src/iopheap.c
+++ b/ee/kernel/src/iopheap.c
@@ -104,8 +104,7 @@ int SifLoadIopHeap(const char *path, void *addr)
         return -E_LIB_API_INIT;
 
     arg.p.addr = addr;
-    strncpy(arg.path, path, LIH_PATH_MAX - 1);
-    arg.path[LIH_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, path, sizeof(arg.path));
 
     if (sceSifCallRpc(&_ih_cd, 3, 0, &arg, sizeof arg, &arg, 4, NULL, NULL) < 0)
         return -E_SIF_RPC_CALL;

--- a/ee/kernel/src/loadfile.c
+++ b/ee/kernel/src/loadfile.c
@@ -75,8 +75,7 @@ int _SifLoadModule(const char *path, int arg_len, const char *args, int *modres,
 
     memset(&arg, 0, sizeof arg);
 
-    strncpy(arg.path, path, LF_PATH_MAX - 1);
-    arg.path[LF_PATH_MAX - 1] = 0;
+    strlcpy(arg.path, path, sizeof(arg.path));
 
     if (args && arg_len) {
         arg.p.arg_len = arg_len > LF_ARG_MAX ? LF_ARG_MAX : arg_len;
@@ -167,8 +166,7 @@ int SifSearchModuleByName(const char *name)
     if (SifLoadFileInit() < 0)
         return -SCE_EBINDMISS;
 
-    strncpy(arg.name, name, LF_PATH_MAX - 1);
-    arg.name[LF_PATH_MAX - 1] = 0;
+    strlcpy(arg.name, name, sizeof(arg.name));
 
     if (sceSifCallRpc(&_lf_cd, LF_F_SEARCH_MOD_BY_NAME, 0, &arg, sizeof arg, &arg, 4, NULL, NULL) < 0)
         return -SCE_ECALLMISS;
@@ -201,10 +199,8 @@ int _SifLoadElfPart(const char *path, const char *secname, t_ExecData *data, int
     if (SifLoadFileInit() < 0)
         return -SCE_EBINDMISS;
 
-    strncpy(arg.path, path, LF_PATH_MAX - 1);
-    strncpy(arg.secname, secname, LF_ARG_MAX - 1);
-    arg.path[LF_PATH_MAX - 1]   = 0;
-    arg.secname[LF_ARG_MAX - 1] = 0;
+    strlcpy(arg.path, path, sizeof(arg.path));
+    strlcpy(arg.secname, secname, sizeof(arg.secname));
 
     if (sceSifCallRpc(&_lf_cd, fno, 0, &arg, sizeof arg, &arg,
                    sizeof(t_ExecData), NULL, NULL) < 0)

--- a/ee/libcglue/src/glue.c
+++ b/ee/libcglue/src/glue.c
@@ -61,7 +61,7 @@ struct passwd __dummy_passwd;
 __attribute__((constructor))
 static void __dummy_passwd_init(void)
 {
-	strncpy(__dummy_passwd_loginbuf, "ps2user", sizeof(__dummy_passwd_loginbuf));
+	strcpy(__dummy_passwd_loginbuf, "ps2user");
 	__dummy_passwd.pw_name = &__dummy_passwd_loginbuf[0];
 	__dummy_passwd.pw_passwd = "xxx";
 	__dummy_passwd.pw_uid = 1000;

--- a/ee/libcglue/src/ps2sdkapi.c
+++ b/ee/libcglue/src/ps2sdkapi.c
@@ -280,8 +280,7 @@ int __fioDreadHelper(void *userdata, struct dirent *dir)
     }
 
     dir->d_fileno = rv; // TODO: This number should be in theory a unique number per file
-    strncpy(dir->d_name, iodir.name, __MAXNAMLEN);
-    dir->d_name[__MAXNAMLEN - 1] = 0;
+    snprintf(dir->d_name, sizeof(dir->d_name), "%*s", (int)(sizeof(iodir.name) - 1), iodir.name);
     dir->d_reclen = 0;
     switch (iodir.stat.mode & FIO_SO_IFMT) {
         case FIO_SO_IFLNK: dir->d_type = DT_LNK;     break;

--- a/ee/network/netman/src/rpc_client.c
+++ b/ee/network/netman/src/rpc_client.c
@@ -2,6 +2,7 @@
 #include <kernel.h>
 #include <sifrpc.h>
 #include <string.h>
+#include <stdio.h>
 #include <malloc.h>
 #include <netman.h>
 #include <netman_rpc.h>
@@ -293,7 +294,7 @@ int NetManSetMainIF(const char *name)
 
 	WaitSema(NetManIOSemaID);
 
-	strncpy(TransmitBuffer.netifName, name, NETMAN_NETIF_NAME_MAX_LEN);
+	strlcpy(TransmitBuffer.netifName, name, sizeof(TransmitBuffer.netifName));
 	TransmitBuffer.netifName[NETMAN_NETIF_NAME_MAX_LEN-1] = '\0';
 	if((result=sceSifCallRpc(&NETMAN_rpc_cd, NETMAN_IOP_RPC_FUNC_SET_MAIN_NETIF, 0, &TransmitBuffer, NETMAN_NETIF_NAME_MAX_LEN, &ReceiveBuffer, sizeof(s32), NULL, NULL))>=0)
 		result=ReceiveBuffer.result;
@@ -316,7 +317,7 @@ int NetManQueryMainIF(char *name)
 	{
 		if((result=ReceiveBuffer.QueryMainNetIFResult.result) == 0)
 		{
-			strncpy(name, ReceiveBuffer.QueryMainNetIFResult.name, NETMAN_NETIF_NAME_MAX_LEN);
+			sprintf(name, "%*s", (int)sizeof(ReceiveBuffer.QueryMainNetIFResult.name), ReceiveBuffer.QueryMainNetIFResult.name);
 			name[NETMAN_NETIF_NAME_MAX_LEN-1] = '\0';
 		}
 	}

--- a/ee/rpc/cdvd/src/libcdvd.c
+++ b/ee/rpc/cdvd/src/libcdvd.c
@@ -214,8 +214,7 @@ s32 sceCdSearchFile(sceCdlFILE *file, const char *name)
         }
     }
 
-    strncpy(searchFileSendBuff.name, name, 255);
-    searchFileSendBuff.name[255] = '\0';
+    strlcpy(searchFileSendBuff.name, name, sizeof(searchFileSendBuff.name));
     searchFileSendBuff.dest      = &searchFileSendBuff;
 
     if (CdDebug > 0)

--- a/ee/rpc/filexio/src/fileXio_ps2sdk.c
+++ b/ee/rpc/filexio/src/fileXio_ps2sdk.c
@@ -387,8 +387,7 @@ int __fileXioDreadHelper(void *userdata, struct dirent *dir)
     }
 
     dir->d_fileno = rv; // TODO: This number should be in theory a unique number per file
-    strncpy(dir->d_name, ioxdir.name, __MAXNAMLEN);
-    dir->d_name[__MAXNAMLEN - 1] = 0;
+    snprintf(dir->d_name, sizeof(dir->d_name), "%*s", (int)(sizeof(ioxdir.name) - 1), ioxdir.name);
     dir->d_reclen = 0;
     switch (ioxdir.stat.mode & FIO_S_IFMT) {
         case FIO_S_IFLNK: dir->d_type = DT_LNK;     break;

--- a/ee/rpc/filexio/src/fileXio_rpc.c
+++ b/ee/rpc/filexio/src/fileXio_rpc.c
@@ -208,7 +208,7 @@ int fileXioGetdir(const char* pathname, struct fileXioDirEntry dirEntry[], unsig
 	WaitSema(__fileXioCompletionSema);
 
 	// copy the requested pathname to the rpc buffer
-	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
+	strlcpy(packet->pathname, pathname, sizeof(packet->pathname));
 
 	sceSifWriteBackDCache(dirEntry, (sizeof(struct fileXioDirEntry) * req_entries));
 
@@ -241,8 +241,8 @@ int fileXioMount(const char* mountpoint, const char* mountstring, int flag)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->blockdevice, mountstring, sizeof(packet->blockdevice));
-	strncpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
+	strlcpy(packet->blockdevice, mountstring, sizeof(packet->blockdevice));
+	strlcpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
 	packet->flags = flag;
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_MOUNT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_mount_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
@@ -270,7 +270,7 @@ int fileXioUmount(const char* mountpoint)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
+	strlcpy(packet->mountpoint, mountpoint, sizeof(packet->mountpoint));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_UMOUNT, __fileXioBlockMode, __sbuff, sizeof(struct fxio_unmount_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -297,8 +297,8 @@ int fileXioCopyfile(const char* source, const char* dest, int mode)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->source, source, sizeof(packet->source));
-	strncpy(packet->dest, dest, sizeof(packet->dest));
+	strlcpy(packet->source, source, sizeof(packet->source));
+	strlcpy(packet->dest, dest, sizeof(packet->dest));
 	packet->mode = mode;
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_COPYFILE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_copyfile_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
@@ -326,7 +326,7 @@ int fileXioMkdir(const char* pathname, int mode)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
+	strlcpy(packet->pathname, pathname, sizeof(packet->pathname));
 	packet->mode = mode;
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_MKDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_mkdir_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
@@ -354,7 +354,7 @@ int fileXioRmdir(const char* pathname)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
+	strlcpy(packet->pathname, pathname, sizeof(packet->pathname));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_RMDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -381,7 +381,7 @@ int fileXioRemove(const char* pathname)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
+	strlcpy(packet->pathname, pathname, sizeof(packet->pathname));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_REMOVE, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -408,8 +408,8 @@ int fileXioRename(const char* source, const char* dest)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->source, source, sizeof(packet->source));
-	strncpy(packet->dest, dest, sizeof(packet->dest));
+	strlcpy(packet->source, source, sizeof(packet->source));
+	strlcpy(packet->dest, dest, sizeof(packet->dest));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_RENAME, __fileXioBlockMode, __sbuff, sizeof(struct fxio_rename_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -436,8 +436,8 @@ int fileXioSymlink(const char* source, const char* dest)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->source, source, sizeof(packet->source));
-	strncpy(packet->dest, dest, sizeof(packet->dest));
+	strlcpy(packet->source, source, sizeof(packet->source));
+	strlcpy(packet->dest, dest, sizeof(packet->dest));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_SYMLINK, __fileXioBlockMode, __sbuff, sizeof(struct fxio_rename_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -467,7 +467,7 @@ int fileXioReadlink(const char* source, char* buf, unsigned int buflen)
 	if( !IS_UNCACHED_SEG(buf))
   	  sceSifWriteBackDCache(buf, buflen);
 
-	strncpy(packet->source, source, sizeof(packet->source));
+	strlcpy(packet->source, source, sizeof(packet->source));
 	packet->buffer = buf;
 	packet->buflen = buflen;
 
@@ -496,7 +496,7 @@ int fileXioChdir(const char* pathname)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, pathname, sizeof(packet->pathname));
+	strlcpy(packet->pathname, pathname, sizeof(packet->pathname));
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_CHDIR, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
@@ -528,7 +528,7 @@ int fileXioOpen(const char* source, int flags, ...)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, source, sizeof(packet->pathname));
+	strlcpy(packet->pathname, source, sizeof(packet->pathname));
 	packet->flags = flags;
 	packet->mode = mode;
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_OPEN, __fileXioBlockMode, __sbuff, sizeof(struct fxio_open_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
@@ -738,7 +738,7 @@ int fileXioChStat(const char *name, iox_stat_t *stat, int mask)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, name, sizeof(packet->pathname));
+	strlcpy(packet->pathname, name, sizeof(packet->pathname));
 	packet->stat = stat;
 	packet->mask = mask;
 
@@ -770,7 +770,7 @@ int fileXioGetStat(const char *name, iox_stat_t *stat)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, name, sizeof(packet->pathname));
+	strlcpy(packet->pathname, name, sizeof(packet->pathname));
 	packet->stat = stat;
 
 	if(!IS_UNCACHED_SEG(stat))
@@ -801,9 +801,8 @@ int fileXioFormat(const char *dev, const char *blockdev, const void *args, int a
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->device, dev, sizeof(packet->device));
-	if(blockdev)
-		strncpy(packet->blockDevice, blockdev, sizeof(packet->blockDevice));
+	strlcpy(packet->device, dev, sizeof(packet->device));
+	strlcpy(packet->blockDevice, blockdev ? blockdev : "", sizeof(packet->blockDevice));
 
 	if((unsigned int)arglen > sizeof(packet->args)) arglen = sizeof(packet->args);
 	memcpy(packet->args, args, arglen);
@@ -834,7 +833,7 @@ int fileXioSync(const char *devname, int flag)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->device, devname, sizeof(packet->device));
+	strlcpy(packet->device, devname, sizeof(packet->device));
 	packet->flags = flag;
 
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_SYNC, __fileXioBlockMode, __sbuff, sizeof(struct fxio_sync_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
@@ -862,7 +861,7 @@ int fileXioDopen(const char *name)
 	_lock();
 	WaitSema(__fileXioCompletionSema);
 
-	strncpy(packet->pathname, name, sizeof(packet->pathname));
+	strlcpy(packet->pathname, name, sizeof(packet->pathname));
 	if((rv = sceSifCallRpc(&__cd0, FILEXIO_DOPEN, __fileXioBlockMode, __sbuff, sizeof(struct fxio_pathsel_packet), __sbuff, 4, (void *)&_fxio_intr, NULL)) >= 0)
 	{
 		if(__fileXioBlockMode == FXIO_NOWAIT) { rv = 0; }
@@ -956,8 +955,7 @@ int fileXioDevctl(const char *name, int cmd, void *arg, unsigned int arglen, voi
 
 	if(arglen > CTL_BUF_SIZE) arglen = CTL_BUF_SIZE;
 	if(buflen > CTL_BUF_SIZE) buflen = CTL_BUF_SIZE;
-	strncpy(packet->name, name, CTL_BUF_SIZE);
-	packet->name[CTL_BUF_SIZE-1] = '\0';
+	strlcpy(packet->name, name, sizeof(packet->name));
 	memcpy(packet->arg, arg, arglen);
 
 	packet->cmd = cmd;

--- a/ee/rpc/hdd/src/libhdd.c
+++ b/ee/rpc/hdd/src/libhdd.c
@@ -323,7 +323,7 @@ int hddMakeFilesystem(int fsSizeMB, char *name, int type)
 	}
 
 	// Check if filesystem already exists
-	snprintf(openString, sizeof(openString), "hdd0:%s", fsName);
+	snprintf(openString, sizeof(openString), "hdd0:%*s", (int)(sizeof(fsName) - 1), fsName);
 	partFd = fileXioOpen(openString, FIO_O_RDONLY);
 	if(partFd > 0 || partFd == -EACCES)	// Filesystem already exists
 	{
@@ -345,7 +345,7 @@ int hddMakeFilesystem(int fsSizeMB, char *name, int type)
 		printf(">>> Attempting to create main partition, size %d MB\n", partSize);
 #endif
 
-		snprintf(openString, sizeof(openString), "hdd0:%s,,,%s,PFS", fsName, sizesString[useIndex]);
+		snprintf(openString, sizeof(openString), "hdd0:%*s,,,%s,PFS", (int)(sizeof(fsName) - 1), fsName, sizesString[useIndex]);
 #ifdef DEBUG
 		printf(">>> openString = %s\n", openString);
 #endif
@@ -441,7 +441,7 @@ int hddMakeFilesystem(int fsSizeMB, char *name, int type)
 
 	fileXioClose(partFd);
 
-	snprintf(openString, sizeof(openString), "hdd0:%s", fsName);
+	snprintf(openString, sizeof(openString), "hdd0:%*s", (int)(sizeof(fsName) - 1), fsName);
 	retVal = fileXioFormat("pfs:", openString, (const char*)&pfsFormatArg, sizeof(pfsFormatArg));
 	if(retVal < 0)
 	{

--- a/ee/rpc/hdd/src/libhdd.c
+++ b/ee/rpc/hdd/src/libhdd.c
@@ -318,7 +318,7 @@ int hddMakeFilesystem(int fsSizeMB, char *name, int type)
 			snprintf(fsName, sizeof(fsName), "+%s", name);
 			break;
 		default:
-			snprintf(fsName, sizeof(fsName), "%s", name);
+			strlcpy(fsName, name, sizeof(fsName));
 			break;
 	}
 

--- a/ee/rpc/memorycard/src/libmc.c
+++ b/ee/rpc/memorycard/src/libmc.c
@@ -520,8 +520,7 @@ static int libmc_rpc_open(const libmc_target_desc_t *target, const char *name, i
 	target->m_interface_data->m_name_desc_param.m_name_param.m_port		= target->m_port;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_slot		= target->m_slot;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_flags		= mode;
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 
 	return libmc_post_rpc(target, MC_RPCCMD_OPEN, 0, NULL, NULL);
 }
@@ -621,8 +620,7 @@ static int libmc_rpc_chdir(const libmc_target_desc_t *target, const char* newDir
 	target->m_interface_data->m_name_desc_param.m_name_param.m_port		= target->m_port;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_slot		= target->m_slot;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_curdir		= target->m_interface_data->m_extra_send_recv_param.m_cur_dir;
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, newDir, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, newDir, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 	sceSifWriteBackDCache(target->m_interface_data->m_extra_send_recv_param.m_cur_dir, sizeof(target->m_interface_data->m_extra_send_recv_param.m_cur_dir));
 	target->m_interface_data->m_extra_end_param.m_dst_cur_dir = currentDir;
 	target->m_interface_data->m_extra_end_param.m_extra_send_recv_param = UNCACHED_SEG(&target->m_interface_data->m_extra_send_recv_param);
@@ -640,8 +638,7 @@ static int libmc_rpc_getdir(const libmc_target_desc_t *target, const char *name,
 	target->m_interface_data->m_name_desc_param.m_name_param.m_flags	= mode;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_maxent	= maxent;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_mcT		= table;
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 	sceSifWriteBackDCache(table, maxent * sizeof(sceMcTblGetDir));
 
 	return libmc_post_rpc(target, MC_RPCCMD_GET_DIR, 0, NULL, NULL);
@@ -658,8 +655,7 @@ static int libmc_rpc_setfileinfo(const libmc_target_desc_t *target, const char* 
 	target->m_interface_data->m_name_desc_param.m_name_param.m_mcT		= &(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff);
 	memcpy(&(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff), info, sizeof(sceMcTblGetDir));
 
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 	FlushCache(0);
 
 	return libmc_post_rpc(target, MC_RPCCMD_SET_INFO, 0, NULL, NULL);
@@ -673,8 +669,7 @@ static int libmc_rpc_delete(const libmc_target_desc_t *target, const char *name)
 	target->m_interface_data->m_name_desc_param.m_name_param.m_port = target->m_port;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_slot = target->m_slot;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_flags = 0;
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, name, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 
 	return libmc_post_rpc(target, MC_RPCCMD_DELETE, 0, NULL, NULL);
 }
@@ -708,8 +703,7 @@ static int libmc_rpc_get_ent_space(const libmc_target_desc_t *target, const char
 	// set global variables
 	target->m_interface_data->m_name_desc_param.m_name_param.m_port = target->m_port;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_slot = target->m_slot;
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, path, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, path, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
 
 	return libmc_post_rpc(target, MC_RPCCMD_GET_ENT, 0, NULL, NULL);
 }
@@ -724,10 +718,8 @@ static int libmc_rpc_rename(const libmc_target_desc_t *target, const char* oldNa
 	target->m_interface_data->m_name_desc_param.m_name_param.m_slot = target->m_slot;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_flags = 0x10;
 	target->m_interface_data->m_name_desc_param.m_name_param.m_mcT = &(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff);
-	strncpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, oldName, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1);
-	target->m_interface_data->m_name_desc_param.m_name_param.m_name[sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name) - 1] = 0;
-	strncpy((char*)target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName, newName, sizeof(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName) - 1);
-	target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName[sizeof(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName) - 1] = 0;
+	strlcpy(target->m_interface_data->m_name_desc_param.m_name_param.m_name, oldName, sizeof(target->m_interface_data->m_name_desc_param.m_name_param.m_name));
+	strlcpy((char*)target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName, newName, sizeof(target->m_interface_data->m_extra_send_recv_param.m_file_info_buff.EntryName));
 	FlushCache(0);
 
 	return libmc_post_rpc(target, MC_RPCCMD_SET_INFO, 0, NULL, NULL);

--- a/ee/rpc/ps2snd/src/ps2snd.c
+++ b/ee/rpc/ps2snd/src/ps2snd.c
@@ -243,7 +243,7 @@ int sndStreamOpen(char *file, u32 voices, u32 flags, u32 bufaddr, u32 bufsize)
 	buf[1] = flags;
 	buf[2] = bufaddr;
 	buf[3] = bufsize;
-	strncpy((char*)&buf[4], file, 27*4);
+	strlcpy((char*)&buf[4], file, 27*4);
 	buf[31] = 0;
 
 	sceSifCallRpc(&sd_client, PS2SND_StreamOpen, 0, buf, 128, buf, 4, NULL, NULL);

--- a/ee/rpc/tcpips/src/ps2ipc.c
+++ b/ee/rpc/tcpips/src/ps2ipc.c
@@ -467,8 +467,7 @@ int ps2ipc_ps2ip_getconfig(char *netif_name, t_ip_info *ip_info)
 	WaitSema(lock_sema);
 
 	// call with netif name
-	strncpy(_rpc_buffer.netif_name, netif_name, sizeof(_rpc_buffer.netif_name));
-	_rpc_buffer.netif_name[sizeof(_rpc_buffer.netif_name) - 1] = '\0';
+	strlcpy(_rpc_buffer.netif_name, netif_name, sizeof(_rpc_buffer.netif_name));
 
 	if (sceSifCallRpc(&_ps2ip, PS2IPS_ID_GETCONFIG, 0, (void*)_rpc_buffer.netif_name, sizeof(_rpc_buffer.netif_name), (void*)&_rpc_buffer.ip_info, sizeof(t_ip_info), NULL, NULL) < 0)
 	{
@@ -721,8 +720,7 @@ struct hostent *ps2ipc_gethostbyname(const char *name)
 	WaitSema(lock_sema);
 
 	result = NULL;
-	strncpy(_rpc_buffer.hostname, name, sizeof(_rpc_buffer.hostname));
-	_rpc_buffer.hostname[sizeof(_rpc_buffer.hostname) - 1] = '\0';
+	strlcpy(_rpc_buffer.hostname, name, sizeof(_rpc_buffer.hostname));
 	if(sceSifCallRpc(&_ps2ip, PS2IPS_ID_GETHOSTBYNAME, 0, (void*)_rpc_buffer.hostname, sizeof(_rpc_buffer.hostname), (void*)res_pkt, sizeof(gethostbyname_res_pkt), NULL, NULL) >=0)
 	{
 		if(res_pkt->result == 0)

--- a/iop/arcade/romwrite/src/romwrite.c
+++ b/iop/arcade/romwrite/src/romwrite.c
@@ -613,7 +613,7 @@ static int do_format_device(int abspart)
 	STATUS_PRINTF("\n");
 	STATUS_PRINTF(" [3/3]Write Boot Sector and Logical Address Table\n");
 	memset(&g_nand_partbuf.m_hdr, 0, sizeof(g_nand_partbuf.m_hdr));
-	strncpy(g_nand_partbuf.m_hdr.m_sig, "S147NAND", 9);
+	strcpy(g_nand_partbuf.m_hdr.m_sig, "S147NAND");
 	g_nand_partbuf.m_hdr.m_bootsector_ver_1 = 3;
 	g_nand_partbuf.m_hdr.m_bootsector_ver_2 = 0;
 	for ( i = 0; i < 8; i += 1 )

--- a/tools/romimg/src/SonyRX.c
+++ b/tools/romimg/src/SonyRX.c
@@ -64,12 +64,10 @@ int GetSonyRXModInfo(const char *path, char *description, unsigned int MaxLength
 
                                     if (SectionHeader.type == (SHT_LOPROC | SHT_LOPROC_IOPMOD_TAB)) {
                                         *version = ((iopmod_t *)buffer)->version;
-                                        strncpy(description, ((iopmod_t *)buffer)->modname, MaxLength - 1);
-                                        description[MaxLength - 1] = '\0';
+                                        snprintf(description, MaxLength, "%s", ((iopmod_t *)buffer)->modname);
                                     } else if (SectionHeader.type == (SHT_LOPROC | SHT_LOPROC_EEMOD_TAB)) {
                                         *version = ((eemod_t *)buffer)->version;
-                                        strncpy(description, ((eemod_t *)buffer)->modname, MaxLength - 1);
-                                        description[MaxLength - 1] = '\0';
+                                        snprintf(description, MaxLength, "%s", ((eemod_t *)buffer)->modname);
                                     }
                                 }
 

--- a/tools/romimg/src/main.c
+++ b/tools/romimg/src/main.c
@@ -25,8 +25,7 @@ static void DisplayROMImgDetails(const ROMIMG *ROMImg)
            GREEN"Name"DEFCOL"      \tSize\n"
            "-----------------------------\n");
     for (i = 0, file = ROMImg->files, TotalSize = 0; i < ROMImg->NumFiles; TotalSize += file->RomDir.size, i++, file++) {
-        strncpy(filename, file->RomDir.name, sizeof(filename) - 1);
-        filename[sizeof(filename) - 1] = '\0';
+        snprintf(filename, sizeof(filename), "%*s", (int)sizeof(file->RomDir.name), file->RomDir.name);
         printf(GREEN"%-10s"DEFCOL"\t%u\n", filename, file->RomDir.size);
     }
 
@@ -160,8 +159,7 @@ int main(int argc, char **argv)
            			   GREEN"Name"DEFCOL"      \tSize\n"
                        "-----------------------------\n");
                 for (i = 0, file = ROMImg.files; i < ROMImg.NumFiles; i++, file++) {
-                    strncpy(filename, file->RomDir.name, sizeof(filename) - 1);
-                    filename[sizeof(filename) - 1] = '\0';
+                    snprintf(filename, sizeof(filename), "%*s", (int)sizeof(file->RomDir.name), file->RomDir.name);
                     printf(GREEN"%-10s"DEFCOL"\t%u\n", filename, file->RomDir.size);
 
                     if (file->RomDir.size > 0) {

--- a/tools/romimg/src/romimg.c
+++ b/tools/romimg/src/romimg.c
@@ -463,8 +463,7 @@ int AddFile(ROMIMG *ROMImg, const char *path, int upperconv)
 		const char* fname = strrchr(path, PATHSEP);
 		if (fname == NULL) fname = path; else fname++;
         if (upperconv) {
-            strncpy(tbuf, fname, sizeof(tbuf));
-            tbuf[sizeof(tbuf) - 1] = '\0';
+            snprintf(tbuf, sizeof(tbuf), "%s", fname);
             if (tbuf[0] != '\0') {
                 upperbuff(tbuf);
                 char* T = strrchr(tbuf, '.');
@@ -487,8 +486,7 @@ int AddFile(ROMIMG *ROMImg, const char *path, int upperconv)
 					file = &ROMImg->files[ROMImg->NumFiles - 1];
 					memset(&ROMImg->files[ROMImg->NumFiles - 1], 0, sizeof(struct FileEntry));
 
-					strncpy(file->RomDir.name, fname, sizeof(file->RomDir.name));
-                    file->RomDir.name[sizeof(file->RomDir.name) - 1] = '\0';
+					snprintf(file->RomDir.name, sizeof(file->RomDir.name), "%s", fname);
 					file->RomDir.ExtInfoEntrySize = 0;
 
 					FileDateStamp = GetFileCreationDate(path);


### PR DESCRIPTION
`strncpy` has major flaws:
* Will zero initialize extra memory after NULL terminator
* Will not NULL terminate if written bytes is equal to buffer size
