### PR TITLE
Do not attempt to register stdio stub in sysclib if not loaded in boot

### DIFF
--- a/iop/system/sysclib/README.md
+++ b/iop/system/sysclib/README.md
@@ -30,5 +30,5 @@ balancing between size, speed, and features.
 
 In order to use this module in your program, you must integrate the module into
 an IOPRP image, then load the image with `UDNL`.\
-Using `LoadModule` or `LoadModuleBuffer` directly will not work, because the
-module is already loaded at IOP boot.
+Using `LoadModule` or `LoadModuleBuffer` directly will work, but is not
+recommended because the old version of the module will remain in memory.

--- a/iop/system/sysclib/src/_start.c
+++ b/iop/system/sysclib/src/_start.c
@@ -17,12 +17,12 @@ extern struct irx_export_table _exp_sysclib;
 extern struct irx_export_table _exp_stdio;
 
 int _start(int argc, char *argv[]) {
-	(void)argc;
 	(void)argv;
 
     if (RegisterLibraryEntries(&_exp_sysclib) != 0)
         return MODULE_NO_RESIDENT_END;
-    if (RegisterLibraryEntries(&_exp_stdio) != 0)
+    // Unofficial: only attempt to register stdio stub if in boot stage
+    if (!argc && RegisterLibraryEntries(&_exp_stdio) != 0)
         return MODULE_NO_RESIDENT_END;
 
     return MODULE_RESIDENT_END;


### PR DESCRIPTION
Allows using sysclib as upgrade to 1.3.4 modules after boot