### PR TITLE
atad: fix zero-progress loop for 65536-sector LBA48 transfers

### DIFF
--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -1026,12 +1026,14 @@ int ata_device_sector_io64(int device, void *buf, u64 lba, u32 nsectors, int dir
     USE_SPD_REGS;
     int res = 0, retries;
     u16 sector, lcyl, hcyl, select, command, len;
+    u32 chunk;
 
     while (res == 0 && nsectors > 0) {
 
         if (atad_devinfo[device].lba48 && (ata_dvrp_workaround ? (lba >= atad_devinfo[device].total_sectors) : 1)) {
             /* Setup for 48-bit LBA.  */
-            len = (u16)((nsectors > 65536) ? 65536 : nsectors); /* 0 means 65536 in LBA48 */
+            chunk = (nsectors > 65536) ? 65536 : nsectors;
+            len   = (u16)chunk; /* 0 means 65536 in the LBA48 sector count register. */
 
             /* Combine bits 24-31 and bits 0-7 of lba into sector.  */
             sector = ((lba >> 16) & 0xff00) | (lba & 0xff);
@@ -1043,7 +1045,8 @@ int ata_device_sector_io64(int device, void *buf, u64 lba, u32 nsectors, int dir
             command = (dir == 1) ? ATA_C_WRITE_DMA_EXT : ATA_C_READ_DMA_EXT;
         } else {
             /* Setup for 28-bit LBA.  */
-            len    = (nsectors > 256) ? 256 : nsectors;
+            chunk  = (nsectors > 256) ? 256 : nsectors;
+            len    = (u16)chunk;
             sector = lba & 0xff;
             lcyl   = (lba >> 8) & 0xff;
             hcyl   = (lba >> 16) & 0xff;
@@ -1062,7 +1065,7 @@ int ata_device_sector_io64(int device, void *buf, u64 lba, u32 nsectors, int dir
 #endif
 #endif
 
-            if ((res = sceAtaExecCmd(buf, len, 0, len, sector, lcyl, hcyl, select, command)) != 0)
+            if ((res = sceAtaExecCmd(buf, chunk, 0, len, sector, lcyl, hcyl, select, command)) != 0)
                 break;
 
 #ifdef ATA_USE_DEV9
@@ -1084,9 +1087,9 @@ int ata_device_sector_io64(int device, void *buf, u64 lba, u32 nsectors, int dir
                 break;
         }
 
-        buf = (void *)((u8 *)buf + len * 512);
-        lba += len;
-        nsectors -= len;
+        buf = (void *)((u8 *)buf + chunk * 512);
+        lba += chunk;
+        nsectors -= chunk;
     }
 
     return res;


### PR DESCRIPTION
`ata_device_sector_io64` narrows the per-iteration transfer length to `u16` before using it for the loop accounting. A request of 65536 sectors or more therefore computes `len == 0`, passes `blkcount` 0 to `sceAtaExecCmd`, and advances `buf`/`lba`/`nsectors` by zero — an infinite loop that never makes progress.

This change keeps the iteration length in a `u32` (`chunk`) and only narrows to `u16` for the sector-count register, where 0 legitimately means 65536. The 28-bit path is expressed the same way for consistency; its behaviour is unchanged (max 256).

Found while characterizing large GPT/exFAT drives on clone network adapters (measurements and test tooling: https://github.com/LAP87/ps2-gamestar-pio), but the defect is independent of adapter type — any BDM/APA caller requesting ≥ 32 MiB in one call hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)