### PR TITLE
add acram module with 128mb support

### DIFF
--- a/iop/arcade/acram/Makefile
+++ b/iop/arcade/acram/Makefile
@@ -6,6 +6,8 @@
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 
+ACRAM_128MB ?= 0
+
 IOP_IMPORT_INCS += \
 	arcade/accore \
 	system/intrman \
@@ -20,6 +22,10 @@ IOP_OBJS = \
 	ram.o \
 	imports.o \
 	exports.o
+
+ifeq ($(ACRAM_128MB),1)
+  IOP_CFLAGS += -DALLOW_128MB_ACRAM
+endif
 
 include $(PS2SDKSRC)/Defs.make
 include $(PS2SDKSRC)/iop/Rules.bin.make

--- a/iop/arcade/acram/README.md
+++ b/iop/arcade/acram/README.md
@@ -16,6 +16,7 @@ There are multiple configurations of this library, allowing the choice of
 balancing between size, speed, and features.
 
 *   `acram` -> The recommended version.
+*   `acram_extended` -> Supports up to 128mb of ACRAM, only on system246 Rack A
 
 ## How to use this module in your program
 

--- a/iop/arcade/acram/src/ram.c
+++ b/iop/arcade/acram/src/ram.c
@@ -14,7 +14,20 @@ static int ram_dma_xfer(acDmaT dma, int intr, acDmaOp op);
 static void ram_dma_done(acDmaT dma);
 static void ram_dma_error(acDmaT dma, int intr, acDmaState state, int result);
 
-static acUint32 Ram_limits[] = {0x2000000, 0x4000000, 0x4000000};
+static acUint32 Ram_limits[] = {
+#ifdef ALLOW_128MB_ACRAM
+#define MAX_BANK 4
+    0x2000000,
+    0x4000000,
+    0x6000000,
+    0x8000000,
+#else
+#define MAX_BANK 3
+    0x2000000,
+    0x4000000,
+    0x4000000
+#endif
+};
 static const acDmaOpsData ops_22 = {&ram_dma_xfer, &ram_dma_done, &ram_dma_error};
 static struct ram_softc Ramc;
 
@@ -44,7 +57,7 @@ static int ram_dma_xfer(acDmaT dma, int intr, acDmaOp op)
 		if ( dmatmp->addr < Ram_limits[v5] )
 			break;
 		v5 = ++i;
-		if ( (unsigned int)i >= 3 )
+		if ( (unsigned int)i > MAX_BANK )
 		{
 			bank = -14;
 			break;

--- a/iop/arcade/acram_extended/Makefile
+++ b/iop/arcade/acram_extended/Makefile
@@ -1,0 +1,17 @@
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2024, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+
+IOP_PARENT_DIR = $(PS2SDKSRC)/iop/arcade/acram
+IOP_SRC_DIR = $(IOP_PARENT_DIR)/src/
+IOP_INC_DIR = $(IOP_PARENT_DIR)/include/
+
+ACRAM_128MB = 1
+
+IOP_BIN ?= acram_extended.irx
+
+include $(IOP_PARENT_DIR)/Makefile


### PR DESCRIPTION
based on wangan midnight, the only game to use double RAM64 PCB

this driver only makes sense for SYSTEM246 Rack A