### PR TITLE
atad: report PS2 area size as LBA48 disk capacity for LBA48-aware DVRP firmware

### DIFF
--- a/iop/dev9/atad/src/ps2atad.c
+++ b/iop/dev9/atad/src/ps2atad.c
@@ -1291,16 +1291,6 @@ static int ata_init_devices(ata_devinfo_t *devinfo)
            either words(61:60) for 28-bit or words(103:100) for 48-bit.  */
         devinfo[i].lba48 = (ata_param[ATA_ID_COMMAND_SETS_SUPPORTED] & 0x0400) != 0;
 
-        /* Check for "PS2LBA48" magic in reserved words 121-124 */
-        if (ata_dvrp_workaround &&
-            ata_param[121] == 0x4456 &&
-            ata_param[122] == 0x524c &&
-            ata_param[123] == 0x4241 &&
-            ata_param[124] == 0x3438) {
-            M_PRINTF("LBA48-capable DVRP firmware detected, disabling the workaround\n");
-            ata_dvrp_workaround = 0;
-        }
-
         /* Save the total sector counts before we overwrite ata_param with the value of Sony identify drive command. */
         total_sectors_nonlba48 = (ata_param[ATA_ID_SECTOTAL_HI] << 16) | ata_param[ATA_ID_SECTOTAL_LO];
         if (ata_param[ATA_ID_48BIT_SECTOTAL_HI]) {
@@ -1341,10 +1331,22 @@ static int ata_init_devices(ata_devinfo_t *devinfo)
             /* If this device is emulated through the DVRP, use the non-48-bit LBA size.  */
             if (ata_dvrp_workaround) {
                 devinfo[i].total_sectors = total_sectors_nonlba48;
+                /* Check for "PS2LBA48" magic in reserved words 121-124 */
+                /* PS2 area size is still stored in the 28-bit LBA size */
+                if (ata_param[121] == 0x4456 &&
+                    ata_param[122] == 0x524c &&
+                    ata_param[123] == 0x4241 &&
+                    ata_param[124] == 0x3438) {
+                    M_PRINTF("LBA48-capable DVRP firmware detected, disabling the workaround\n");
+                    ata_dvrp_workaround = 0;
+                    devinfo[i].total_sectors_lba48 = total_sectors_nonlba48;
+                } else {
+                    devinfo[i].total_sectors_lba48 = total_sectors_lba48;
+                }
             } else {
                 devinfo[i].total_sectors = total_sectors_lba48;
+                devinfo[i].total_sectors_lba48 = total_sectors_lba48;
             }
-            devinfo[i].total_sectors_lba48 = total_sectors_lba48;
         } else {
             devinfo[i].total_sectors       = total_sectors_nonlba48;
             devinfo[i].total_sectors_lba48 = total_sectors_nonlba48;


### PR DESCRIPTION
With the updated LBA48 implementation in the DVRP custom firmware, the full disk capacity is now reported in the LBA48 capacity fields rather than just the PS2 area size. While this change was necessary to support XMB 2.11, it causes all applications to see the entire disk rather than being restricted to the PS2 area.

This PR ensures applications see only the (32-bit) PS2 area size.