### PR TITLE
workaround: fileio uses strncpy to avoid linking with newlib libc

### DIFF
--- a/ee/kernel/src/fileio.c
+++ b/ee/kernel/src/fileio.c
@@ -176,7 +176,8 @@ int fioOpen(const char *name, int mode)
     WaitSema(_fio_completion_sema);
 
     arg.mode = mode;
-    strlcpy(arg.name, name, sizeof(arg.name));
+    strncpy(arg.name, name, sizeof(arg.name));
+    arg.name[sizeof(arg.name) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_OPEN, _fio_block_mode, &arg, sizeof arg,
                           _fio_recv_data, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -398,7 +399,8 @@ int fioRemove(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strlcpy(arg.path, name, sizeof(arg.path));
+    strncpy(arg.path, name, sizeof(arg.path));
+    arg.path[sizeof(arg.path) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_REMOVE, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -430,7 +432,8 @@ int fioMkdir(const char *path)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strlcpy(arg.path, path, sizeof(arg.path));
+    strncpy(arg.path, path, sizeof(arg.path));
+    arg.path[sizeof(arg.path) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_MKDIR, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -462,7 +465,8 @@ int fioRmdir(const char *dirname)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strlcpy(arg.path, dirname, sizeof(arg.path));
+    strncpy(arg.path, dirname, sizeof(arg.path));
+    arg.path[sizeof(arg.path) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_RMDIR, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -538,7 +542,8 @@ int fioDopen(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strlcpy(arg.name, name, sizeof(arg.name));
+    strncpy(arg.name, name, sizeof(arg.name));
+    arg.name[sizeof(arg.name) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_DOPEN, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -631,7 +636,8 @@ int fioGetstat(const char *name, io_stat_t *buf)
     WaitSema(_fio_completion_sema);
 
     arg.p.buf = buf;
-    strlcpy(arg.name, name, sizeof(arg.name));
+    strncpy(arg.name, name, sizeof(arg.name));
+    arg.name[sizeof(arg.name) - 1] = 0;
 
     if (!IS_UNCACHED_SEG(buf))
         sceSifWriteBackDCache(buf, sizeof(io_stat_t));
@@ -664,7 +670,8 @@ int fioChstat(const char *name, io_stat_t *buf, u32 cbit)
 
     arg.p.cbit = cbit;
     memcpy(&arg.stat, buf, sizeof(io_stat_t));
-    strlcpy(arg.name, name, sizeof(arg.name));
+    strncpy(arg.name, name, sizeof(arg.name));
+    arg.name[sizeof(arg.name) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_CHSTAT, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {
@@ -696,7 +703,8 @@ int fioFormat(const char *name)
     WaitSema(_fio_io_sema);
     WaitSema(_fio_completion_sema);
 
-    strlcpy(arg.path, name, sizeof(arg.path));
+    strncpy(arg.path, name, sizeof(arg.path));
+    arg.path[sizeof(arg.path) - 1] = 0;
 
     if ((res = sceSifCallRpc(&_fio_cd, FIO_F_FORMAT, 0, &arg, sizeof arg,
                           &arg, 4, (void *)_fio_intr, NULL)) >= 0) {


### PR DESCRIPTION
Needed for minimal configurations