### PR TITLE
fix: release camera semaphore after failed transfer

### DIFF
--- a/iop/usb/camera/src/ps2cam.c
+++ b/iop/usb/camera/src/ps2cam.c
@@ -10,7 +10,7 @@
  */
 
 //(1) Please keep this file neat.
-//(2) This irx must always be backwords compatible.
+//(2) This irx must always be backwards compatible.
 #include <stdio.h>
 #include <sysclib.h>
 #include <tamtypes.h>
@@ -896,6 +896,7 @@ int PS2CamReadData(CAMERA_DEVICE* dev, void *addr, int size)
 	if(ret != USB_RC_OK)
 	{
 		printf("Usb: Error sending sceUsbdIsochronousTransfer\n");
+		SignalSema(ps2cam_sema);
 		return -1;
 	}
 	else


### PR DESCRIPTION
Release `ps2cam_sema` when `sceUsbdIsochronousTransfer()` fails synchronously.

Without this release, later camera reads block indefinitely: the semaphore is acquired before submitting the transfer, but a failed submission does not issue the completion callback that would normally release it.

Also corrected the backwards-compatibility spelling in the file header whilst I was at it