### PR TITLE
Make 1400 variants of padman and mcman default

### DIFF
--- a/iop/input/Makefile
+++ b/iop/input/Makefile
@@ -9,7 +9,7 @@
 SUBDIRS = \
     padman \
     padman-1300 \
-    padman-1400 \
+    padman-2000 \
     rmman \
     rmman2 \
     rmmanx

--- a/iop/input/padman-2000/Makefile
+++ b/iop/input/padman-2000/Makefile
@@ -6,12 +6,12 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-IOP_BIN_ALTNAMES =
+IOP_BIN_ALTNAMES = rpadman.irx
 
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/input/padman/src/
 
-IOP_BIN ?= padman-1400.irx
+IOP_BIN ?= padman-2000.irx
 
-PADMAN_BUILDING_XPADMAN_V2 ?= 0
+PADMAN_BUILDING_XPADMAN_V2 ?= 1
 
 include $(PS2SDKSRC)/iop/input/padman/Makefile

--- a/iop/input/padman/Makefile
+++ b/iop/input/padman/Makefile
@@ -6,7 +6,7 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-IOP_BIN_ALTNAMES ?= freepad.irx rpadman.irx padman-2000.irx
+IOP_BIN_ALTNAMES ?= freepad.irx padman-1400.irx
 
 # IOP_CFLAGS += -DDEBUG
 
@@ -28,7 +28,7 @@ IOP_OBJS = freepad.o rpcserver.o exports.o imports.o padInit.o padPortOpen.o pad
 PADMAN_BUILDING_XPADMAN ?= 1
 
 # Build the newer version of the gamepad module that links against the remote-compatible SIO2MAN?
-PADMAN_BUILDING_XPADMAN_V2 ?= 1
+PADMAN_BUILDING_XPADMAN_V2 ?= 0
 
 ifneq (x$(PADMAN_BUILDING_XPADMAN),x0)
 IOP_CFLAGS += -DBUILDING_XPADMAN

--- a/iop/memorycard/Makefile
+++ b/iop/memorycard/Makefile
@@ -10,7 +10,7 @@ SUBDIRS = \
 	dongleman \
 	mcman \
 	mcman-1300 \
-	mcman-1400 \
+	mcman-2000 \
 	mcserv \
 	mcserv-1300 \
 	vmcman \

--- a/iop/memorycard/mcman-2000/Makefile
+++ b/iop/memorycard/mcman-2000/Makefile
@@ -11,8 +11,8 @@ IOP_BIN_ALTNAMES =
 IOP_SRC_DIR = $(PS2SDKSRC)/iop/memorycard/mcman/src/
 IOP_INC_DIR = $(PS2SDKSRC)/iop/memorycard/mcman/include/
 
-IOP_BIN ?= mcman-1400.irx
+IOP_BIN ?= mcman-2000.irx
 
-MCMAN_BUILDING_XMCMAN_V2 ?= 0
+MCMAN_BUILDING_XMCMAN_V2 ?= 1
 
 include $(PS2SDKSRC)/iop/memorycard/mcman/Makefile

--- a/iop/memorycard/mcman/Makefile
+++ b/iop/memorycard/mcman/Makefile
@@ -6,13 +6,13 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
-IOP_BIN_ALTNAMES ?= mcman-2000.irx
+IOP_BIN_ALTNAMES ?= mcman-1400.irx
 
 # Build the newer version of the memory card module?
 MCMAN_BUILDING_XMCMAN ?= 1
 
 # Build the newer version of the memory card module that links against the remote-compatible SIO2MAN?
-MCMAN_BUILDING_XMCMAN_V2 ?= 1
+MCMAN_BUILDING_XMCMAN_V2 ?= 0
 
 # Read from the dev9 external flash ROM instead of the memory card?
 MCMAN_BUILDING_XFROMMAN ?= 0


### PR DESCRIPTION
The interaction between the 2000 variants of padman and mcman and the mmce/mx4sio drivers causes issues such as inputs not working and hang on reading.

Going back to 2000 variants will be revisited once pad2/mc2/readfast/writefast is implemented.

Tested working with basic function of wLE and OPL