### PR TITLE
atad: disable DVRP workaround for LBA48-aware DVRP firmware

### DIFF
--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -1291,6 +1291,16 @@ static int ata_init_devices(ata_devinfo_t *devinfo)
            either words(61:60) for 28-bit or words(103:100) for 48-bit.  */
         devinfo[i].lba48 = (ata_param[ATA_ID_COMMAND_SETS_SUPPORTED] & 0x0400) != 0;
 
+        /* Check for "PS2LBA48" magic in reserved words 121-124 */
+        if (ata_dvrp_workaround &&
+            ata_param[121] == 0x4456 &&
+            ata_param[122] == 0x524c &&
+            ata_param[123] == 0x4241 &&
+            ata_param[124] == 0x3438) {
+            M_PRINTF("LBA48-capable DVRP firmware detected, disabling the workaround\n");
+            ata_dvrp_workaround = 0;
+        }
+
         /* Save the total sector counts before we overwrite ata_param with the value of Sony identify drive command. */
         total_sectors_nonlba48 = (ata_param[ATA_ID_SECTOTAL_HI] << 16) | ata_param[ATA_ID_SECTOTAL_LO];
         if (ata_param[ATA_ID_48BIT_SECTOTAL_HI]) {


### PR DESCRIPTION
The current workaround implementation forces LBA28 if it detects a DVRP-emulated hard drive.
This PR adds support for LBA48-aware DVRP firmware by checking for the "PS2LBA48" magic signature added by a compatible CFW in ATA IDENTIFY words 121-124.

This allows full LBA48 for PSX consoles with custom firmware while keeping backwards compatibility with the original firmware.
Tested on PSX DESR-7100 with DVRPwned 2.0.0:
```
  atad: LBA48-capable DVRP firmware detected, disabling the workaround
  hdd: disk0: 0x161e70f6 sectors, max 0x00800000
  hdd: drive status 0, format version 00000002
  hdd: version 0205 driver start. This is OSD version!

  Testing LBA48 support:
        Testing sectors 0x20000-0x10020000
        memcmp results: 0x00 0xde 0xde 0x00 0x00 0xde
  
  LBA48 test OK
        Testing sectors 0x2000000-0x12000000
        memcmp results: 0xffffff89 0x67 0x67 0x00 0x00 0xde
  
  LBA48 test OK
```